### PR TITLE
Handle images without file extension

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
@@ -54,7 +54,9 @@ function addSeedLinkToCovers(mbid: string, origin: string): void {
 async function addSeedLinkToCover(fig: Element, mbid: string, origin: string): Promise<void> {
     const imageUrl = qs<HTMLAnchorElement>('a.icon', fig).href;
 
-    const ext = imageUrl.split('.').at(-1);
+    // Not using .split('.').at(-1) here because I'm not sure whether .at is
+    // polyfilled on atisket.
+    const ext = imageUrl.match(/\.(\w+)$/)?.[1];
     const imageDimensions = await getImageDimensions(imageUrl);
     const dimensionStr = `${imageDimensions.width}x${imageDimensions.height}`;
 

--- a/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
@@ -54,8 +54,7 @@ function addSeedLinkToCovers(mbid: string, origin: string): void {
 async function addSeedLinkToCover(fig: Element, mbid: string, origin: string): Promise<void> {
     const imageUrl = qs<HTMLAnchorElement>('a.icon', fig).href;
 
-    // Not using .split('.').at(-1) here because I'm not sure whether .at is
-    // polyfilled on atisket.
+    // Not using .split('.') here because Spotify images do not have an extension.
     const ext = imageUrl.match(/\.(\w+)$/)?.[1];
     const imageDimensions = await getImageDimensions(imageUrl);
     const dimensionStr = `${imageDimensions.width}x${imageDimensions.height}`;


### PR DESCRIPTION
Spotify images no longer have a file extension, so we should not assume that everything after the last dot is a file extension.

Fixes #216.