### PR TITLE
feat(caa upload): paste multiple links

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -26,13 +26,13 @@ export class InputForm {
                 // Early validation.
                 if (!evt.currentTarget.value) return;
 
-                for (const inputUrl of evt.currentTarget.value.split(/\s+/)) {
+                for (const inputUrl of evt.currentTarget.value.trim().split(/\s+/)) {
                     // eslint-disable-next-line init-declarations
                     let url: URL;
                     // Only use the try block to parse the URL, since we don't
                     // want to suppress errors in the image fetching.
                     try {
-                        url = new URL(decodeURI(inputUrl.trim()));
+                        url = new URL(decodeURI(inputUrl));
                     } catch (err) {
                         LOGGER.error(`Invalid URL: ${inputUrl}`, err);
                         continue;


### PR DESCRIPTION
Closes #53 and closes #52.

Fairly self-explanatory: Split URLs on whitespace and fetch them one-by-one. Also decoding the URLs as otherwise it may cause image names etc. to be displayed incorrectly.