### PR TITLE
fix(caa upload): polyfill `array.at`

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/index.ts
@@ -8,6 +8,8 @@ import USERSCRIPT_NAME from 'consts:userscript-name';
 import DEBUG_MODE from 'consts:debug-mode';
 import { seederFactory } from './seeding';
 
+import 'core-js/features/array/at';
+
 import { App } from './App';
 
 LOGGER.configure({

--- a/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
@@ -54,9 +54,7 @@ function addSeedLinkToCovers(mbid: string, origin: string): void {
 async function addSeedLinkToCover(fig: Element, mbid: string, origin: string): Promise<void> {
     const imageUrl = qs<HTMLAnchorElement>('a.icon', fig).href;
 
-    // Not using .split('.').at(-1) here because I'm not sure whether .at is
-    // polyfilled on atisket.
-    const ext = imageUrl.match(/\.(\w+)$/)?.[1];
+    const ext = imageUrl.split('.').at(-1);
     const imageDimensions = await getImageDimensions(imageUrl);
     const dimensionStr = `${imageDimensions.width}x${imageDimensions.height}`;
 


### PR DESCRIPTION
I though MB polyfilled this one for us, but apparently it doesn't.

I'm not sure how I feel about including a whole bunch of polyfill code just for that single method (it's not actually polyfilling anything but `array.at`, but just happens to include a bunch of other stuff for core-js internals I guess?). At the same time, I want the source code to be modern and not have to be limited to old ES versions.

For this method though, I'm not sure whether it's worth the bloat... But on the other hand, the script also runs on pages other than MB, where polyfills might not be available.

Possibly closes #214