### PR TITLE
fix(caa upload): improve messaging when no images are queued

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -118,7 +118,7 @@ export class ImageFetcher {
         // This could throw, assuming caller will catch.
         const images = await provider.findImages(url);
 
-        LOGGER.info(`Found ${images.length} images in ${provider.name} release`);
+        LOGGER.info(`Found ${images.length || 'no'} images in ${provider.name} release`);
         const fetchResults: FetchedImage[] = [];
         for (const img of images) {
             if (this.#urlAlreadyAdded(img.url)) {

--- a/src/mb_enhanced_cover_art_uploads/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/index.ts
@@ -53,7 +53,9 @@ class App {
 
         fillEditNote(fetchResult, origin, this.#note);
         this.#ui.clearOldInputValue(url.href);
-        LOGGER.success(`Successfully added ${fetchResult.images.length} image(s)`);
+        if (fetchResult.images.length) {
+            LOGGER.success(`Successfully added ${fetchResult.images.length} image(s)`);
+        }
     }
 
     processSeedingParameters(): void {


### PR DESCRIPTION
* Don't show "successfully added 0 image(s)"
* "Found 0 images in x release" -> "Found no images in x release"

Closes #173.

That's all for today, I think.