### PR TITLE
fix(caa upload): clean up fetched image filenames

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -148,6 +148,11 @@ export class ImageFetcher {
         };
     }
 
+    #createUniqueFilename(filename: string, mimeType: string): string {
+        const filenameWithoutExt = filename.replace(/\.(?:png|jpe?g|gif)$/i, '');
+        return `${filenameWithoutExt}.${this.#lastId++}.${mimeType.split('/')[1]}`;
+    }
+
     async fetchImageContents(url: URL, fileName: string, headers: Record<string, unknown>): Promise<ImageContents> {
         const resp = await gmxhr(url, {
             responseType: 'blob',
@@ -174,7 +179,7 @@ export class ImageFetcher {
                         wasRedirected,
                         file: new File(
                             [resp.response],
-                            `${fileName}.${this.#lastId++}.${mimeType.split('/')[1]}`,
+                            this.#createUniqueFilename(fileName, mimeType),
                             { type: mimeType }),
                     });
                 });

--- a/tests/mb_enhanced_cover_art_uploads/fetch.test.ts
+++ b/tests/mb_enhanced_cover_art_uploads/fetch.test.ts
@@ -47,7 +47,7 @@ function enableDummyFetch(mock: jest.SpiedFunction<ImageFetcher['fetchImageConte
             fetchedUrl: url,
             requestedUrl: url,
             wasRedirected: false,
-            file: new File([new Blob(['test'])], filename + '.0.jpg', { type: 'image/jpeg' }),
+            file: new File([new Blob(['test'])], filename.replace(/\.\w+$/, '') + '.0.jpg', { type: 'image/jpeg' }),
         }));
 }
 
@@ -110,7 +110,7 @@ describe('fetching image contents', () => {
             .resolves.toMatchObject({
                 file: {
                     type: 'image/png',
-                    name: 'test.jpg.0.png',
+                    name: 'test.0.png',
                 },
                 requestedUrl: {
                     href: 'https://example.com/working',
@@ -149,13 +149,13 @@ describe('fetching image contents', () => {
         await expect(fetcher.fetchImageContents(new URL('https://example.com/working'), 'test.jpg', {}))
             .resolves.toMatchObject({
                 file: {
-                    name: 'test.jpg.0.png',
+                    name: 'test.0.png',
                 },
             });
         await expect(fetcher.fetchImageContents(new URL('https://example.com/working'), 'test.jpg', {}))
             .resolves.toMatchObject({
                 file: {
-                    name: 'test.jpg.1.png',
+                    name: 'test.1.png',
                 },
             });
     });
@@ -188,7 +188,7 @@ describe('fetching image from URL', () => {
 
         it('uses the URL filename if present', async () => {
             await expect(fetcher.fetchImageFromURL(new URL('https://example.com/test.jpg')))
-                .resolves.toHaveProperty('content.name', 'test.jpg.0.jpg');
+                .resolves.toHaveProperty('content.name', 'test.0.jpg');
         });
 
         it('falls back to default filename if none present in URL', async () => {
@@ -244,7 +244,7 @@ describe('fetching image from URL', () => {
 
         it('fetches the first maximised candidate', async () => {
             await expect(fetcher.fetchImageFromURL(new URL('https://example.com/test')))
-                .resolves.toHaveProperty('content.name', '1.png.0.jpg');
+                .resolves.toHaveProperty('content.name', '1.0.jpg');
         });
 
         it('fetches the second maximised candidate if first fails', async () => {


### PR DESCRIPTION
Don't duplicate the file extension, as that might look like a bug
instead of an intentional thing. We still use the extension
retrieved from the mime type over the extension given to the image
originally, since a provider might be lying about the image.

Closes #175 