### PR TITLE
Refactor `gmxhr`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "MIT; https://opensource.org/licenses/MIT",
       "dependencies": {
-        "core-js": "^3.13.1"
+        "core-js": "^3.13.1",
+        "ts-custom-error": "^3.2.0"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",
@@ -9755,6 +9756,14 @@
         "glob": "^7.1.2"
       }
     },
+    "node_modules/ts-custom-error": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.2.0.tgz",
+      "integrity": "sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/ts-node": {
       "version": "10.2.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.1.tgz",
@@ -17514,6 +17523,11 @@
       "requires": {
         "glob": "^7.1.2"
       }
+    },
+    "ts-custom-error": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.2.0.tgz",
+      "integrity": "sha512-cBvC2QjtvJ9JfWLvstVnI45Y46Y5dMxIaG1TDMGAD/R87hpvqFL+7LhvUDhnRCfOnx/xitollFWWvUKKKhbN0A=="
     },
     "ts-node": {
       "version": "10.2.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "typescript": "^4.3.2"
   },
   "dependencies": {
-    "core-js": "^3.13.1"
+    "core-js": "^3.13.1",
+    "ts-custom-error": "^3.2.0"
   }
 }

--- a/src/lib/util/xhr.ts
+++ b/src/lib/util/xhr.ts
@@ -2,6 +2,8 @@
 
 // TODO: Look into using GM.* instead of GM_*, they're async
 
