### PR TITLE
feat(caa upload): add QUB Musique provider

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/index.ts
@@ -9,6 +9,7 @@ import { AmazonProvider } from './amazon';
 import { AmazonMusicProvider } from './amazon_music';
 import { QobuzProvider } from './qobuz';
 import { VGMdbProvider } from './vgmdb';
+import { QubMusiqueProvider } from './qub_musique';
 
 const PROVIDER_DISPATCH: Map<string, CoverArtProvider> = new Map();
 
@@ -24,6 +25,7 @@ add_provider(new BandcampProvider());
 add_provider(new DeezerProvider());
 add_provider(new DiscogsProvider());
 add_provider(new QobuzProvider());
+add_provider(new QubMusiqueProvider());
 add_provider(new SpotifyProvider());
 add_provider(new TidalProvider());
 add_provider(new VGMdbProvider());

--- a/src/mb_enhanced_cover_art_uploads/providers/qub_musique.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/qub_musique.ts
@@ -1,0 +1,14 @@
+import { QobuzProvider } from './qobuz';
+
+// Qub Musique uses Qobuz as a backend and reuses the same IDs and covers. See
+// https://github.com/ROpdebee/mb-userscripts/issues/158
+export class QubMusiqueProvider extends QobuzProvider {
+    override supportedDomains = ['qub.ca'];
+    override favicon = 'https://www.qub.ca/assets/favicons/apple-touch-icon.png';
+    override name = 'QUB Musique';
+    // Include musique in the regex as it seems QUB does much more than just
+    // music streaming
+    override urlRegex = [/musique\/album\/[\w-]*-([A-Za-z0-9]+)(?:\/|$)/];
+    // We can reuse the rest of the implementations of QobuzProvider, since it
+    // extracts the ID and uses the Qobuz API instead of loading the page.
+}

