### PR TITLE
Linting improvements

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -72,7 +72,6 @@ module.exports = {
                 }],
                 '@typescript-eslint/no-base-to-string': ['warn'],
                 '@typescript-eslint/no-confusing-void-expression': ['warn'],
-                '@typescript-eslint/no-implicit-any-catch': ['warn'],
                 '@typescript-eslint/no-invalid-void-type': ['warn'],
                 '@typescript-eslint/no-unnecessary-condition': ['warn'],
                 '@typescript-eslint/no-unsafe-argument': ['warn'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
         "moduleResolution": "node",
         "esModuleInterop": true,
         "noImplicitReturns": true,
+        "noImplicitOverride": true,
         "pretty": true,
         "baseUrl": "./",
         "typeRoots": [


### PR DESCRIPTION
* Disable `no-implicit-any-catch` since it generates false warnings for TS 4.4 (where caught errors are `unknown` by default)
* Enable `noImplicitOverride` in TS. Doesn't generate any warnings yet, so it's a good idea to enable it for the future.