### PR TITLE
ci: don't suppress fatal deploy errors

### DIFF
--- a/build/deploy.ts
+++ b/build/deploy.ts
@@ -112,4 +112,7 @@ async function scanAndPush(): Promise<void> {
     }
 }
 
-scanAndPush().catch(console.error);
+scanAndPush().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});


### PR DESCRIPTION
See deployment of #160, which "passed" although there was a fatal deployment error, because the deploy script erroneously caught and suppressed the error without failing CI.

Although it would be possible to "fix" the underlying error via a sort of `git pull; git push` retry loop, I'm not willing to spend the effort on that right now because those situations ought to be rare. Nonetheless, we should at the very least make sure we don't silently skip a failing deployment.