### PR TITLE
fix(caa upload): Adapt to new Amazon page source code indentation

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
@@ -91,7 +91,7 @@ export class AmazonProvider extends CoverArtProvider {
     }
 
     extractFromEmbeddedJS(pageContent: string): CoverArt[] | undefined {
-        const embeddedImages = pageContent.match(/^'colorImages': { 'initial': (.+)},$/m)?.[1];
+        const embeddedImages = pageContent.match(/'colorImages': { 'initial': (.+)},$/m)?.[1];
         if (!embeddedImages) {
             LOGGER.warn('Failed to extract Amazon images from the embedded JS, falling back to thumbnails');
             return;


### PR DESCRIPTION
The Amazon provider fails to extract the embedded JSON because it is no longer at the beginning of a new line but indented since a recent update.

Fixes #272.