### PR TITLE
perf(build): reduce size of built scripts

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -2,5 +2,4 @@
 chrome >= 49
 edge >= 14
 firefox >= 52
-ie >= 11
-safari >= 9.0
+safari >= 12

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -14,12 +14,20 @@ const prodConfig = {
             allExtensions: true,
         }],
         ['@babel/preset-env', {
-            corejs: '3.13',
+            corejs: '3.19',
             useBuiltIns: 'entry',
         }],
     ],
     plugins: [
         '@babel/plugin-syntax-jsx',
+        // Transform async/await into promises. Need to do this before plugin-transform-runtime
+        // as that will transpile to generators with regenerator. This will skip
+        // complex async things, like async generators, those will still be handled
+        // by babel itself. However, transforming "simple" async/await to promises
+        // leads to a severely smaller footprint in the output.
+        ['babel-plugin-transform-async-to-promises', {
+            externalHelpers: true,
+        }],
         ['@babel/plugin-transform-runtime', {
             regenerator: true,
             helpers: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@types/setup-polly-jest": "0.5.1",
         "@typescript-eslint/eslint-plugin": "5.6.0",
         "@typescript-eslint/parser": "5.6.0",
+        "babel-plugin-transform-async-to-promises": "^0.8.16",
         "confusing-browser-globals": "1.0.10",
         "eslint": "8.4.1",
         "eslint-plugin-jest": "25.3.0",
@@ -4084,6 +4085,12 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
+    },
+    "node_modules/babel-plugin-transform-async-to-promises": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.16.tgz",
+      "integrity": "sha512-mm0UMekJVOTuIlkGIEH1fpnExyTIIJ2/L5ixTTI1zAVdMpbG7Em3LiS92p0TCWKiMkHhYYinz/zn2D/BPPJaxA==",
+      "dev": true
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",
@@ -15663,6 +15670,12 @@
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.3.0"
       }
+    },
+    "babel-plugin-transform-async-to-promises": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.16.tgz",
+      "integrity": "sha512-mm0UMekJVOTuIlkGIEH1fpnExyTIIJ2/L5ixTTI1zAVdMpbG7Em3LiS92p0TCWKiMkHhYYinz/zn2D/BPPJaxA==",
+      "dev": true
     },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/setup-polly-jest": "0.5.1",
     "@typescript-eslint/eslint-plugin": "5.6.0",
     "@typescript-eslint/parser": "5.6.0",
+    "babel-plugin-transform-async-to-promises": "^0.8.16",
     "confusing-browser-globals": "1.0.10",
     "eslint": "8.4.1",
     "eslint-plugin-jest": "25.3.0",

