### PR TITLE
fix(caa upload): prevent processing URL if it's already in progress

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/index.ts
@@ -24,10 +24,12 @@ class App {
     #note: EditNote;
     #fetcher: ImageFetcher;
     #ui: InputForm;
+    #urlsInProgress: Set<string>;
 
     constructor() {
         this.#note = EditNote.withFooterFromGMInfo();
         this.#fetcher = new ImageFetcher();
+        this.#urlsInProgress = new Set();
 
         const banner = new StatusBanner();
         LOGGER.addSink(banner);
@@ -35,6 +37,20 @@ class App {
     }
 
     async processURL(url: URL, types: ArtworkTypeIDs[] = [], comment = '', origin = ''): Promise<void> {
+        // Don't process a URL if we're already doing so
+        if (this.#urlsInProgress.has(url.href)) {
+            return;
+        }
+
+        try {
+            this.#urlsInProgress.add(url.href);
+            await this.#_processURL(url, types, comment, origin);
+        } finally {
+            this.#urlsInProgress.delete(url.href);
+        }
+    }
+
+    async #_processURL(url: URL, types: ArtworkTypeIDs[] = [], comment = '', origin = ''): Promise<void> {
         // eslint-disable-next-line init-declarations
         let fetchResult: FetchedImages;
         try {


### PR DESCRIPTION
May close #193 

In older versions, spam-clicking the provider button will lead to the same URL being processed multiple times, and possibly enqueued multiple times too, depending on the interleaving of certain async operations. To prevent this, we're now keeping a set of URLs which are currently in progress, and skip all processing of a URL entirely if it's already being processed.