### PR TITLE
chore(deps): don't group all non-major renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,6 @@
 {
   "extends": [
     "config:base",
-    "group:allNonMajor",
     "schedule:weekends",
     ":semanticCommitTypeAll(build)",
     ":maintainLockFilesMonthly",


### PR DESCRIPTION
Grouping all non-major updates makes it possible for the PR to be blocked by one dependency, as is currently happening in #268. This isn't ideal.

renovate will still group monorepos and only raise PRs on weekends, so it should still reduce dependency update spam. Grouping all updates doesn't reduce dependency update spam that much, since renovate will keep pushing new updates to the existing grouped PR, which still sends many emails.