### PR TITLE
ci: only generate preview on collaborator comment

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,18 @@ jobs:
 
   deploy:
     needs: build-and-test
-    if: always() && github.repository == 'ROpdebee/mb-userscripts'
+    if: >
+      always()
+      && github.event_name == 'push'
+      && github.event.ref == 'refs/heads/main'
+      && github.repository == 'ROpdebee/mb-userscripts'
     uses: ROpdebee/mb-userscripts/.github/workflows/deploy.yml@main
     with:
       test-result: ${{ needs.build-and-test.result }}
-      preview: ${{ github.event_name == 'pull_request' }}
+
+  deploy-check:
+    needs: build-and-test
+    if: >
+      github.event_name == 'pull_request'
+      && github.repository == 'ROpdebee/mb-userscripts'
+    uses: ROpdebee/mb-userscripts/.github/workflows/deploy-check.yml@main

--- a/.github/workflows/deploy-check.yml
+++ b/.github/workflows/deploy-check.yml
@@ -1,0 +1,54 @@
+---
+name: deploy-check
+on:
+  workflow_call:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Check and report whether deploy will be necessary
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Set up environment
+        uses: ./.github/actions/setup
+
+      - name: Find out PR number and title
+        id: active-pr
+        uses: actions/github-script@v5
+        with:
+          script: |
+            // This is a PR. We can easily find the number, title, and labels
+            // through the event payload
+            const pr = context.payload.pull_request;
+            return {
+              number: pr.number,
+              title: pr.title,
+              labels: pr.labels.map((label) => label.name),
+            };
+
+      - name: Checkout second dist copy
+        uses: actions/checkout@v2
+        with:
+          path: repoDist
+          ref: dist
+
+      - name: Dry-run deploying new userscript versions
+        id: deploy-step
+        env:
+          PR_INFO: ${{ steps.active-pr.outputs.result }}
+          # Since this is running from a pull_request event, PRs from forks
+          # won't have the appropriate access level to create pushes anyway.
+          SKIP_PUSH: 1
+        run: npm run deploy repoDist
+
+      - name: Report preview
+        # Will be skipped if deployment failed
+        env:
+          PR_INFO: ${{ steps.active-pr.outputs.result }}
+          DEPLOY_INFO: ${{ steps.deploy-step.outputs.deployment-info }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const script = require('./build/report-deploy.js');
+            await script.reportPreview({ github, context, full: false });

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,66 @@
+---
+# Can only be run on dispatch by authorised user. We automate this via a
+# slash comment dispatcher.
+name: deploy-preview-command
+on:
+  repository_dispatch:
+    types: [deploy-preview-command]
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    name: Generate deployment preview
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
+      - name: Set up environment
+        uses: ./.github/actions/setup
+
+      - name: Find out PR number and title
+        id: active-pr
+        uses: actions/github-script@v5
+        with:
+          script: |
+            // Information can be found in the payload
+            const pr = context.payload.client_payload.pull_request;
+            return {
+              number: pr.number,
+              title: pr.title,
+              labels: pr.labels.map((label) => label.name),
+            };
+
+      - name: Checkout second dist copy
+        uses: actions/checkout@v2
+        with:
+          path: repoDist
+          ref: dist
+      - name: Create preview branch
+        working-directory: repoDist
+        env:
+          BRANCH_NAME: dist-preview-${{ fromJSON(steps.active-pr.outputs.result).number }}
+        run: |
+          git checkout -b "$BRANCH_NAME"
+          # Force-push to overwrite any previous preview commits already
+          git push -f
+
+      - name: Dry-run deploying new userscript versions
+        id: deploy-step
+        env:
+          PR_INFO: ${{ steps.active-pr.outputs.result }}
+        # Allow pushes now. It'll push to the newly created branch. Since this
+        # job can only be run on repository_dispatch, which requires admin
+        # privileges, this is safe.
+        run: npm run deploy repoDist
+
+      - name: Report preview
+        # Will be skipped if deployment failed
+        env:
+          PR_INFO: ${{ steps.active-pr.outputs.result }}
+          DEPLOY_INFO: ${{ steps.deploy-step.outputs.deployment-info }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            const script = require('./build/report-deploy.js');
+            await script.reportPreview({ github, context, full: true });

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,10 +7,6 @@ on:
         description: Outcome of testing job
         required: true
         type: string
-      preview:
-        description: Whether this is a preview deployment for reporting in PR.
-        required: true
-        type: boolean
 
 jobs:
   deploy:
@@ -27,17 +23,6 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            // If this is a PR, we can easily find the number, title, and labels
-            // through the event payload
-            if (context.eventName === 'pull_request') {
-              const pr = context.payload.pull_request;
-              return {
-                number: pr.number,
-                title: pr.title,
-                labels: pr.labels.map((label) => label.name),
-              };
-            }
-
             // Find PR that introduced this commit by searching the commit SHA
             // This works even for squashes and rebased merges
             const { GITHUB_SHA, GITHUB_REPOSITORY } = process.env;
@@ -73,18 +58,8 @@ jobs:
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git config user.name 'GitHub Actions'
           git config push.default current
-      - name: Create preview branch
+      - name: Delete preview branch, if any
         working-directory: repoDist
-        if: inputs.preview && github.event_name == 'pull_request'
-        env:
-          BRANCH_NAME: dist-preview-${{ github.event.pull_request.number }}
-        run: |
-          git checkout -b "$BRANCH_NAME"
-          # Force-push to overwrite any previous preview commits already
-          git push -f
-      - name: Delete preview branch
-        working-directory: repoDist
-        if: '!inputs.preview'
         # Don't fail if the branch did not exist
         continue-on-error: true
         env:
@@ -96,12 +71,10 @@ jobs:
         if: inputs.test-result == 'success'
         env:
           PR_INFO: ${{ steps.active-pr.outputs.result }}
-        # If we're running a preview, this will push it onto the preview branch
-        # we just created in the previous step.
         run: npm run deploy repoDist
 
       - name: Report deployment status
-        if: always() && !inputs.preview && steps.deploy-step.result != 'cancelled'
+        if: always() && steps.deploy-step.result != 'cancelled'
         env:
           PR_INFO: ${{ steps.active-pr.outputs.result }}
           TEST_RESULT: ${{ inputs.test-result }}
@@ -112,15 +85,3 @@ jobs:
           script: |
             const script = require('./build/report-deploy.js');
             await script.reportDeploy({ github, context });
-
-      - name: Report preview
-        # Will be skipped if deployment failed
-        if: inputs.preview
-        env:
-          PR_INFO: ${{ steps.active-pr.outputs.result }}
-          DEPLOY_INFO: ${{ steps.deploy-step.outputs.deployment-info }}
-        uses: actions/github-script@v5
-        with:
-          script: |
-            const script = require('./build/report-deploy.js');
-            await script.reportPreview({ github, context });

--- a/.github/workflows/slash-commands-dispatch.yml
+++ b/.github/workflows/slash-commands-dispatch.yml
@@ -1,0 +1,18 @@
+---
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.SLASH_COMMAND_DISPATCH_PAT }}
+          commands: |
+            deploy-preview
+          issue-type: pull-request
+          permission: write
+

