### PR TITLE
test(caa upload): make sure Tidal provider does not extract video

### DIFF
--- a/tests/mb_enhanced_cover_art_uploads/providers/tidal.test.ts
+++ b/tests/mb_enhanced_cover_art_uploads/providers/tidal.test.ts
@@ -52,6 +52,15 @@ describe('tidal provider', () => {
         expect(coverUrl[0].comment).toBeUndefined();
     });
 
+    it('extracts static cover if release has video cover', async () => {
+        const coverUrl = await provider.findImages(new URL('https://listen.tidal.com/album/171032759'));
+
+        expect(coverUrl).toBeArrayOfSize(1);
+        expect(coverUrl[0].url.pathname).toBe('/images/72c1e674/70ca/4442/a530/0f00b0ef354a/origin.jpg');
+        expect(coverUrl[0].types).toStrictEqual([ArtworkTypeIDs.Front]);
+        expect(coverUrl[0].comment).toBeUndefined();
+    });
+
     it('throws if release does not exist', async () => {
         pollyContext.polly.configure({
             recordFailedRequests: true,

--- a/tests/test-data/__recordings__/tidal-provider_1176636160/extracts-static-cover-if-release-has-video-cover_2300049562/recording.har
+++ b/tests/test-data/__recordings__/tidal-provider_1176636160/extracts-static-cover-if-release-has-video-cover_2300049562/recording.har
@@ -1,0 +1,212 @@
+{
+  "log": {
+    "_recordingName": "tidal provider/extracts static cover if release has video cover",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "5.1.1"
+    },
+    "entries": [
+      {
+        "_id": "47c39b1a5162a6c91ca5b413317109d4",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [],
+          "headersSize": 51,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://listen.tidal.com/v1/ping"
+        },
+        "response": {
+          "bodySize": 2,
+          "content": {
+            "mimeType": "text/plain",
+            "size": 2,
+            "text": "OK"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "no-cache"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "2"
+            },
+            {
+              "name": "content-type",
+              "value": "text/plain"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 20 Oct 2021 18:53:03 GMT"
+            },
+            {
+              "name": "server",
+              "value": "noyb"
+            },
+            {
+              "name": "via",
+              "value": "1.1 bdba42cf1410fb617eeb4ffd3e0b9cb7.cloudfront.net (CloudFront)"
+            },
+            {
+              "name": "x-amz-cf-id",
+              "value": "vSHqwl8um0SLDX-hJNth3rbHqlvQ50ZMXUP--fKrT7bOHsPj1zkppw=="
+            },
+            {
+              "name": "x-amz-cf-pop",
+              "value": "AMS1-C1"
+            },
+            {
+              "name": "x-cache",
+              "value": "Miss from cloudfront"
+            },
+            {
+              "name": "x-pollyjs-finalurl",
+              "value": "https://listen.tidal.com/v1/ping"
+            }
+          ],
+          "headersSize": 392,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-20T18:53:02.909Z",
+        "time": 279,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 279
+        }
+      },
+      {
+        "_id": "c77873e2c8d87b184c964c6c0445b419",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-tidal-token",
+              "value": "CzET4vdadNUFQ5JU"
+            }
+          ],
+          "headersSize": 141,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "albumId",
+              "value": "171032759"
+            },
+            {
+              "name": "countryCode",
+              "value": "NL"
+            },
+            {
+              "name": "deviceType",
+              "value": "BROWSER"
+            }
+          ],
+          "url": "https://listen.tidal.com/v1/pages/album?albumId=171032759&countryCode=NL&deviceType=BROWSER"
+        },
+        "response": {
+          "bodySize": 3634,
+          "content": {
+            "mimeType": "application/json;charset=UTF-8",
+            "size": 3634,
+            "text": "{\"selfLink\":null,\"id\":\"eyJwIjoiZTZlM2ZmMWItZDZjNC00NzczLTg4ZDAtMGNmOTdjY2ZjYjU5IiwicFYiOjEzfQ==\",\"title\":\"Wild Youngster (feat. ScHoolboy Q) (Jamie Jones' Wobble Remix)\",\"rows\":[{\"modules\":[{\"id\":\"eyJwIjoiZTZlM2ZmMWItZDZjNC00NzczLTg4ZDAtMGNmOTdjY2ZjYjU5IiwicFYiOjEzLCJtIjoiOTg3YjJiZGUtMGE5MS00YzYxLWFkNGItNzllYzdkNGY5NmU0IiwibVYiOjEsIm1IIjoiYTRkNjQ0NWEifQ==\",\"type\":\"ALBUM_HEADER\",\"width\":100,\"title\":\"\",\"description\":\"\",\"preTitle\":\"\",\"album\":{\"id\":171032759,\"title\":\"Wild Youngster (feat. ScHoolboy Q) (Jamie Jones' Wobble Remix)\",\"duration\":193,\"streamReady\":true,\"streamStartDate\":\"2021-02-12T00:00:00.000+0000\",\"allowStreaming\":true,\"numberOfTracks\":1,\"numberOfVideos\":0,\"numberOfVolumes\":1,\"releaseDate\":\"2021-02-12\",\"copyright\":\"(P) 2021 The Wild Children, LLC under exclusive license to Three Six Zero Recordings/Sony Music Entertainment\",\"type\":\"SINGLE\",\"version\":null,\"url\":\"http://www.tidal.com/album/171032759\",\"cover\":\"72c1e674-70ca-4442-a530-0f00b0ef354a\",\"videoCover\":\"9cc2842e-7430-4280-a7ba-4e06eec9ab3f\",\"explicit\":false,\"popularity\":0,\"audioQuality\":\"HI_RES\",\"audioModes\":[\"STEREO\"],\"artists\":[{\"id\":20699717,\"name\":\"NEZ\",\"type\":\"MAIN\",\"picture\":\"43d88a75-b76c-437f-8892-b8c7fe151fb3\"},{\"id\":3882537,\"name\":\"ScHoolboy Q\",\"type\":\"FEATURED\",\"picture\":\"4b9d0b7b-f972-435a-ac3e-639b407fe0bc\"}]},\"review\":{\"text\":null,\"source\":null},\"credits\":{\"items\":[]},\"playbackControls\":[{\"shuffle\":false,\"playbackMode\":\"PLAY\",\"title\":\"Play\",\"icon\":\"play_tracks\",\"targetModuleId\":\"eyJwIjoiZTZlM2ZmMWItZDZjNC00NzczLTg4ZDAtMGNmOTdjY2ZjYjU5IiwicFYiOjEzLCJtIjoiNjJmY2NhZTUtNDIwZC00MGJlLWJjZGMtZTUzODIwYzAwZjA5IiwibVYiOjEsIm1IIjoiYmMzMGM4NWQifQ==\"},{\"shuffle\":true,\"playbackMode\":\"SHUFFLE\",\"title\":\"Shuffle\",\"icon\":\"shuffle_tracks\",\"targetModuleId\":\"eyJwIjoiZTZlM2ZmMWItZDZjNC00NzczLTg4ZDAtMGNmOTdjY2ZjYjU5IiwicFYiOjEzLCJtIjoiNjJmY2NhZTUtNDIwZC00MGJlLWJjZGMtZTUzODIwYzAwZjA5IiwibVYiOjEsIm1IIjoiYmMzMGM4NWQifQ==\"}]}]},{\"modules\":[{\"id\":\"eyJwIjoiZTZlM2ZmMWItZDZjNC00NzczLTg4ZDAtMGNmOTdjY2ZjYjU5IiwicFYiOjEzLCJtIjoiNjJmY2NhZTUtNDIwZC00MGJlLWJjZGMtZTUzODIwYzAwZjA5IiwibVYiOjEsIm1IIjoiYmMzMGM4NWQifQ==\",\"type\":\"ALBUM_ITEMS\",\"width\":100,\"title\":\"\",\"description\":\"\",\"preTitle\":null,\"showMore\":null,\"supportsPaging\":false,\"quickPlay\":false,\"copyright\":\"(P) 2021 The Wild Children, LLC under exclusive license to Three Six Zero Recordings/Sony Music Entertainment\",\"releaseDate\":\"2021-02-12\",\"listFormat\":\"NUMBERS\",\"pagedList\":{\"limit\":9999,\"offset\":0,\"totalNumberOfItems\":1,\"items\":[{\"item\":{\"id\":171032760,\"title\":\"Wild Youngster (feat. ScHoolboy Q) (Jamie Jones' Wobble Remix)\",\"duration\":193,\"version\":null,\"url\":\"http://www.tidal.com/track/171032760\",\"artists\":[{\"id\":20699717,\"name\":\"NEZ\",\"type\":\"MAIN\",\"picture\":\"43d88a75-b76c-437f-8892-b8c7fe151fb3\"},{\"id\":3882537,\"name\":\"ScHoolboy Q\",\"type\":\"FEATURED\",\"picture\":\"4b9d0b7b-f972-435a-ac3e-639b407fe0bc\"}],\"album\":{\"id\":171032759,\"title\":\"Wild Youngster (feat. ScHoolboy Q) (Jamie Jones' Wobble Remix)\",\"cover\":\"72c1e674-70ca-4442-a530-0f00b0ef354a\",\"vibrantColor\":\"#FFFFFF\",\"videoCover\":\"9cc2842e-7430-4280-a7ba-4e06eec9ab3f\",\"url\":\"http://www.tidal.com/album/171032759\",\"releaseDate\":\"2021-02-12\"},\"explicit\":false,\"volumeNumber\":1,\"trackNumber\":1,\"popularity\":1,\"allowStreaming\":true,\"streamReady\":true,\"streamStartDate\":\"2021-02-12T00:00:00.000+0000\",\"editable\":false,\"replayGain\":-6.56,\"audioQuality\":\"HI_RES\",\"audioModes\":[\"STEREO\"],\"mixes\":{\"MASTER_TRACK_MIX\":\"0146c3e3ea420c3b8440c8d4845aa8\",\"TRACK_MIX\":\"0011fb8ceb3f1ac3b3ad78d0b5e07e\"}},\"type\":\"track\"}],\"dataApiPath\":\"pages/data/2fbf68c2-dc58-49b1-b1be-6958e66383f3?albumId=171032759\"},\"playButton\":true,\"shuffleButton\":true}]}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "cache-control",
+              "value": "private, max-age=60, s-max-age=60,"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "content-length",
+              "value": "3634"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json;charset=UTF-8"
+            },
+            {
+              "name": "date",
+              "value": "Wed, 20 Oct 2021 18:53:03 GMT"
+            },
+            {
+              "name": "etag",
+              "value": "\"-84408911\""
+            },
+            {
+              "name": "server",
+              "value": "noyb"
+            },
+            {
+              "name": "vary",
+              "value": "x-tidal-sessionid,x-tidal-token,authorization"
+            },
+            {
+              "name": "via",
+              "value": "1.1 317b3418459e7cb903a13afaecea9340.cloudfront.net (CloudFront)"
+            },
+            {
+              "name": "x-amz-cf-id",
+              "value": "Fa7yOE0RZFmfvbjbhjhHPwFdLBfVb9pIsn2Oz9e3IqQy83ndJsw1Zg=="
+            },
+            {
+              "name": "x-amz-cf-pop",
+              "value": "AMS1-C1"
+            },
+            {
+              "name": "x-cache",
+              "value": "Miss from cloudfront"
+            },
+            {
+              "name": "x-pollyjs-finalurl",
+              "value": "https://listen.tidal.com/v1/pages/album?albumId=171032759&countryCode=NL&deviceType=BROWSER"
+            }
+          ],
+          "headersSize": 572,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-20T18:53:03.190Z",
+        "time": 217,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 217
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
I bumped into a Tidal release where the front cover is actually a video. Since video covers aren't supported on CAA yet (see [CAA-132](https://tickets.metabrainz.org/browse/CAA-132)), we should make sure that we grab the static image rather than the cover.

It turns out that this already works properly in the code, but I'm adding a test case to make this explicit and prevent regressions in the future.