### PR TITLE
fix(caa upload): match underscores in a-tasket's self_id query param

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
@@ -30,7 +30,7 @@ export const AtasketSeeder: Seeder = {
 
     insertSeedLinks(): void {
         const mbid = document.location.search.match(/[?&]release_mbid=([a-f0-9-]+)/)?.[1];
-        const selfId = document.location.search.match(/[?&]self_id=([a-zA-Z0-9-]+)/)?.[1];
+        const selfId = document.location.search.match(/[?&]self_id=([a-zA-Z0-9_-]+)/)?.[1];
         if (!mbid || !selfId) {
             LOGGER.error('Cannot extract IDs! Seeding is disabled :(');
             return;


### PR DESCRIPTION
The seeder previously returned incomplete cached URLs for a-tasket pages, i.e. it only returned only `cached=<barcode>-d` instead of `cached=<barcode>-d_<deezerId>-s_<spotifyId-i_<appleId>`.

A cleaner solution would be the usage of `URLSearchParams` instead of regular expressions. Is/Was there any reason no to use them?

*Edit*: In any case, that's it from me for today, feel free to release this as a hotfix (we can do the cleaner solution later) or push directly to this branch if you want.