+import { CustomError } from 'ts-custom-error';
+
 type LimitedGMXHROptions = Omit<GMXMLHttpRequestOptions, 'onload'|'onerror'|'onabort'|'ontimeout'|'onprogress'|'onreadystatechange'|'method'|'url'>;
 
 interface GMXHROptions extends LimitedGMXHROptions {
@@ -13,21 +15,57 @@ interface GMXHRResponse extends GMXMLHttpRequestResponse {
     response: Blob
 }
 
+abstract class ResponseError extends CustomError {
+    url: string | URL
+
+    constructor(url: string | URL, extraMessage: string) {
+        super(extraMessage);
+        this.url = url;
+    }
+}
+class HTTPResponseError extends ResponseError {
+    statusCode: number
+    statusText: string
+    response: GMXMLHttpRequestResponse
+
+    constructor(url: string | URL, response: GMXMLHttpRequestResponse) {
+        super(url, `HTTP error ${response.status}: ${response.statusText}`);
+
+        this.response = response;
+        this.statusCode = response.status;
+        this.statusText = response.statusText;
+    }
+}
+class TimeoutError extends ResponseError {
+    constructor(url: string | URL) {
+        super(url, 'Request timed out');
+    }
+}
+class AbortedError extends ResponseError {
+    constructor(url: string | URL) {
+        super(url, 'Request aborted');
+    }
+}
+class NetworkError extends ResponseError {
+    constructor(url: string | URL) {
+        super(url, 'Network error');
+    }
+}
+
 export async function gmxhr(url: string | URL, options?: GMXHROptions): Promise<GMXHRResponse> {
-    return new Promise((resolve, reject_) => {
-        const reject = (reason: string, error: any) => reject_({reason, error});
+    return new Promise((resolve, reject) => {
         GM_xmlhttpRequest({
             method: 'GET',
             url: url instanceof URL ? url.href : url,
             ...options ?? {},
 
             onload: (resp) => {
-                if (resp.status >= 400) reject(`HTTP error ${resp.statusText}`, resp);
+                if (resp.status >= 400) reject(new HTTPResponseError(url, resp));
                 else resolve(resp as GMXHRResponse);
             },
-            onerror: (err) => reject('network error', err),
-            onabort: (err) => reject('aborted', err),
-            ontimeout: (err) => reject('timed out', err),
+            onerror: () => reject(new NetworkError(url)),
+            onabort: () => reject(new AbortedError(url)),
+            ontimeout: () => reject(new TimeoutError(url)),
         });
     });
 };

--- a/src/lib/util/xhr.ts
+++ b/src/lib/util/xhr.ts
@@ -2,10 +2,11 @@
 
 // TODO: Look into using GM.* instead of GM_*, they're async
 
-type LimitedGMXHROptions = Omit<GMXMLHttpRequestOptions, 'onload'|'onerror'|'onabort'|'ontimeout'|'onprogress'|'onreadystatechange'>;
+type LimitedGMXHROptions = Omit<GMXMLHttpRequestOptions, 'onload'|'onerror'|'onabort'|'ontimeout'|'onprogress'|'onreadystatechange'|'method'>;
 
 interface GMXHROptions extends LimitedGMXHROptions {
     responseType?: XMLHttpRequestResponseType
+    method?: GMXMLHttpRequestOptions['method']
 }
 
 interface GMXHRResponse extends GMXMLHttpRequestResponse {
@@ -16,6 +17,7 @@ export async function gmxhr(options: GMXHROptions): Promise<GMXHRResponse> {
     return new Promise((resolve, reject_) => {
         const reject = (reason: string, error: any) => reject_({reason, error});
         GM_xmlhttpRequest({
+            method: 'GET',
             ...options,
             onload: (resp) => {
                 if (resp.status >= 400) reject(`HTTP error ${resp.statusText}`, resp);

--- a/src/lib/util/xhr.ts
+++ b/src/lib/util/xhr.ts
@@ -2,7 +2,7 @@
 
 // TODO: Look into using GM.* instead of GM_*, they're async
 
-type LimitedGMXHROptions = Omit<GMXMLHttpRequestOptions, 'onload'|'onerror'|'onabort'|'ontimeout'|'onprogress'|'onreadystatechange'|'method'>;
+type LimitedGMXHROptions = Omit<GMXMLHttpRequestOptions, 'onload'|'onerror'|'onabort'|'ontimeout'|'onprogress'|'onreadystatechange'|'method'|'url'>;
 
 interface GMXHROptions extends LimitedGMXHROptions {
     responseType?: XMLHttpRequestResponseType
@@ -13,12 +13,14 @@ interface GMXHRResponse extends GMXMLHttpRequestResponse {
     response: Blob
 }
 
-export async function gmxhr(options: GMXHROptions): Promise<GMXHRResponse> {
+export async function gmxhr(url: string | URL, options?: GMXHROptions): Promise<GMXHRResponse> {
     return new Promise((resolve, reject_) => {
         const reject = (reason: string, error: any) => reject_({reason, error});
         GM_xmlhttpRequest({
             method: 'GET',
-            ...options,
+            url: url instanceof URL ? url.href : url,
+            ...options ?? {},
+
             onload: (resp) => {
                 if (resp.status >= 400) reject(`HTTP error ${resp.statusText}`, resp);
                 else resolve(resp as GMXHRResponse);

--- a/src/mb_enhanced_cover_art_uploads/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/index.tsx
@@ -277,8 +277,7 @@ class ImageImporter {
     }
 
     async #fetchImage(url: URL, fileName: string, headers: Record<string, unknown> = {}): Promise<FetchResult> {
-        const resp = await gmxhr({
-            url: url.href,
+        const resp = await gmxhr(url, {
             responseType: 'blob',
             headers: headers,
         });

--- a/src/mb_enhanced_cover_art_uploads/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/index.tsx
@@ -279,7 +279,6 @@ class ImageImporter {
     async #fetchImage(url: URL, fileName: string, headers: Record<string, unknown> = {}): Promise<FetchResult> {
         const resp = await gmxhr({
             url: url.href,
-            method: 'GET',
             responseType: 'blob',
             headers: headers,
         });

--- a/src/mb_enhanced_cover_art_uploads/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/index.tsx
@@ -214,7 +214,7 @@ class ImageImporter {
         try {
             containedImages = await findImages(url);
         } catch (err) {
-            this.#banner.set(`Failed to search images: ${err}`);
+            this.#banner.set(`Failed to search images: ${err instanceof Error ? err.message : err}`);
             console.error(err);
             return;
         }
@@ -238,7 +238,7 @@ class ImageImporter {
         try {
             result = await this.#fetchLargestImage(url);
         } catch (err) {
-            this.#banner.set(`Failed to load ${originalFilename}: ${err}`);
+            this.#banner.set(`Failed to load ${originalFilename}: ${err instanceof Error ? err.message : err}`);
             console.error(err);
             return;
         }

--- a/src/mb_enhanced_cover_art_uploads/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/index.tsx
@@ -1,3 +1,5 @@
+import { CustomError } from 'ts-custom-error';
+
 import { assertHasValue } from '../lib/util/assert';
 import { qs, qsa } from '../lib/util/dom';
 import { EditNote } from '../lib/util/editNotes';
@@ -10,6 +12,17 @@ import { findImages, getProvider, hasProvider } from './providers';
 import { ArtworkTypeIDs } from './providers/base';
 
 import type { CoverArt } from './providers/base';
+
+class BadFileTypeError extends CustomError {
+    url: string | URL
+    fileName: string
+
+    constructor(url: string | URL, fileName: string) {
+        super(`${fileName} has an unsupported file type`);
+        this.url = url;
+        this.fileName = fileName;
+    }
+}
 
 class StatusBanner {
 
@@ -200,8 +213,8 @@ class ImageImporter {
         let containedImages: CoverArt[] | undefined;
         try {
             containedImages = await findImages(url);
-        } catch (err: any) {
-            this.#banner.set(`Failed to search images: ${err.reason ?? err}`);
+        } catch (err) {
+            this.#banner.set(`Failed to search images: ${err}`);
             console.error(err);
             return;
         }
@@ -224,8 +237,8 @@ class ImageImporter {
         let result: FetchResult;
         try {
             result = await this.#fetchLargestImage(url);
-        } catch (err: any) {
-            this.#banner.set(`Failed to load ${originalFilename}: ${err.reason ?? err}`);
+        } catch (err) {
+            this.#banner.set(`Failed to load ${originalFilename}: ${err}`);
             console.error(err);
             return;
         }
@@ -267,8 +280,8 @@ class ImageImporter {
             try {
                 this.#banner.set(`Trying ${candName}…`);
                 return await this.#fetchImage(imageResult.url, candName, imageResult.headers);
-            } catch (err: any) {
-                console.error(`${candName} failed: ${err.reason ?? err}`);
+            } catch (err) {
+                console.error(`${candName} failed: ${err}`);
             }
         }
 
@@ -286,7 +299,7 @@ class ImageImporter {
 
         return new Promise((resolve, reject) => {
             MB.CoverArt.validate_file(rawFile)
-                .fail((error) => { reject({ reason: error, error }); })
+                .fail(() => { reject(new BadFileTypeError(url, fileName)); })
                 .done((mimeType) => {
                     resolve({
                         fetchedUrl: url,

--- a/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
@@ -18,7 +18,7 @@ export class AmazonProvider implements CoverArtProvider {
     }
 
     async findImages(url: URL): Promise<CoverArt[]> {
-        const pageResp = await gmxhr({ url: url.href });
+        const pageResp = await gmxhr(url);
         const pageDom = parseDOM(pageResp.responseText);
 
         if (qsMaybe('#digitalMusicProductImage_feature_div', pageDom) !== null) {

--- a/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
@@ -18,7 +18,7 @@ export class AmazonProvider implements CoverArtProvider {
     }
 
     async findImages(url: URL): Promise<CoverArt[]> {
-        const pageResp = await gmxhr({ url: url.href, method: 'GET' });
+        const pageResp = await gmxhr({ url: url.href });
         const pageDom = parseDOM(pageResp.responseText);
 
         if (qsMaybe('#digitalMusicProductImage_feature_div', pageDom) !== null) {

--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -71,7 +71,7 @@ export abstract class HeadMetaPropertyProvider implements CoverArtProvider {
     async findImages(url: URL): Promise<CoverArt[]> {
         // Find an image link from a HTML head meta property, maxurl will
         // maximize it for us. Don't want to use the API because of OAuth.
-        const resp = await gmxhr({ url: url.href, method: 'GET' });
+        const resp = await gmxhr({ url: url.href });
         const respDocument = parseDOM(resp.responseText);
         const coverElmt = qs<HTMLMetaElement>('head > meta[property="og:image"]', respDocument);
         return [{

--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -71,7 +71,7 @@ export abstract class HeadMetaPropertyProvider implements CoverArtProvider {
     async findImages(url: URL): Promise<CoverArt[]> {
         // Find an image link from a HTML head meta property, maxurl will
         // maximize it for us. Don't want to use the API because of OAuth.
-        const resp = await gmxhr({ url: url.href });
+        const resp = await gmxhr(url);
         const respDocument = parseDOM(resp.responseText);
         const coverElmt = qs<HTMLMetaElement>('head > meta[property="og:image"]', respDocument);
         return [{

--- a/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
@@ -69,9 +69,7 @@ export class DiscogsProvider implements CoverArtProvider {
                 sha256Hash: QUERY_SHA256,
             },
         }));
-        const resp = await gmxhr({
-            url: `https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=${variables}&extensions=${extensions}`,
-        });
+        const resp = await gmxhr(`https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=${variables}&extensions=${extensions}`);
 
         return JSON.parse(resp.responseText);
     }

--- a/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
@@ -71,7 +71,6 @@ export class DiscogsProvider implements CoverArtProvider {
         }));
         const resp = await gmxhr({
             url: `https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=${variables}&extensions=${extensions}`,
-            method: 'GET',
         });
 
         return JSON.parse(resp.responseText);

--- a/src/mb_enhanced_cover_art_uploads/providers/qobuz.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/qobuz.ts
@@ -79,7 +79,6 @@ export class QobuzProvider implements CoverArtProvider {
     static async getMetadata(id: string): Promise<AlbumMetadata> {
         const resp = await gmxhr({
             url: `https://www.qobuz.com/api.json/0.2/album/get?album_id=${id}&offset=0&limit=20`,
-            method: 'GET',
             headers: {
                 'x-app-id': QOBUZ_APP_ID,
             },

--- a/src/mb_enhanced_cover_art_uploads/providers/qobuz.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/qobuz.ts
@@ -77,8 +77,7 @@ export class QobuzProvider implements CoverArtProvider {
     }
 
     static async getMetadata(id: string): Promise<AlbumMetadata> {
-        const resp = await gmxhr({
-            url: `https://www.qobuz.com/api.json/0.2/album/get?album_id=${id}&offset=0&limit=20`,
+        const resp = await gmxhr(`https://www.qobuz.com/api.json/0.2/album/get?album_id=${id}&offset=0&limit=20`, {
             headers: {
                 'x-app-id': QOBUZ_APP_ID,
             },

--- a/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
@@ -20,7 +20,7 @@ export class TidalProvider implements CoverArtProvider {
         assertHasValue(albumId);
         url.href = `https://tidal.com/browse/album/${albumId}`;
 
-        const resp = await gmxhr({ url: url.href, method: 'GET' });
+        const resp = await gmxhr({ url: url.href });
         const respDocument = parseDOM(resp.responseText);
 
         if (qsMaybe('p#cmsg') !== null) {

--- a/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
@@ -20,7 +20,7 @@ export class TidalProvider implements CoverArtProvider {
         assertHasValue(albumId);
         url.href = `https://tidal.com/browse/album/${albumId}`;
 
-        const resp = await gmxhr({ url: url.href });
+        const resp = await gmxhr(url);
         const respDocument = parseDOM(resp.responseText);
 
         if (qsMaybe('p#cmsg') !== null) {

--- a/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
@@ -24,7 +24,7 @@ export class TidalProvider implements CoverArtProvider {
         const respDocument = parseDOM(resp.responseText);
 
         if (qsMaybe('p#cmsg') !== null) {
-            throw {reason: 'captcha'};
+            throw new Error('Tidal presented us with a captcha');
         }
 
         const coverElmt = qs<HTMLMetaElement>('head > meta[property="og:image"]', respDocument);

--- a/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
@@ -106,7 +106,7 @@ export class VGMdbProvider implements CoverArtProvider {
         const id = url.pathname.match(ID_REGEX)?.[1];
         assertHasValue(id);
         const apiUrl = `https://vgmdb.info/album/${id}?format=json`;
-        const apiResp = await gmxhr({ url: apiUrl, method: 'GET' });
+        const apiResp = await gmxhr({ url: apiUrl });
         const metadata = JSON.parse(apiResp.responseText) as AlbumMetadata;
 
         return this.#extractImages(metadata);

--- a/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
@@ -106,7 +106,7 @@ export class VGMdbProvider implements CoverArtProvider {
         const id = url.pathname.match(ID_REGEX)?.[1];
         assertHasValue(id);
         const apiUrl = `https://vgmdb.info/album/${id}?format=json`;
-        const apiResp = await gmxhr(url);
+        const apiResp = await gmxhr(apiUrl);
         const metadata = JSON.parse(apiResp.responseText) as AlbumMetadata;
 
         return this.#extractImages(metadata);

--- a/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
@@ -106,7 +106,7 @@ export class VGMdbProvider implements CoverArtProvider {
         const id = url.pathname.match(ID_REGEX)?.[1];
         assertHasValue(id);
         const apiUrl = `https://vgmdb.info/album/${id}?format=json`;
-        const apiResp = await gmxhr({ url: apiUrl });
+        const apiResp = await gmxhr(url);
         const metadata = JSON.parse(apiResp.responseText) as AlbumMetadata;
 
         return this.#extractImages(metadata);


### PR DESCRIPTION
Little bit of refactoring because I dislike the interface of `GM_xmlhttpRequest` and since we're using a wrapper, we can do better.

* Make the `method` parameter optional, default to `GET` since that'll be used most often.
* Move the `url` to a separate parameter, since it's always required anyway, whereas other options might not be. Also accept `URL` instances.