### PR TITLE
Fix import of metadata files

### DIFF
--- a/rollup/plugin-userscript.ts
+++ b/rollup/plugin-userscript.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { pathToFileURL } from 'url';
 
 import type { Plugin } from 'rollup';
 import type { PackageJson } from 'type-fest';
@@ -119,7 +120,8 @@ function _userscript(options: Readonly<_UserscriptOptionsWithDefaults>): Plugin 
      * @return     {Promise<UserscriptMetadata>}  The userscript's metadata.
      */
     async function loadMetadata(): Promise<AllUserscriptMetadata> {
-        const metadataFile = path.resolve('./src', options.userscriptName, 'meta.js');
+        // use file URLs for compatibility with Windows, otherwise drive letters are recognized as an invalid protocol
+        const metadataFile = pathToFileURL(path.resolve('./src', options.userscriptName, 'meta.ts')).href;
         const specificMetadata: UserscriptMetadata = (await import(metadataFile)).default;
         return insertDefaultMetadata(specificMetadata);
     }


### PR DESCRIPTION
- Correct the file extension
- Import the module using a file URL for compatibility with Windows, otherwise drive letters are recognized as an invalid protocol

I could not resist and had to try out the new features of mb_upload_to_caa_from_url, so I tried to setup the build environment on my computer ❤️