### PR TITLE
Revert minifying full scripts

### DIFF
--- a/rollup.ts
+++ b/rollup.ts
@@ -32,18 +32,14 @@ const BABEL_OPTIONS: RollupBabelInputPluginOptions = {
     extensions: EXTENSIONS,
 };
 
-const TERSER_BASE_OPTIONS: MinifyOptions = {
+const TERSER_OPTIONS: MinifyOptions = {
     ecma: 5,
     safari10: true,  // Supported by MB
     compress: {
         passes: 4,
     },
-};
-
-const TERSER_OPTIONS = {
-    [VENDOR_CHUNK_NAME]: {...TERSER_BASE_OPTIONS, module: true},
-    // Don't garble top-level names for built-in lib.
-    [BUILTIN_LIB_CHUNK_NAME]: {...TERSER_BASE_OPTIONS, module: false},
+    // Don't garble top-level names
+    module: false,
 };
 
 async function buildUserscripts(): Promise<void> {
@@ -226,7 +222,7 @@ const minifyPlugin: OutputPlugin = {
         // Only minify the vendor and lib chunks
         if (![VENDOR_CHUNK_NAME, BUILTIN_LIB_CHUNK_NAME].includes(chunk.name)) return null;
         const terserOptions = {
-            ...TERSER_OPTIONS[chunk.name as keyof typeof TERSER_OPTIONS],
+            ...TERSER_OPTIONS,
             format: {
                 preamble: getVendorMinifiedPreamble(chunk),
             },


### PR DESCRIPTION
* Revert 56691144ce64123f38fb91f932fc3ba224a4daec
* Change build to never minify top-level declarations in modules, not even in 3rd-party code

This should make bug reports a lot easier, and stack traces useful again.

Closes #50 