### PR TITLE
fix(caa upload): fix TamperMonkey match patterns

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/meta.ts
+++ b/src/mb_enhanced_cover_art_uploads/meta.ts
@@ -8,8 +8,10 @@ const metadata: UserscriptMetadata = {
     'run-at': 'document-load',
     match: [
         'release/*/add-cover-art',
-    ].map(transformMBMatchURL).concat(
-        ['*://atisket.pulsewidth.org.uk/*']),
+        'release/*/add-cover-art?*',
+    ].map(transformMBMatchURL).concat([
+        '*://atisket.pulsewidth.org.uk/*'
+    ]),
     exclude: ['*://atisket.pulsewidth.org.uk/'],
     grant: [
         'GM_xmlhttpRequest',


### PR DESCRIPTION
In #72, we changed the URL seeding to use query parameters instead
of hashes. As we already knew from #59, ViolentMonkey and TamperMonkey
handle match patterns with query parameters differently. This change
led to an incompatibility with TamperMonkey.

Possibly closes #145.