### PR TITLE
Run ESLint for .tsx files & Use it to spot variables without inferred types

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,7 +46,7 @@ module.exports = {
     },
     overrides: [
         {
-            files: ['*.ts'],
+            files: ['*.ts', '*.tsx'],
             parserOptions: {
                 parser: '@typescript-eslint/parser',
                 project: './tsconfig.json',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "NODE_ENV=production node --unhandled-rejections=strict --loader ts-node/esm rollup.ts",
     "build-dev": "node --unhandled-rejections=strict --loader ts-node/esm rollup.ts",
-    "lint": "eslint . --ext .js,.ts",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "typecheck": "tsc"
   },
   "repository": {

--- a/src/.eslintrc.cjs
+++ b/src/.eslintrc.cjs
@@ -3,4 +3,9 @@ module.exports = {
         browser: true,
         es2021: true
     },
+    rules: {
+        // Warnings for declarations without initialisation to spot variables without inferred types.
+        // This makes it easier to ensure they have type annotations before disabling the warning locally.
+        'init-declarations': ['warn', 'always'],
+    },
 };

--- a/src/mb_blind_votes/index.tsx
+++ b/src/mb_blind_votes/index.tsx
@@ -17,6 +17,7 @@ function unblindEdit(edit: Edit) {
 Edit.onVoteChanged((edit: Edit) => {
     // We cannot use classList.toggle here, since a vote may have changed from
     // 'No' to 'Yes', both of which need to be unblinded.
+    // eslint-disable-next-line init-declarations
     let blindToggler: (edit: Edit) => void;
     if (edit.myVote === Vote.NONE) {
         blindToggler = blindEdit;

--- a/src/mb_blind_votes/index.tsx
+++ b/src/mb_blind_votes/index.tsx
@@ -5,11 +5,11 @@ import { onDocumentLoaded } from '../lib/util/dom';
 // Add unblind stylesheet
 document.head.append(<style id='ROpdebee_blind_votes'>{css}</style>);
 
-function blindEdit(edit: Edit) {
+function blindEdit(edit: Edit): void {
     edit.baseContainer.classList.remove('unblind');
 }
 
-function unblindEdit(edit: Edit) {
+function unblindEdit(edit: Edit): void {
     edit.baseContainer.classList.add('unblind');
 }
 

--- a/src/mb_enhanced_cover_art_uploads/atisket.tsx
+++ b/src/mb_enhanced_cover_art_uploads/atisket.tsx
@@ -1,7 +1,7 @@
 import { qs, qsa, qsMaybe } from '../lib/util/dom';
 
 export function addAtisketSeedLinks(): void {
-    const dispatch: Record<string, () => void> = {
+    const dispatch: Record<string, (() => void) | undefined> = {
         '/atasket.php': addOnComplementaryPage,
         '/': addOnOverviewPage,
     };
@@ -14,7 +14,7 @@ export function addAtisketSeedLinks(): void {
     }
 }
 
-function addOnComplementaryPage() {
+function addOnComplementaryPage(): void {
     const mbid = document.location.search.match(/[?&]release_mbid=([a-f0-9-]+)/)?.[1];
     if (!mbid) {
         console.error('Cannot figure out MBID :(');
@@ -23,7 +23,7 @@ function addOnComplementaryPage() {
     addSeedLinkToCovers(mbid);
 }
 
-function addOnOverviewPage() {
+function addOnOverviewPage(): void {
     const alreadyInMB = qsMaybe('.already-in-mb-item');
     if (alreadyInMB === null) {
         return;
@@ -32,11 +32,11 @@ function addOnOverviewPage() {
     addSeedLinkToCovers(qs<HTMLAnchorElement>('a.mb', alreadyInMB).innerText.trim());
 }
 
-function addSeedLinkToCovers(mbid: string) {
-    qsa('figure.cover').forEach((fig) => addSeedLinkToCover(fig, mbid));
+function addSeedLinkToCovers(mbid: string): void {
+    qsa('figure.cover').forEach((fig) => { addSeedLinkToCover(fig, mbid); });
 }
 
-async function addSeedLinkToCover(fig: Element, mbid: string) {
+async function addSeedLinkToCover(fig: Element, mbid: string): Promise<void> {
     const url = qs<HTMLAnchorElement>('a.icon', fig).href;
 
     // Not using .split('.').at(-1) here because I'm not sure whether .at is
@@ -47,11 +47,11 @@ async function addSeedLinkToCover(fig: Element, mbid: string) {
     const seedUrl = `https://musicbrainz.org/release/${mbid}/add-cover-art#artwork_url=${encodeURIComponent(url)}&origin=atisket&artwork_type=Front`;
     // Reverse order of insertion.
     qs<HTMLElement>('figcaption > a', fig).insertAdjacentElement('afterend',
-        <a href={seedUrl} style={{display: 'block'}}>
+        <a href={seedUrl} style={{ display: 'block' }}>
             Add to release
         </a>);
     qs<HTMLElement>('figcaption > a', fig).insertAdjacentElement('afterend',
-        <span style={{display: 'block'}}>
+        <span style={{ display: 'block' }}>
             {dimensionStr + (ext ? ` ${ext.toUpperCase()}` : '')}
         </span>);
 }
@@ -65,14 +65,14 @@ function getImageDimensions(url: string): Promise<string> {
         let done = false;
         const img = <img
             src={url}
-            onLoad={() => {
+            onLoad={(): void => {
                 clearInterval(interval);
                 if (!done) {
                     resolve(`${img.naturalHeight}x${img.naturalWidth}`);
                     done = true;
                 }
             }}
-            onError={() => {
+            onError={(): void => {
                 clearInterval(interval);
                 if (!done) {
                     done = true;

--- a/src/mb_enhanced_cover_art_uploads/atisket.tsx
+++ b/src/mb_enhanced_cover_art_uploads/atisket.tsx
@@ -60,7 +60,7 @@ async function addSeedLinkToCover(fig: Element, mbid: string) {
 // dimensions. TBH CAA dimensions should operate on atisket as well.
 function getImageDimensions(url: string): Promise<string> {
     return new Promise((resolve, reject) => {
-        // eslint-disable-next-line prefer-const
+        // eslint-disable-next-line prefer-const, init-declarations
         let interval: number;
         let done = false;
         const img = <img

--- a/src/mb_enhanced_cover_art_uploads/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/index.tsx
@@ -194,6 +194,7 @@ class ImageImporter {
 
     async #addImages(url: URL, artworkTypes: ArtworkTypeIDs[] = [], comment = ''): Promise<QueuedURLsResult | undefined> {
         this.#banner.set('Searching for images…');
+        // eslint-disable-next-line init-declarations
         let containedImages: CoverArt[] | undefined;
         try {
             containedImages = await findImages(url);
@@ -217,6 +218,7 @@ class ImageImporter {
         }
         this.#doneImages.add(url.href);
 
+        // eslint-disable-next-line init-declarations
         let result: FetchResult;
         try {
             result = await this.#fetchLargestImage(url);


### PR DESCRIPTION
- Run ESLint for .jsx and .tsx files too (was missing in `package.json` and `.eslintrc.cjs`).
- Also includes fixes for most of these new linter warnings (except any type in catch clauses).
- Enable warnings for variable declarations without initialisation. This makes it easier to ensure they have type annotations (to prevent them from being any type) before disabling the warning locally.