### PR TITLE
fix: URL matching

### DIFF
--- a/mb_qol_inline_recording_tracks.user.js
+++ b/mb_qol_inline_recording_tracks.user.js
@@ -1,15 +1,15 @@
 // ==UserScript==
 // @name         MB: QoL: Inline all recording's tracks on releases
-// @version      2021.5.23
+// @version      2021.12.18
 // @description  Display all tracks and releases on which a recording appears from the release page.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
 // @namespace    https://github.com/ROpdebee/mb-userscripts
 // @downloadURL  https://raw.github.com/ROpdebee/mb-userscripts/main/mb_qol_inline_recording_tracks.user.js
 // @updateURL    https://raw.github.com/ROpdebee/mb-userscripts/main/mb_qol_inline_recording_tracks.user.js
-// @match        *://*musicbrainz.org/release/*
-// @exclude      *://*musicbrainz.org/release/add
-// @exclude      *://*musicbrainz.org/release/*/*
+// @match        *://*.musicbrainz.org/release/*
+// @exclude      *://*.musicbrainz.org/release/add
+// @exclude      *://*.musicbrainz.org/release/*/edit*
 // @require      https://code.jquery.com/jquery-3.6.0.min.js
 // @run-at       document-end
 // @grant        none

--- a/mb_qol_seed_recording_disambiguation.user.js
+++ b/mb_qol_seed_recording_disambiguation.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: QoL: Seed the batch recording comments script
-// @version      2021.6.7
+// @version      2021.12.18
 // @description  Seed the recording comments for the batch recording comments userscripts with live and DJ-mix data.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -9,7 +9,7 @@
 // @updateURL    https://raw.github.com/ROpdebee/mb-userscripts/main/mb_qol_seed_recording_disambiguation.user.js
 // @match        *://*.musicbrainz.org/release/*
 // @exclude      *://*.musicbrainz.org/release/add
-// @exclude      *://*.musicbrainz.org/release/*/*
+// @exclude      *://*.musicbrainz.org/release/*/edit*
 // @run-at       document-end
 // @grant        none
 // ==/UserScript==

--- a/mb_validate_work_codes.user.js
+++ b/mb_validate_work_codes.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Validate Work Codes
-// @version      2021.5.27
+// @version      2021.12.18
 // @description  Validate work identifier codes: Highlight invalid or ill-formatted work codes.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -8,17 +8,12 @@
 // @downloadURL  https://raw.github.com/ROpdebee/mb-userscripts/main/mb_validate_work_codes.user.js
 // @updateURL    https://raw.github.com/ROpdebee/mb-userscripts/main/mb_validate_work_codes.user.js
 // @match        *://*.musicbrainz.org/work/*
-// @match        *://musicbrainz.org/work/*
 // @match        *://*.musicbrainz.org/artist/*/works
-// @match        *://musicbrainz.org/artist/*/works
-// @match        *://musicbrainz.org/edit/*
+// @match        *://*.musicbrainz.org/artist/*/works?*
 // @match        *://*.musicbrainz.org/edit/*
-// @match        *://musicbrainz.org/*/edits*
 // @match        *://*.musicbrainz.org/*/edits*
-// @match        *://musicbrainz.org/collection/*
 // @match        *://*.musicbrainz.org/collection/*
 // @exclude      *://*.musicbrainz.org/work/*/edit
-// @exclude      *://musicbrainz.org/work/*/edit
 // @require      https://code.jquery.com/jquery-3.6.0.min.js
 // @require      https://raw.github.com/ROpdebee/mb-userscripts/main/lib/work_identifiers.js?v=2021.5.27
 // @run-at       document-end


### PR DESCRIPTION
* Fix URL matching of multi-page artist works for MB: Validate Work Codes (same as #61)
* Run `MB: QoL: Seed the batch recording comments script` and `MB: QoL: Inline all recording's tracks on releases` on `/release/*/disc1` pages. These are reachable through `/track/` URLs.
* Fix `MB: QoL: Inline all recording's tracks on releases` match pattern to exclude `notmusicbrainz.org` etc.