### PR TITLE
ci: run CI on a weekly schedule

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -7,6 +7,10 @@ on:
   push:
     branches:
       - main
+  # Periodically run CI for CodeQL security advisories etc, in case new checks
+  # are added.
+  schedule:
+    - cron: '39 12 * * 0'
 
 jobs:
   build-and-test:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,10 +3,6 @@ name: CodeQL
 
 on:
   workflow_call:
-  workflow_dispatch:
-  # Periodically run CodeQL for the security advisories etc.
-  schedule:
-    - cron: '39 12 * * 0'
 
 jobs:
   analyze:


### PR DESCRIPTION
We were previously running the CodeQL analysis on a weekly schedule,
we're now moving that to running the whole CI on a weekly schedule.

The reason we run CodeQL regularly is because it may get updated
with new rules etc., so it makes sense to periodically rescan the
code to make use of the new rules. However, for some reason, when
CodeQL finds a security alert, it won't close that security alert
unless the very same workflow finds that the security alert is fixed.
See 64843d7a87ade07ca8719e0df103f524ecc4fba2, before I manually ran
that workflow, we had three security alerts which were already fixed,
but not marked as resolved. After I ran it, the alerts got resolved
automatically.

Because we were running CodeQL through the CI workflow, as well as
scheduled separately, there were two possible workflows that would
report alerts: "CI" and "CodeQL". As I found out, only if the same
workflow finds the report to be fixed, will it be closed. So, if it
were to happen that a scheduled "CodeQL" workflow finds a problem,
even if we were to fix that problem and "CI" would report it as
fixed, we'd need to wait until "CodeQL" runs again the week after
for the alert to be closed.

Instead, we'll run "CI" on a schedule and run "CodeQL" only through
calls from "CI", so that only one workflow can find problems.
Therefore, when the scheduled "CI" workflow finds an issue, it can
also close it when it's triggered by a `push` event after we fix it.

TL;DR: Run "CI" on a schedule rather than "CodeQL" so that fixed
security alerts get resolved automatically as soon as they're fixed,
not the week after.