### PR TITLE
fix(caa upload): extract track covers for releases without main cover

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/bandcamp.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/bandcamp.ts
@@ -55,8 +55,9 @@ export class BandcampProvider extends CoverArtProvider {
         // It appears that they used to have an API which returned all track
         // images in one request, but that API has been locked down :(
         // https://michaelherger.github.io/Bandcamp-API/#/Albums/get_api_album_2_info
-        LOGGER.info('Checking for Bandcamp track images, this may take a few seconds…');
         const trackRows = qsa<HTMLTableRowElement>('#track_table .track_row_view', doc);
+        if (!trackRows.length) return [];
+        LOGGER.info('Checking for Bandcamp track images, this may take a few seconds…');
 
         // Max 5 requests per second
         const throttledFetchPage = pThrottle({

--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -89,7 +89,7 @@ export abstract class CoverArtProvider {
         return resp.responseText;
     }
 
-    protected mergeTrackImages(trackImages: Array<ParsedTrackImage | undefined>, mainUrl: string): CoverArt[] {
+    protected mergeTrackImages(trackImages: Array<ParsedTrackImage | undefined>, mainUrl?: string): CoverArt[] {
         const newTrackImages = filterNonNull(trackImages)
             // Filter out tracks that have the same image as the main release.
             .filter((img) => img.url !== mainUrl);


### PR DESCRIPTION
The changes from #152 prevent extracting any covers if the main release does not have a cover. However, there could still be separate track covers which we can extract.

Other smaller fixes:
* Don't log an error if a track is known to have no covers.
* Don't log messages about track cover extraction if there is no tracklist (e.g. for `/track/` URLs).