--- a/build/deploy.ts
+++ b/build/deploy.ts
@@ -101,8 +101,10 @@ async function scanAndPush(): Promise<void> {
     }
 
     if (updates.length) {
-        console.log('Pushing…');
-        await gitDist.push();
+        if (!process.env.SKIP_PUSH) {
+            console.log('Pushing…');
+            await gitDist.push();
+        }
 
         // Logging this message, it should get picked up by the Actions runner
         // to set the step output.

--- a/build/report-deploy.js
+++ b/build/report-deploy.js
@@ -49,14 +49,14 @@ async function reportDeploy({ github, context }) {
 }
 
 // @ts-expect-error Not typescript
-async function reportPreview({ github, context }) {
+async function reportPreview({ github, context, full }) {
     const prInfo = JSON.parse(process.env.PR_INFO || '{}');
     const deployInfo = JSON.parse(process.env.DEPLOY_INFO || '{}');
 
     let content;
     if (!deployInfo.scripts || !deployInfo.scripts.length) {
         content = 'This PR makes no changes to the built userscripts.';
-    } else {
+    } else if (full) {
         const basePreviewUrl = `https://raw.github.com/${context.repo.owner}/${context.repo.repo}/dist-preview-${prInfo.number}`;
         const diffUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/compare/dist...dist-preview-${prInfo.number}`;
         content = [
@@ -69,6 +69,16 @@ async function reportPreview({ github, context }) {
             '',
             `[See all changes](${diffUrl})`,
         ]).join('\n');
+    } else {
+        content = [
+            `This PR changes ${deployInfo.scripts.length} built userscript(s):`
+        // @ts-expect-error not typescript
+        ].concat(deployInfo.scripts.map((script) => {
+            return `* \`${script.name}\``;
+        }).concat([
+            '',
+            '_Comment /preview to generate a preview of the deployed changes. Available to collaborators only._',
+        ])).join('\n');
     }
 
     const existingComments = await github.rest.issues.listComments({


### PR DESCRIPTION
Collaborators and above must create a comment starting with `/deploy-preview`
to generate a preview for the current PR. This is because PRs
originating from forked repos (incl. dependabot) don't have write
access to push to a comparison branch.

@kellnerd: Pinging you since you're the only collaborator on this repo at the moment. Basically, these changes _should_ us to create a preview of the changes made in a PR by adding a comment where the first line is `/deploy-preview`. The bot should now leave a comment saying whether or not changes to the built userscript will occur, but it won't generate a built preview that can be installed or compared to the current version yet. The main reason is because it's a bit unsafe: Someone could change the build scripts to do malicious things and the bot would happily execute all of that... So that's disabled, and you have to explicitly "run" that `/preview` "command" (but only if it's safe, of course 😄 )

Edit: Of course, the bot also doesn't have the permissions to leave comments on PRs from forks, and I think it's a bit overkill to try and fix that, so I'll make another change to not do the check automatically either.

TL;DR: If you need to preview changes to the built userscripts in a PR, comment `/deploy-preview` and the bot will do it.