--- a/src/mb_enhanced_cover_art_uploads/supportedProviders.md
+++ b/src/mb_enhanced_cover_art_uploads/supportedProviders.md
@@ -12,6 +12,7 @@ The following table describes the types of links supported by MB: Upload to CAA 
 | Deezer | ✔️ | ✔️ |
 | Discogs | Partial | ❌ | Images are limited to 600x600, see [qsniyg/maxurl#689](https://github.com/qsniyg/maxurl/issues/689) |
 | Qobuz | ✔️ | ✔️ | Goodies are grabbed whenever possible. Back covers might not be supported at this time, if you have a release with a back cover, please let me know. |
+| QUB Musique | ✔️ | ✔️ | Dispatched to Qobuz provider. |
 | Spotify | ✔️ | ✔️ |
 | Tidal | ✔️ | ✔️ | listen.tidal.com/store.tidal.com are converted to tidal.com prior to fetching |
 | VGMdb | ✔️ | ✔️ | Types are filled on a best-effort basis, make sure to double-check. Some images are not fetched, see issue [#62](https://github.com/ROpdebee/mb-userscripts/issues/62). |

--- a/tests/mb_enhanced_cover_art_uploads/providers/qub_musique.test.ts
+++ b/tests/mb_enhanced_cover_art_uploads/providers/qub_musique.test.ts
@@ -1,0 +1,54 @@
+import { setupPolly } from '@test-utils/pollyjs';
+
+import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { HTTPResponseError } from '@lib/util/xhr';
+import { QubMusiqueProvider } from '@src/mb_enhanced_cover_art_uploads/providers/qub_musique';
+
+describe('qub musique provider', () => {
+    const pollyContext = setupPolly();
+    const provider = new QubMusiqueProvider();
+
+    const urlCases = [
+        ['album URLs', 'https://www.qub.ca/musique/album/normal-de-l-est-w2l52wh19l0ib', 'w2l52wh19l0ib'],
+        ['album URLs with numbers', 'https://www.qub.ca/musique/album/rapelles-saison-1-ysyh4e97276hc', 'ysyh4e97276hc'],
+        ['dirty album URLs', 'https://www.qub.ca/musique/album/rapelles-saison-1-ysyh4e97276hc?test=123', 'ysyh4e97276hc'],
+    ];
+    const urlIgnoreCases = [
+        ['artist URLs', 'https://www.qub.ca/musique/artiste/multi-artistes-3662940'],
+        ['radio URLs', 'https://www.qub.ca/radio/balado/benoit-dutrizac'],
+        ['article URLs', 'https://www.qub.ca/article/jean-charest-defend-le-regime-de-pekin-1058978600'],
+    ];
+
+    it.each(urlCases)('matches %s', (_1, url) => {
+        expect(provider.supportsUrl(new URL(url)))
+            .toBeTrue();
+    });
+
+    it.each(urlIgnoreCases)('does not match %s', (_1, url) => {
+        expect(provider.supportsUrl(new URL(url)))
+            .toBeFalse();
+    });
+
+    it.each(urlCases)('extracts ID for %s', (_1, url, expectedId) => {
+        expect(provider.extractId(new URL(url)))
+            .toBe(expectedId);
+    });
+
+    it('finds cover image', async () => {
+        const covers = await provider.findImages(new URL('https://www.qub.ca/musique/album/pour-le-plug-dbssxi6nl5fuc'));
+
+        expect(covers).toBeArrayOfSize(1);
+        expect(covers[0].url.pathname).toBe('/images/covers/uc/5f/dbssxi6nl5fuc_org.jpg');
+        expect(covers[0].types).toStrictEqual([ArtworkTypeIDs.Front]);
+        expect(covers[0].comment).toBeUndefined();
+    });
+
+    it('throws on non-existent release', async () => {
+        pollyContext.polly.configure({
+            recordFailedRequests: true,
+        });
+
+        await expect(provider.findImages(new URL('https://www.qub.ca/musique/album/pour-le-plug-dbssx')))
+            .rejects.toBeInstanceOf(HTTPResponseError);
+    });
+});

--- a/tests/test-data/__recordings__/qub-musique-provider_764412081/finds-cover-image_3823227505/recording.har
+++ b/tests/test-data/__recordings__/qub-musique-provider_764412081/finds-cover-image_3823227505/recording.har
@@ -1,0 +1,150 @@
+{
+  "log": {
+    "_recordingName": "qub musique provider/finds cover image",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "5.1.1"
+    },
+    "entries": [
+      {
+        "_id": "b16607351321e2c011463e98d82d4db7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-app-id",
+              "value": 712109809
+            }
+          ],
+          "headersSize": 123,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "album_id",
+              "value": "dbssxi6nl5fuc"
+            },
+            {
+              "name": "offset",
+              "value": "0"
+            },
+            {
+              "name": "limit",
+              "value": "20"
+            }
+          ],
+          "url": "https://www.qobuz.com/api.json/0.2/album/get?album_id=dbssxi6nl5fuc&offset=0&limit=20"
+        },
+        "response": {
+          "bodySize": 12511,
+          "content": {
+            "mimeType": "application/json",
+            "size": 12511,
+            "text": "{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"product_url\":\"\\/fr-fr\\/album\\/pour-le-plug-tizzo\\/dbssxi6nl5fuc\",\"media_count\":1,\"product_sales_factors_weekly\":0,\"artist\":{\"id\":4165177,\"name\":\"Tizzo\",\"slug\":\"tizzo\",\"albums_count\":15,\"picture\":null,\"image\":null},\"genres_list\":[\"Rap\"],\"created_at\":1627310302,\"description\":\"\",\"released_at\":1634248800,\"product_sales_factors_monthly\":0,\"release_tags\":[],\"title\":\"Pour le Plug\",\"duration\":2132,\"parental_warning\":true,\"artists\":[{\"id\":4165177,\"name\":\"Tizzo\",\"roles\":[\"main-artist\"]}],\"popularity\":0,\"genre\":{\"id\":133,\"color\":\"#5eabc1\",\"name\":\"Hip-Hop\\/Rap\",\"path\":[133],\"slug\":\"rap-hip-hop\"},\"catchline\":\"\",\"id\":\"dbssxi6nl5fuc\",\"slug\":\"pour-le-plug-tizzo\",\"image\":{\"large\":\"https:\\/\\/static.qobuz.com\\/images\\/covers\\/uc\\/5f\\/dbssxi6nl5fuc_600.jpg\",\"small\":\"https:\\/\\/static.qobuz.com\\/images\\/covers\\/uc\\/5f\\/dbssxi6nl5fuc_230.jpg\",\"thumbnail\":\"https:\\/\\/static.qobuz.com\\/images\\/covers\\/uc\\/5f\\/dbssxi6nl5fuc_50.jpg\",\"back\":null},\"composer\":{\"id\":573076,\"name\":\"Various Composers\",\"slug\":\"various-composers\",\"albums_count\":583621,\"picture\":null,\"image\":null},\"upc\":\"3616558001818\",\"release_type\":\"album\",\"label\":{\"id\":1065091,\"name\":\"Canicule Records\",\"slug\":\"canicule-records\",\"supplier_id\":3,\"albums_count\":28},\"product_sales_factors_yearly\":0,\"qobuz_id\":127435241,\"version\":null,\"url\":\"https:\\/\\/www.qobuz.com\\/nl-nl\\/album\\/pour-le-plug-tizzo\\/dbssxi6nl5fuc\",\"is_official\":false,\"relative_url\":\"\\/album\\/pour-le-plug-tizzo\\/dbssxi6nl5fuc\",\"product_type\":\"album\",\"subtitle\":\"Tizzo\",\"tracks_count\":11,\"maximum_channel_count\":2,\"maximum_sampling_rate\":44.100000000000001,\"articles\":[{\"id\":490612289,\"url\":\"\\/order\\/490612289\",\"price\":8.9900000000000002,\"currency\":\"EUR\",\"type\":\"lls\",\"label\":\"Cd-kwaliteit\",\"description\":\"Lossless, 16-bits\\/44,1 kHz (FLAC, ALAC, WMA, AIFF, WAV)\"}],\"release_date_original\":\"2021-10-15\",\"release_date_download\":\"2021-10-15\",\"release_date_stream\":\"2021-10-15\",\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false,\"tracks\":{\"offset\":0,\"limit\":20,\"total\":11,\"items\":[{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"Tizzo, MainArtist - Teddy Laguerre, Lyricist - Birdzonthetrack, Producer - Lendcey Fineus, Composer\",\"audio_info\":{\"replaygain_track_peak\":0.96606400000000003,\"replaygain_track_gain\":-9.0199999999999996},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Lendcey Fineus\",\"id\":7524070},\"isrc\":\"FRX282176261\",\"title\":\"#PLP\",\"version\":\"Intro\",\"duration\":191,\"parental_warning\":true,\"track_number\":1,\"maximum_channel_count\":2,\"id\":127435242,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"P.C., Producer - Tizzo, MainArtist - Teddy Laguerre, Lyricist - Christopher Pierre, Composer\",\"audio_info\":{\"replaygain_track_peak\":0.999969,\"replaygain_track_gain\":-1},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Christopher Pierre\",\"id\":6145686},\"isrc\":\"FRX282176262\",\"title\":\"Robinet\",\"version\":null,\"duration\":198,\"parental_warning\":true,\"track_number\":2,\"maximum_channel_count\":2,\"id\":127435243,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"P.C., Producer - Tizzo, MainArtist - Alexdagr8, Producer - Teddy Laguerre, Lyricist - Michael Mastoropoulos, Composer - Christopher Pierre, Composer - Henry Mitcheal, Composer\",\"audio_info\":{\"replaygain_track_peak\":0.97500600000000004,\"replaygain_track_gain\":-2.5299999999999998},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Michael Mastoropoulos\",\"id\":4778289},\"isrc\":\"FRX202174828\",\"title\":\"Shewing Gum\",\"version\":null,\"duration\":171,\"parental_warning\":true,\"track_number\":3,\"maximum_channel_count\":2,\"id\":127435244,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"Tizzo, MainArtist - Teddy Laguerre, Lyricist - shreez, FeaturedArtist - Kheir, Producer - Kheir Eldine Hori, Composer - JuicemanSF, FeaturedArtist\",\"audio_info\":{\"replaygain_track_peak\":0.99612400000000001,\"replaygain_track_gain\":-3.5600000000000001},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Kheir Eldine Hori\",\"id\":8844867},\"isrc\":\"FRX282176263\",\"title\":\"Hennyyyyy\",\"version\":null,\"duration\":199,\"parental_warning\":true,\"track_number\":4,\"maximum_channel_count\":2,\"id\":127435245,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"Rach, FeaturedArtist - Tizzo, MainArtist - Rapha\\u00ebl Simard, Composer - Teddy Laguerre, Lyricist - Raphlex, Producer\",\"audio_info\":{\"replaygain_track_peak\":0.90487700000000004,\"replaygain_track_gain\":-4.2800000000000002},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Rapha\\u00ebl Simard\",\"id\":4356299},\"isrc\":\"FRX282176264\",\"title\":\"Pinel\",\"version\":null,\"duration\":205,\"parental_warning\":true,\"track_number\":5,\"maximum_channel_count\":2,\"id\":127435246,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"Tizzo, MainArtist - Teddy Laguerre, Lyricist - White Migz, FeaturedArtist - William Herrera Gagnon, Composer - Plutonic Beats, Producer\",\"audio_info\":{\"replaygain_track_peak\":0.97720300000000004,\"replaygain_track_gain\":-8.1699999999999999},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"William Herrera Gagnon\",\"id\":10123906},\"isrc\":\"FRX282176265\",\"title\":\"Viral\",\"version\":null,\"duration\":185,\"parental_warning\":true,\"track_number\":6,\"maximum_channel_count\":2,\"id\":127435247,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"P.C., Producer - Tizzo, MainArtist - Teddy Laguerre, Lyricist - Connaisseur Ticaso, FeaturedArtist - Christopher Pierre, Composer\",\"audio_info\":{\"replaygain_track_peak\":0.999969,\"replaygain_track_gain\":-3.0099999999999998},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Christopher Pierre\",\"id\":6145686},\"isrc\":\"FRX282176266\",\"title\":\"GDR\",\"version\":null,\"duration\":202,\"parental_warning\":true,\"track_number\":7,\"maximum_channel_count\":2,\"id\":127435248,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"Tizzo, MainArtist - Teddy Laguerre, Lyricist - shreez, FeaturedArtist - Birdzonthetrack, Producer - Lendcey Fineus, Composer\",\"audio_info\":{\"replaygain_track_peak\":0.999969,\"replaygain_track_gain\":-6.6799999999999997},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Lendcey Fineus\",\"id\":7524070},\"isrc\":\"FRX282176267\",\"title\":\"Cajun\",\"version\":null,\"duration\":199,\"parental_warning\":true,\"track_number\":8,\"maximum_channel_count\":2,\"id\":127435249,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"Tizzo, MainArtist - Teddy Laguerre, Lyricist - MikeZup, FeaturedArtist - RKT, Producer - Romeo Kouemeni Tongambou, Composer\",\"audio_info\":{\"replaygain_track_peak\":0.97604400000000002,\"replaygain_track_gain\":-1.79},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Romeo Kouemeni Tongambou\",\"id\":7917732},\"isrc\":\"FRX282176268\",\"title\":\"Cheminement particulier\",\"version\":null,\"duration\":243,\"parental_warning\":true,\"track_number\":9,\"maximum_channel_count\":2,\"id\":127435250,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"Tizzo, MainArtist - Alexdagr8, Producer - Teddy Laguerre, Lyricist - Michael Mastoropoulos, Composer - J.BO, FeaturedArtist\",\"audio_info\":{\"replaygain_track_peak\":0.999969,\"replaygain_track_gain\":-1.9299999999999999},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Michael Mastoropoulos\",\"id\":4778289},\"isrc\":\"FRX282176269\",\"title\":\"Intercom\",\"version\":null,\"duration\":172,\"parental_warning\":true,\"track_number\":10,\"maximum_channel_count\":2,\"id\":127435251,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false},{\"maximum_bit_depth\":16,\"copyright\":\"2021 Canicule Records 2021 Canicule Records\",\"performers\":\"YB, FeaturedArtist - Tizzo, MainArtist - Teddy Laguerre, Lyricist - Felix Binette, Composer - Neutrontheplug, Producer\",\"audio_info\":{\"replaygain_track_peak\":1,\"replaygain_track_gain\":-8.1899999999999995},\"performer\":{\"name\":\"Tizzo\",\"id\":4165177},\"work\":null,\"composer\":{\"name\":\"Felix Binette\",\"id\":10123909},\"isrc\":\"FRX282176270\",\"title\":\"Outro\",\"version\":null,\"duration\":167,\"parental_warning\":true,\"track_number\":11,\"maximum_channel_count\":2,\"id\":127435252,\"media_number\":1,\"maximum_sampling_rate\":44.100000000000001,\"release_date_original\":null,\"release_date_download\":null,\"release_date_stream\":null,\"purchasable\":true,\"streamable\":false,\"previewable\":true,\"sampleable\":true,\"downloadable\":true,\"displayable\":true,\"purchasable_at\":1634248800,\"streamable_at\":1634248800,\"hires\":false,\"hires_streamable\":false}]}}"
+          },
+          "cookies": [
+            {
+              "domain": "qobuz.com",
+              "httpOnly": true,
+              "name": "qobuz-session-aws",
+              "path": "/",
+              "value": "37ec19e5bbc875be4145aeba836e1d85:c8797971e9e5a87e66922a0152645babc5c3d060"
+            }
+          ],
+          "headers": [
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-zone, x-language-code"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            },
+            {
+              "name": "content-length",
+              "value": "12511"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 22 Oct 2021 16:49:38 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "set-cookie",
+              "value": "qobuz-session-aws=37ec19e5bbc875be4145aeba836e1d85:c8797971e9e5a87e66922a0152645babc5c3d060; path=/; domain=qobuz.com; HttpOnly"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "x-language-code",
+              "value": "nl"
+            },
+            {
+              "name": "x-store",
+              "value": "NL-nl"
+            },
+            {
+              "name": "x-varnish",
+              "value": "2066627917"
+            },
+            {
+              "name": "x-zone",
+              "value": "NL"
+            },
+            {
+              "name": "x-pollyjs-finalurl",
+              "value": "https://www.qobuz.com/api.json/0.2/album/get?album_id=dbssxi6nl5fuc&offset=0&limit=20"
+            }
+          ],
+          "headersSize": 608,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-10-22T16:49:38.074Z",
+        "time": 712,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 712
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/tests/test-data/__recordings__/qub-musique-provider_764412081/throws-on-non-existent-release_1189313548/recording.har
+++ b/tests/test-data/__recordings__/qub-musique-provider_764412081/throws-on-non-existent-release_1189313548/recording.har
@@ -1,0 +1,138 @@
+{
+  "log": {
+    "_recordingName": "qub musique provider/throws on non-existent release",
+    "creator": {
+      "comment": "persister:fs",
+      "name": "Polly.JS",
+      "version": "5.1.1"
+    },
+    "entries": [
+      {
+        "_id": "a601be04b0320095f390c1548a98e530",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "name": "x-app-id",
+              "value": 712109809
+            }
+          ],
+          "headersSize": 115,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [
+            {
+              "name": "album_id",
+              "value": "dbssx"
+            },
+            {
+              "name": "offset",
+              "value": "0"
+            },
+            {
+              "name": "limit",
+              "value": "20"
+            }
+          ],
+          "url": "https://www.qobuz.com/api.json/0.2/album/get?album_id=dbssx&offset=0&limit=20"
+        },
+        "response": {
+          "bodySize": 75,
+          "content": {
+            "mimeType": "application/json",
+            "size": 75,
+            "text": "{\"status\":\"error\",\"code\":404,\"message\":\"No result matching given argument\"}"
+          },
+          "cookies": [
+            {
+              "domain": "qobuz.com",
+              "httpOnly": true,
+              "name": "qobuz-session-aws",
+              "path": "/",
+              "value": "46486a49c4fd87ae5455fbe252584aed:9f31d78196d0184cad579c3dfb10328832f873ce"
+            }
+          ],
+          "headers": [
+            {
+              "name": "accept-ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "access-control-allow-origin",
+              "value": "*"
+            },
+            {
+              "name": "access-control-expose-headers",
+              "value": "x-zone, x-language-code"
+            },
+            {
+              "name": "age",
+              "value": "0"
+            },
+            {
+              "name": "cache-control",
+              "value": "private"
+            },
+            {
+              "name": "connection",
+              "value": "Close"
+            },
+            {
+              "name": "content-length",
+              "value": "75"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "name": "date",
+              "value": "Fri, 22 Oct 2021 16:49:39 GMT"
+            },
+            {
+              "name": "server",
+              "value": "nginx"
+            },
+            {
+              "name": "set-cookie",
+              "value": "qobuz-session-aws=46486a49c4fd87ae5455fbe252584aed:9f31d78196d0184cad579c3dfb10328832f873ce; path=/; domain=qobuz.com; HttpOnly"
+            },
+            {
+              "name": "via",
+              "value": "1.1 varnish"
+            },
+            {
+              "name": "x-varnish",
+              "value": "2066628281"
+            },
+            {
+              "name": "x-pollyjs-finalurl",
+              "value": "https://www.qobuz.com/api.json/0.2/album/get?album_id=dbssx&offset=0&limit=20"
+            }
+          ],
+          "headersSize": 548,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 404,
+          "statusText": "Not Found"
+        },
+        "startedDateTime": "2021-10-22T16:49:38.803Z",
+        "time": 250,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 250
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}


### PR DESCRIPTION
/deploy-preview

Closes #158.

We're pretty much just reusing the Qobuz provider for this, as it's using Qobuz data behind the scenes.