### PR TITLE
Fix duplicate image detection on error

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/index.tsx
@@ -218,7 +218,6 @@ class ImageImporter {
             this.#clearInput(url.href);
             return;
         }
-        this.#doneImages.add(url.href);
 
         // eslint-disable-next-line init-declarations
         let result: FetchResult;
@@ -239,9 +238,10 @@ class ImageImporter {
             this.#clearInput(url.href);
             return;
         }
-        this.#doneImages.add(fetchedUrl.href);
 
         this.#enqueueImageForUpload(file, artworkTypes, comment);
+        this.#doneImages.add(fetchedUrl.href);
+        this.#doneImages.add(url.href);
         return {
             queuedUrls: [{
                 filename: file.name,


### PR DESCRIPTION
Noticed this while testing for #69. We were adding the URL to the done set before it was actually done, and this prevents retrying the same URL if it failed previously. Fixing by adding the URLs to the done set after the image was queued.