### PR TITLE
Allow Update all recordings on release add too

### DIFF
--- a/mb_qol_select_all_update_recordings.user.js
+++ b/mb_qol_select_all_update_recordings.user.js
@@ -1,14 +1,14 @@
 // ==UserScript==
 // @name         MB: QoL: Select All Update Recordings
-// @version      2021.5.22
+// @version      2021.10.24
 // @description  Add buttons to release editor to select all "Update recordings" checkboxes.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
 // @namespace    https://github.com/ROpdebee/mb-userscripts
 // @downloadURL  https://raw.github.com/ROpdebee/mb-userscripts/main/mb_qol_select_all_update_recordings.user.js
 // @updateURL    https://raw.github.com/ROpdebee/mb-userscripts/main/mb_qol_select_all_update_recordings.user.js
-// @match        *://musicbrainz.org/release/*/edit
 // @match        *://*.musicbrainz.org/release/*/edit
+// @match        *://*.musicbrainz.org/release/add
 // @require      https://code.jquery.com/jquery-3.6.0.min.js
 // @run-at       document-idle
 // @grant        none


### PR DESCRIPTION
Convenient when adding another edition and
fixing recordings at the same time

Bonus: Remove redundant `@match` rule:
`//*.domain.tld` includes `//domain.tdl` per [Google Chrome specs](https://developer.chrome.com/extensions/match_patterns).