### PR TITLE
refactor(caa upload): move `ArtworkTypeIDs` to `lib/MB/CoverArt`

### DIFF
--- a/src/lib/MB/CoverArt.ts
+++ b/src/lib/MB/CoverArt.ts
@@ -1,0 +1,16 @@
+export enum ArtworkTypeIDs {
+    Back = 2,
+    Booklet = 3,
+    Front = 1,
+    Liner = 12,
+    Medium = 4,
+    Obi = 5,
+    Other = 8,
+    Poster = 11,
+    Raw = 14,  // Raw/Unedited
+    Spine = 6,
+    Sticker = 10,
+    Track = 7,
+    Tray = 9,
+    Watermark = 13
+}

--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -1,11 +1,11 @@
 import { LOGGER } from '@lib/logging/logger';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { gmxhr } from '@lib/util/xhr';
+import { urlBasename } from '@lib/util/urls';
+import { getFromPageContext } from '@src/compat';
 import { getMaximisedCandidates } from './maximise';
 import { getProvider } from './providers';
-import { ArtworkTypeIDs } from './providers/base';
 import type { CoverArt, CoverArtProvider } from './providers/base';
-import { getFromPageContext } from '@src/compat';
-import { urlBasename } from '@lib/util/urls';
 
 interface ImageContents {
     requestedUrl: URL;

--- a/src/mb_enhanced_cover_art_uploads/form.ts
+++ b/src/mb_enhanced_cover_art_uploads/form.ts
@@ -1,10 +1,12 @@
+import type { ArtworkTypeIDs } from '@lib/MB/CoverArt';
+import type { EditNote } from '@lib/MB/EditNote';
 import { assertDefined } from '@lib/util/assert';
 import { retryTimes } from '@lib/util/async';
-import { cloneIntoPageContext, getFromPageContext } from '@src/compat';
 import { qs, qsa } from '@lib/util/dom';
-import type { EditNote } from '@lib/MB/EditNote';
+
+import { cloneIntoPageContext, getFromPageContext } from '@src/compat';
+
 import type { FetchedImage, FetchedImages } from './fetch';
-import type { ArtworkTypeIDs } from './providers/base';
 
 export async function enqueueImages({ images }: FetchedImages, defaultTypes: ArtworkTypeIDs[] = [], defaultComment = ''): Promise<void> {
     await Promise.all(images.map((image) => {

--- a/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
@@ -1,10 +1,11 @@
 import { LOGGER } from '@lib/logging/logger';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { parseDOM, qsa, qsMaybe } from '@lib/util/dom';
 import { safeParseJSON } from '@lib/util/json';
 import { GMgetResourceUrl } from '@src/compat';
 
 import type { CoverArt } from './base';
-import { ArtworkTypeIDs, CoverArtProvider } from './base';
+import { CoverArtProvider } from './base';
 
 const PLACEHOLDER_IMG_REGEX = /01RmK(?:\+|%2B)J4pJL/;
 

--- a/src/mb_enhanced_cover_art_uploads/providers/bandcamp.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/bandcamp.ts
@@ -1,11 +1,12 @@
 import pThrottle from 'p-throttle';
 
 import { LOGGER } from '@lib/logging/logger';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { filterNonNull } from '@lib/util/array';
 import { parseDOM, qs, qsa, qsMaybe } from '@lib/util/dom';
 
 import type { CoverArt, ParsedTrackImage } from './base';
-import { ArtworkTypeIDs, ProviderWithTrackImages } from './base';
+import { ProviderWithTrackImages } from './base';
 import { getImageDimensions } from '../image_dimensions';
 
 export class BandcampProvider extends ProviderWithTrackImages {

--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -1,4 +1,5 @@
 import { LOGGER } from '@lib/logging/logger';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { filterNonNull, groupBy } from '@lib/util/array';
 import { blobToDigest } from '@lib/util/blob';
 import { parseDOM, qs } from '@lib/util/dom';
@@ -131,23 +132,6 @@ export interface CoverArt {
 export interface ParsedTrackImage {
     url: string;
     trackNumber?: string;
-}
-
-export enum ArtworkTypeIDs {
-    Back = 2,
-    Booklet = 3,
-    Front = 1,
-    Liner = 12,
-    Medium = 4,
-    Obi = 5,
-    Other = 8,
-    Poster = 11,
-    Raw = 14,  // Raw/Unedited
-    Spine = 6,
-    Sticker = 10,
-    Track = 7,
-    Tray = 9,
-    Watermark = 13,
 }
 
 export abstract class HeadMetaPropertyProvider extends CoverArtProvider {

--- a/src/mb_enhanced_cover_art_uploads/providers/beatport.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/beatport.ts
@@ -1,7 +1,8 @@
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { parseDOM, qs } from '@lib/util/dom';
 
 import type { CoverArt } from './base';
-import { ArtworkTypeIDs, CoverArtProvider } from './base';
+import { CoverArtProvider } from './base';
 
 export class BeatportProvider extends CoverArtProvider {
     supportedDomains = ['beatport.com'];

--- a/src/mb_enhanced_cover_art_uploads/providers/musicbrainz.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/musicbrainz.ts
@@ -3,7 +3,8 @@ import { safeParseJSON } from '@lib/util/json';
 import { urlBasename } from '@lib/util/urls';
 
 import type { CoverArt } from './base';
-import { ArtworkTypeIDs, CoverArtProvider } from './base';
+import { CoverArtProvider } from './base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 
 interface CAAIndex {
     images: Array<{

--- a/src/mb_enhanced_cover_art_uploads/providers/qobuz.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/qobuz.ts
@@ -1,9 +1,10 @@
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { assert, assertHasValue } from '@lib/util/assert';
 import { safeParseJSON } from '@lib/util/json';
 import { gmxhr, HTTPResponseError } from '@lib/util/xhr';
 
 import type { CoverArt } from './base';
-import { ArtworkTypeIDs, CoverArtProvider } from './base';
+import { CoverArtProvider } from './base';
 
 interface Goodie {
     id: number;

--- a/src/mb_enhanced_cover_art_uploads/providers/rateyourmusic.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/rateyourmusic.ts
@@ -1,8 +1,10 @@
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
+import { assertHasValue } from '@lib/util/assert';
 import { parseDOM, qs, qsMaybe } from '@lib/util/dom';
 
 import type { CoverArt } from './base';
-import { ArtworkTypeIDs, CoverArtProvider } from './base';
-import { assertHasValue } from '@lib/util/assert';
+import { CoverArtProvider } from './base';
+
 
 export class RateYourMusicProvider extends CoverArtProvider {
     supportedDomains = ['rateyourmusic.com'];

--- a/src/mb_enhanced_cover_art_uploads/providers/soundcloud.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/soundcloud.ts
@@ -1,5 +1,6 @@
 import { filterNonNull } from '@lib/util/array';
-import { ArtworkTypeIDs, ProviderWithTrackImages } from './base';
+import { ProviderWithTrackImages } from './base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import type { CoverArt } from './base';
 import { safeParseJSON } from '@lib/util/json';
 import { assert } from '@lib/util/assert';

--- a/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
@@ -1,9 +1,10 @@
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { assert, assertHasValue } from '@lib/util/assert';
 import { safeParseJSON } from '@lib/util/json';
 import { gmxhr } from '@lib/util/xhr';
 
 import type { CoverArt } from './base';
-import { ArtworkTypeIDs, CoverArtProvider } from './base';
+import { CoverArtProvider } from './base';
 
 // Extracted from listen.tidal.com JS. There seem to be at least 10 different
 // API keys, I guess they might depend on the user type and/or country?

--- a/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
@@ -1,4 +1,5 @@
 import { LOGGER } from '@lib/logging/logger';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { assert, assertHasValue } from '@lib/util/assert';
 import { parseDOM, qs, qsa, qsMaybe } from '@lib/util/dom';
 import { safeParseJSON } from '@lib/util/json';
@@ -6,7 +7,7 @@ import { urlBasename } from '@lib/util/urls';
 import { gmxhr } from '@lib/util/xhr';
 
 import type { CoverArt } from './base';
-import { ArtworkTypeIDs, CoverArtProvider } from './base';
+import { CoverArtProvider } from './base';
 
 // Not full, only what we need
 interface AlbumMetadata {

--- a/tests/unit/mb_enhanced_cover_art_uploads/fetch.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/fetch.test.ts
@@ -2,7 +2,8 @@ import { gmxhr, NetworkError } from '@lib/util/xhr';
 import { ImageFetcher } from '@src/mb_enhanced_cover_art_uploads/fetch';
 import type { FetchedImage } from '@src/mb_enhanced_cover_art_uploads/fetch';
 import { getMaximisedCandidates } from '@src/mb_enhanced_cover_art_uploads/maximise';
-import { ArtworkTypeIDs, CoverArtProvider } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { CoverArtProvider } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { getProvider } from '@src/mb_enhanced_cover_art_uploads/providers';
 import { createCoverArt, createImageFile, createXhrResponse } from './test-utils/dummy-data';
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/form.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/form.test.ts
@@ -2,8 +2,8 @@ import path from 'path';
 import fs from 'fs/promises';
 
 import $ from 'jquery';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { enqueueImages, fillEditNote } from '@src/mb_enhanced_cover_art_uploads/form';
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
 import { EditNote } from '@lib/MB/EditNote';
 import { createFetchedImage, createImageFile } from './test-utils/dummy-data';
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/7digital.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/7digital.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { SevenDigitalProvider } from '@src/mb_enhanced_cover_art_uploads/providers/7digital';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/amazon.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/amazon.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { AmazonProvider } from '@src/mb_enhanced_cover_art_uploads/providers/amazon';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/amazon_music.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/amazon_music.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { AmazonMusicProvider } from '@src/mb_enhanced_cover_art_uploads/providers/amazon_music';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/apple_music.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/apple_music.test.ts
@@ -1,5 +1,5 @@
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { AppleMusicProvider } from '@src/mb_enhanced_cover_art_uploads/providers/apple_music';
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/bandcamp.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/bandcamp.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { BandcampProvider } from '@src/mb_enhanced_cover_art_uploads/providers/bandcamp';
 import { getImageDimensions } from '@src/mb_enhanced_cover_art_uploads/image_dimensions';
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/base.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/base.test.ts
@@ -3,7 +3,8 @@ import { when } from 'jest-when';
 import { gmxhr } from '@lib/util/xhr';
 
 import type { CoverArt, ParsedTrackImage } from '@src/mb_enhanced_cover_art_uploads/providers/base';
-import { ArtworkTypeIDs, CoverArtProvider, HeadMetaPropertyProvider, ProviderWithTrackImages } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { CoverArtProvider, HeadMetaPropertyProvider, ProviderWithTrackImages } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 
 import { createBlob, createFetchedImage, createXhrResponse } from '../test-utils/dummy-data';
 import { registerMatchers } from '../test-utils/matchers';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/beatport.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/beatport.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { BeatportProvider } from '@src/mb_enhanced_cover_art_uploads/providers/beatport';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/deezer.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/deezer.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { DeezerProvider } from '@src/mb_enhanced_cover_art_uploads/providers/deezer';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/melon.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/melon.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { MelonProvider } from '@src/mb_enhanced_cover_art_uploads/providers/melon';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/musicbrainz.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/musicbrainz.test.ts
@@ -1,6 +1,6 @@
 import HttpAdapter from '@pollyjs/adapter-node-http';
 
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { MusicBrainzProvider } from '@src/mb_enhanced_cover_art_uploads/providers/musicbrainz';
 
 import { mockFetch, setupPolly } from '@test-utils/pollyjs';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/qobuz.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/qobuz.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { QobuzProvider } from '@src/mb_enhanced_cover_art_uploads/providers/qobuz';
 
 import { setupPolly } from '@test-utils/pollyjs';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/qub_musique.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/qub_musique.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { QubMusiqueProvider } from '@src/mb_enhanced_cover_art_uploads/providers/qub_musique';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/rateyourmusic.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/rateyourmusic.test.ts
@@ -1,5 +1,5 @@
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import type { CoverArtProvider } from '@src/mb_enhanced_cover_art_uploads/providers/base';
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
 import { RateYourMusicProvider } from '@src/mb_enhanced_cover_art_uploads/providers/rateyourmusic';
 
 import { setupPolly } from '@test-utils/pollyjs';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/soundcloud.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/soundcloud.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { SoundcloudProvider } from '@src/mb_enhanced_cover_art_uploads/providers/soundcloud';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/spotify.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/spotify.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { SpotifyProvider } from '@src/mb_enhanced_cover_art_uploads/providers/spotify';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/tidal.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/tidal.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { TidalProvider } from '@src/mb_enhanced_cover_art_uploads/providers/tidal';
 
 import { itBehavesLike } from '@test-utils/shared_behaviour';

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/vgmdb.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/vgmdb.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { convertCaptions, mapJacketType, VGMdbProvider } from '@src/mb_enhanced_cover_art_uploads/providers/vgmdb';
 
 import { setupPolly } from '@test-utils/pollyjs';

--- a/tests/unit/mb_enhanced_cover_art_uploads/seeding/parameters.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/seeding/parameters.test.ts
@@ -1,4 +1,4 @@
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { SeedParameters } from '@src/mb_enhanced_cover_art_uploads/seeding/parameters';
 
 describe('seed parameters', () => {

--- a/tests/unit/mb_enhanced_cover_art_uploads/test-utils/matchers.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/test-utils/matchers.ts
@@ -1,7 +1,7 @@
 // Custom matchers for provider testing
 
 import type { CoverArt } from '@src/mb_enhanced_cover_art_uploads/providers/base';
-import { ArtworkTypeIDs } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 
 export interface ExpectedCoverArt {
     urlPart: string | RegExp;


### PR DESCRIPTION
It'll most likely be useful in Supercharged CAA Edits, but more importantly, we'll need it in some of the E2E tests, and importing it from `providers/base` (which wasn't a good spot for the enum anyway) leads to errors because of a dependency chain ending up in `@src/compat`, which dereferences `GM` functions.

Cherry-picked from #254, will probably conflict with #301 but we can fix that later.