### PR TITLE
Include `mb_collapse_work_codes` on paginated artist pages

### DIFF
--- a/mb_collapse_work_attributes.user.js
+++ b/mb_collapse_work_attributes.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Collapse Work Attributes
-// @version      2021.4.25.2
+// @version      2021.9.25
 // @description  Collapses work attributes when there are too many. Workaround for MBS-11535/MBS-11537.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -8,14 +8,10 @@
 // @downloadURL  https://raw.github.com/ROpdebee/mb-userscripts/main/mb_collapse_work_attributes.user.js
 // @updateURL    https://raw.github.com/ROpdebee/mb-userscripts/main/mb_collapse_work_attributes.user.js
 // @match        *://*.musicbrainz.org/work/*
-// @match        *://musicbrainz.org/work/*
 // @match        *://*.musicbrainz.org/artist/*/works
-// @match        *://musicbrainz.org/artist/*/works
-// @match        *://musicbrainz.org/edit/*
+// @match        *://*.musicbrainz.org/artist/*/works?*
 // @match        *://*.musicbrainz.org/edit/*
-// @match        *://musicbrainz.org/*/edits*
 // @match        *://*.musicbrainz.org/*/edits*
-// @match        *://musicbrainz.org/collection/*
 // @match        *://*.musicbrainz.org/collection/*
 // @require      https://code.jquery.com/jquery-3.6.0.min.js
 // @run-at       document-end


### PR DESCRIPTION
I'm not a huge fan of this approach, since it will now match `artist/.../workPageThatShouldNotBeProcessed`, but it's the only way I can find to fix this without using `@include` instead.

Tested on FF/TM and FF/VM and confirmed to work on both. I'm assuming it should work on other combinations too.

This shouldn't be an issue for other `@match` patterns in this script as they all end in `*`.

Fixes #59 