### PR TITLE
fix(caa upload): properly decode URLs

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -31,7 +31,7 @@ export interface FetchedImages {
 }
 
 function getFilename(url: URL): string {
-    return url.pathname.split('/').at(-1) || 'image';
+    return decodeURIComponent(url.pathname.split('/').at(-1)) || 'image';
 }
 
 export class ImageFetcher {

--- a/src/mb_enhanced_cover_art_uploads/form.ts
+++ b/src/mb_enhanced_cover_art_uploads/form.ts
@@ -70,7 +70,7 @@ export function fillEditNote({ images, containerUrl }: FetchedImages, origin: st
     let prefix = '';
     if (containerUrl) {
         prefix = ' * ';
-        editNote.addExtraInfo(containerUrl.href);
+        editNote.addExtraInfo(decodeURI(containerUrl.href));
     }
 
     // Limiting to 3 URLs to reduce noise
@@ -80,12 +80,12 @@ export function fillEditNote({ images, containerUrl }: FetchedImages, origin: st
             editNote.addExtraInfo(prefix + 'Uploaded from data URL');
             continue;
         }
-        editNote.addExtraInfo(prefix + queuedUrl.originalUrl.href);
+        editNote.addExtraInfo(prefix + decodeURI(queuedUrl.originalUrl.href));
         if (queuedUrl.wasMaximised) {
-            editNote.addExtraInfo(' '.repeat(prefix.length) + '→ Maximised to ' + queuedUrl.maximisedUrl.href);
+            editNote.addExtraInfo(' '.repeat(prefix.length) + '→ Maximised to ' + decodeURI(queuedUrl.maximisedUrl.href));
         }
         if (queuedUrl.wasRedirected) {
-            editNote.addExtraInfo(' '.repeat(prefix.length) + '→ Redirected to ' + queuedUrl.fetchedUrl.href);
+            editNote.addExtraInfo(' '.repeat(prefix.length) + '→ Redirected to ' + decodeURI(queuedUrl.fetchedUrl.href));
         }
     }
 

--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -32,7 +32,7 @@ export class InputForm {
                     // Only use the try block to parse the URL, since we don't
                     // want to suppress errors in the image fetching.
                     try {
-                        url = new URL(decodeURI(inputUrl));
+                        url = new URL(inputUrl);
                     } catch (err) {
                         LOGGER.error(`Invalid URL: ${inputUrl}`, err);
                         continue;


### PR DESCRIPTION
The previous attempt did not work properly, as it decoded the URL
before providing it back to the `URL` constructor, which then
encoded it again. Now we're decoding the URL in the places where it
gets rendered on the page.

Closes #52 again.