### PR TITLE
fix(caa upload): also clean up PDF filenames

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -170,7 +170,7 @@ export class ImageFetcher {
     }
 
     #createUniqueFilename(filename: string, mimeType: string): string {
-        const filenameWithoutExt = filename.replace(/\.(?:png|jpe?g|gif)$/i, '');
+        const filenameWithoutExt = filename.replace(/\.(?:png|jpe?g|gif|pdf)$/i, '');
         return `${filenameWithoutExt}.${this.#lastId++}.${mimeType.split('/')[1]}`;
     }
 


### PR DESCRIPTION
In #175, we removed duplicate extensions for GIF, PNG, and JPEG, but we forgot to do the same for PDF.

Cherry-picked from #254