### PR TITLE
fix: remove usage of deprecated functions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,5 @@
 dist/**
+coverage/*
 # Ignore top-level scripts for now
 mb_*.js
 lib/*
-
-# Specifically allowlist the commit_release file in the GH directory
-!.github
-.github/*
-!.github/commit_release.ts

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,10 +12,12 @@ module.exports = {
     ],
     plugins: [
         '@typescript-eslint',
+        '@delagen/deprecation',
     ],
     parserOptions: {
         ecmaVersion: 12,
         sourceType: 'module',
+        project: './tsconfig.json',
     },
     rules: {
         'indent': [
@@ -43,6 +45,7 @@ module.exports = {
         ],
         'jest/unbound-method': ['off'],
         'no-restricted-globals': ['error', 'origin'].concat(restrictedGlobals),
+        '@delagen/deprecation/deprecation': ['warn'],
     },
     overrides: [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@babel/plugin-transform-runtime": "7.16.4",
         "@babel/preset-env": "7.16.4",
         "@babel/preset-typescript": "7.16.0",
+        "@delagen/eslint-plugin-deprecation": "1.3.0",
         "@pollyjs/adapter-fetch": "6.0.1",
         "@pollyjs/adapter-node-http": "6.0.1",
         "@pollyjs/core": "6.0.1",
@@ -1758,6 +1759,27 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@delagen/eslint-plugin-deprecation": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@delagen/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.0.tgz",
+      "integrity": "sha512-hPe516znPnWrwyW1DFPcUKp+NQWPR4nx0+ycVbETIviw2G7V7vlqHRnf18skCniD15fGEGYzxOh1ZeuJndW9tQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "typescript": "^3.7.5 || ^4.0.0"
+      }
+    },
+    "node_modules/@delagen/eslint-plugin-deprecation/node_modules/tslib": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "dev": true
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.0.5",
@@ -14072,6 +14094,25 @@
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-2.0.0.tgz",
       "integrity": "sha512-P7BVvddsP2Wl5v3drJ3ArzpdfXMqoZ/oHOV/yFiGFb3JQr9Z9UXZ9tnHAKJsO89lfprR1F9ExW3Yij21EjEBIA==",
       "dev": true
+    },
+    "@delagen/eslint-plugin-deprecation": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@delagen/eslint-plugin-deprecation/-/eslint-plugin-deprecation-1.3.0.tgz",
+      "integrity": "sha512-hPe516znPnWrwyW1DFPcUKp+NQWPR4nx0+ycVbETIviw2G7V7vlqHRnf18skCniD15fGEGYzxOh1ZeuJndW9tQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.0.0",
+        "tslib": "^2.3.1",
+        "tsutils": "^3.21.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "dev": true
+        }
+      }
     },
     "@eslint/eslintrc": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@babel/plugin-transform-runtime": "7.16.4",
     "@babel/preset-env": "7.16.4",
     "@babel/preset-typescript": "7.16.0",
+    "@delagen/eslint-plugin-deprecation": "1.3.0",
     "@pollyjs/adapter-fetch": "6.0.1",
     "@pollyjs/adapter-node-http": "6.0.1",
     "@pollyjs/core": "6.0.1",

--- a/src/lib/MB/EditNote.ts
+++ b/src/lib/MB/EditNote.ts
@@ -16,7 +16,7 @@ export class EditNote {
         // Maybe kept from page reload
         const existingInfoBlock = this.#editNoteTextArea.value.split(separator)[0];
         if (existingInfoBlock) {
-            this.#extraInfoLines = new Set(existingInfoBlock.split('\n').map((l) => l.trimRight()));
+            this.#extraInfoLines = new Set(existingInfoBlock.split('\n').map((l) => l.trimEnd()));
         } else {
             this.#extraInfoLines = new Set();
         }


### PR DESCRIPTION
Add a linter for deprecated function calls.
Replace `trimRight` (deprecated) with `trimEnd`.