--- a/src/lib/util/domain_dispatch.ts
+++ b/src/lib/util/domain_dispatch.ts
@@ -8,7 +8,7 @@ function splitDomain(domain: string): string[] {
     let splitIdx = -2;
     // Watch out for e.g. amazon.co.uk or amazon.com.au. Our handling of this is
     // pretty naive (co.be is a valid site for example), but it works well enough.
-    if (['org', 'co', 'com'].includes(parts.at(-2))) {
+    if (['org', 'co', 'com'].includes(parts[parts.length - 2])) {
         splitIdx = -3;
     }
     return parts.slice(0, splitIdx).concat([parts.slice(splitIdx).join('.')]);

--- a/src/lib/util/urls.ts
+++ b/src/lib/util/urls.ts
@@ -1,0 +1,7 @@
+export function urlBasename(url: string | URL, defaultBasename = ''): string {
+    if (typeof url !== 'string') url = url.pathname;
+    // We don't need nullish coalescing here, since the array will always have
+    // at least one element, but the last element may be the empty string.
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    return url.split('/').pop() || defaultBasename;
+}

--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -5,6 +5,7 @@ import { getProvider } from './providers';
 import { ArtworkTypeIDs } from './providers/base';
 import type { CoverArt, CoverArtProvider } from './providers/base';
 import { getFromPageContext } from '@src/compat';
+import { urlBasename } from '@lib/util/urls';
 
 interface ImageContents {
     requestedUrl: URL;
@@ -33,7 +34,7 @@ export interface FetchedImages {
 }
 
 function getFilename(url: URL): string {
-    return decodeURIComponent(url.pathname.split('/').at(-1)) || 'image';
+    return decodeURIComponent(urlBasename(url, 'image'));
 }
 
 export class ImageFetcher {

--- a/src/mb_enhanced_cover_art_uploads/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/index.ts
@@ -8,8 +8,6 @@ import USERSCRIPT_NAME from 'consts:userscript-name';
 import DEBUG_MODE from 'consts:debug-mode';
 import { seederFactory } from './seeding';
 
-import 'core-js/features/array/at';
-
 import { App } from './App';
 
 LOGGER.configure({

--- a/src/mb_enhanced_cover_art_uploads/maximise.ts
+++ b/src/mb_enhanced_cover_art_uploads/maximise.ts
@@ -3,6 +3,7 @@
 import { LOGGER } from '@lib/logging/logger';
 import { retryTimes } from '@lib/util/async';
 import { DispatchMap } from '@lib/util/domain_dispatch';
+import { urlBasename } from '@lib/util/urls';
 import { DiscogsProvider } from './providers/discogs';
 
 // IMU does its initialisation synchronously, and it's loaded before the
@@ -82,7 +83,7 @@ IMU_EXCEPTIONS.set('img.discogs.com', async (smallurl) => {
     const fullSizeURL = await DiscogsProvider.maximiseImage(smallurl);
     return [{
         url: fullSizeURL,
-        filename: fullSizeURL.pathname.split('/').at(-1),
+        filename: urlBasename(fullSizeURL),
         headers: {},
     }];
 });
@@ -102,7 +103,8 @@ IMU_EXCEPTIONS.set('*.mzstatic.com', async (smallurl) => {
         // https://is5-ssl.mzstatic.com/image/thumb/Music124/v4/58/34/98/58349857-55bb-62ae-81d4-4a2726e33528/5060786561909.png/999999999x0w-999.png
         // We're still conservative though, if it's not a JPEG, we won't
         // return the JPEG version
-        if (/\.jpe?g$/i.test(imgGeneric.url.pathname.split('/').at(-2))) {
+        const pathParts = imgGeneric.url.pathname.split('/');
+        if (/\.jpe?g$/i.test(pathParts[pathParts.length - 2])) {
             results.push({
                 ...imgGeneric,
                 url: new URL(imgGeneric.url.href.replace(/\.png$/i, '.jpg'))

--- a/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
@@ -1,5 +1,6 @@
 import { assert, assertHasValue } from '@lib/util/assert';
 import { safeParseJSON } from '@lib/util/json';
+import { urlBasename } from '@lib/util/urls';
 import { gmxhr } from '@lib/util/xhr';
 import type { CoverArt } from './base';
 import { CoverArtProvider } from './base';
@@ -117,7 +118,7 @@ export class DiscogsProvider extends CoverArtProvider {
         if (!releaseId) return url;
         const releaseData = await this.getReleaseImages(releaseId);
         const matchedImage = releaseData.data.release.images.edges
-            .find((img) => img.node.fullsize.sourceUrl.split('/').at(-1) === imageName);
+            .find((img) => urlBasename(img.node.fullsize.sourceUrl) === imageName);
 
         /* istanbul ignore if: Should never happen on valid image */
         if (!matchedImage) return url;

--- a/src/mb_enhanced_cover_art_uploads/providers/musicbrainz.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/musicbrainz.ts
@@ -1,5 +1,6 @@
 import { assertDefined } from '@lib/util/assert';
 import { safeParseJSON } from '@lib/util/json';
+import { urlBasename } from '@lib/util/urls';
 
 import type { CoverArt } from './base';
 import { ArtworkTypeIDs, CoverArtProvider } from './base';
@@ -36,7 +37,7 @@ export class MusicBrainzProvider extends CoverArtProvider {
         const caaIndex = safeParseJSON<CAAIndex>(await caaResp.text(), 'Could not parse index.json');
 
         return caaIndex.images.map((img) => {
-            const imageFileName = img.image.split('/').at(-1);
+            const imageFileName = urlBasename(img.image);
             return {
                 // Skip one level of indirection
                 url: new URL(`https://archive.org/download/mbid-${mbid}/mbid-${mbid}-${imageFileName}`),

--- a/src/mb_enhanced_cover_art_uploads/providers/soundcloud.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/soundcloud.ts
@@ -3,6 +3,7 @@ import { ArtworkTypeIDs, ProviderWithTrackImages } from './base';
 import type { CoverArt } from './base';
 import { safeParseJSON } from '@lib/util/json';
 import { assert } from '@lib/util/assert';
+import { urlBasename } from '@lib/util/urls';
 
 // Incomplete, only what we need.
 interface SCHydration {
@@ -56,7 +57,7 @@ export class SoundcloudProvider extends ProviderWithTrackImages {
             && !SoundcloudProvider.badArtistIDs.has(artistId)
             // artist/likes, artist/track/recommended, artist/sets, ...
             // but not artist/sets/setname!
-            && !SoundcloudProvider.badSubpaths.has(pathParts.at(-1)));
+            && !SoundcloudProvider.badSubpaths.has(urlBasename(url)));
     }
 
     override extractId(url: URL): string | undefined {

--- a/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
@@ -2,6 +2,7 @@ import { LOGGER } from '@lib/logging/logger';
 import { assert, assertHasValue } from '@lib/util/assert';
 import { parseDOM, qs, qsa, qsMaybe } from '@lib/util/dom';
 import { safeParseJSON } from '@lib/util/json';
+import { urlBasename } from '@lib/util/urls';
 import { gmxhr } from '@lib/util/xhr';
 
 import type { CoverArt } from './base';
@@ -164,7 +165,7 @@ export class VGMdbProvider extends CoverArtProvider {
 
         // Add the main cover if it's not in the gallery
         const mainCoverUrl = qsMaybe<HTMLDivElement>('#coverart', pageDom)?.style.backgroundImage.match(/url\(["']?(.+?)["']?\)/)?.[1];
-        if (mainCoverUrl && !galleryCovers.some((cover) => cover.url.pathname.endsWith(mainCoverUrl.split('/').at(-1)))) {
+        if (mainCoverUrl && !galleryCovers.some((cover) => urlBasename(cover.url) === urlBasename(mainCoverUrl))) {
             galleryCovers.unshift({
                 url: new URL(mainCoverUrl),
                 types: [ArtworkTypeIDs.Front],

--- a/src/mb_enhanced_cover_art_uploads/seeding/parameters.ts
+++ b/src/mb_enhanced_cover_art_uploads/seeding/parameters.ts
@@ -9,7 +9,8 @@ function encodeValue(value: unknown): string {
 }
 
 function decodeSingleKeyValue(key: string, value: string, images: CoverArt[]): void {
-    const keyName = key.split('.').at(-1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const keyName = key.split('.').pop()!;
     const imageIdxString = key.match(/x_seed\.image\.(\d+)\./)?.[1];
     if (!imageIdxString || !['url', 'types', 'comment'].includes(keyName)) {
         throw new Error(`Unsupported seeded key: ${key}`);

--- a/types/ESProposals.d.ts
+++ b/types/ESProposals.d.ts
@@ -1,3 +1,0 @@
-declare interface Array<T> {
-    at(index: number): T;
-}


### PR DESCRIPTION
These changes should massively reduce the size of the built scripts without changing anything functionally. Cherry-picked from #254.

Summary:
* Drop support for some old browsers which don't support userscripts, to eliminate some transpilations for these browsers.
* Use a babel plugin to convert async/await into promises where possible, instead of using babel's regenerator. The regenerator is still included (mainly for some generators/async generators), but this eliminates most of the weird `switch` statements and leads to shorter, more natural code.
* Remove any usage of `Array.prototype.at` since it's not supported in most browsers and including the polyfill is way more expensive than using alternative means of using negative array indices.

Excluded from this PR: Switching to polyfill.io. There could be an issue if multiple scripts load the polyfill from polyfill.io, so we're not using those polyfills yet until we can find a suitable solution. In practice, this doesn't change anything, since we weren't properly polyfilling everything yet anyway.