### PR TITLE
[caa edits] Add fatbox to non-square packagings

### DIFF
--- a/mb_supercharged_caa_edits.user.js
+++ b/mb_supercharged_caa_edits.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Supercharged Cover Art Edits
-// @version      2021.4.1.2
+// @version      2021.4.2
 // @description  Supercharges reviewing cover art edits. Displays release information on CAA edits. Enables image comparisons on removed and added images.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -62,6 +62,7 @@ const NONSQUARE_PACKAGING_TYPES = [
     6, // Keep case
     8, // Cassette
     9, // Book
+    10, // Fatbox
     17, // Digibook
 ];
 


### PR DESCRIPTION
Tested with [Edit #78562367](https://musicbrainz.org/edit/78562367), front covers should usually have the same aspect ratio as back covers for regular jewel cases and can possibly also include spines.
I also checked the [docs](https://musicbrainz.org/doc/Release/Packaging) for more likely non-square packaging types while I was at it, but I found none. Only the _Snap Case_ could be another possible candidate - but I have never seen one and there is no example image, only a description:

> A digipak-like case held together with a "snapping" plastic closure.