### PR TITLE
fix(ci): remove bad check in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,8 +12,7 @@ jobs:
     name: Build and test
     if: >
       github.event.pull_request.merged
-      && github.repository == 'ROpdebee/mb-userscripts'
-      && github.ref == 'refs/heads/main'
+      && github.repository == 'ROpdebee/mb-userscripts'g
       && !contains(github.event.pull_request.labels.*.name, 'skip cd')
     uses: ROpdebee/mb-userscripts/.github/workflows/main.yml@main
 


### PR DESCRIPTION
We previously checked whether `github.ref` pointed to the main branch,
but this is always false in workflows triggered by PRs (unless the source
branch is the main branch), because `github.ref` points to the ref
of the source branch. Since this workflow is explicitly only enabled
on PRs that have `main` as the target, the check is redundant.