### PR TITLE
fix(caa upload): fix bad seeding origin in edit notes

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/index.ts
@@ -69,7 +69,7 @@ class App {
 
         this.#ui.clearOldInputValue(url.href);
 
-        fillEditNote([fetchResult], origin, this.#note);
+        fillEditNote([fetchResult], '', this.#note);
         if (fetchResult.images.length) {
             LOGGER.success(`Successfully added ${fetchResult.images.length} image(s)`);
         }


### PR DESCRIPTION
Some refactoring in the previous PRs removed some local variable `origin`, but forgot to remove its usage. `origin` is also a `window` variable, so it's now resolving to that, and the edit note always says "Seeded from musicbrainz.org".

Urgent, hotfixing.