### PR TITLE
Improved Audible Audiobook support

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
@@ -45,6 +45,14 @@ export class AmazonProvider extends CoverArtProvider {
         const pageContent = await this.fetchPage(url);
         const pageDom = parseDOM(pageContent, url.href);
 
+        // Look for Audible buttons on standard product pages, as we can only
+        // extract 500px images from these pages. Prefer /hz/audible/mlp/mfpdp
+        // pages which should have the same image in its full resolution.
+        if (qsMaybe('.audible_mm_title', pageDom)) {
+            const audibleUrl = new URL(url.pathname.replace(/gp\/product|dp/, 'hz/audible/mlp/mfpdp'), url);
+            return this.findImages(audibleUrl);
+        }
+
         // Look for products which only have a single image, the front cover.
         const frontCover = this.#extractFrontCover(pageDom);
         if (frontCover) {

--- a/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
@@ -39,7 +39,7 @@ export class AmazonProvider extends CoverArtProvider {
     }
 
     name = 'Amazon';
-    urlRegex = /\/(?:gp\/product|dp)\/([A-Za-z0-9]{10})(?:\/|$)/;
+    urlRegex = /\/(?:gp\/product|dp|hz\/audible\/mlp\/mfpdp)\/([A-Za-z0-9]{10})(?:\/|$)/;
 
     async findImages(url: URL): Promise<CoverArt[]> {
         const pageContent = await this.fetchPage(url);
@@ -73,7 +73,8 @@ export class AmazonProvider extends CoverArtProvider {
     #extractFrontCover(pageDom: Document): CoverArt | undefined {
         const frontCoverSelectors = [
             '#digitalMusicProductImage_feature_div > img', // Streaming/MP3 products
-            'img#main-image', // Audible products
+            'img#main-image', // Audible products, /dp URLs
+            '#mf_pdp_hero_widget_book_img img', // Audible products, /hz/audible/mlp/mfpdp URLs
         ];
 
         for (const selector of frontCoverSelectors) {


### PR DESCRIPTION
* Support Amazon Audible `/hz/audible/mlp/mfpdp` URLs:
These should have the cover image in its full resolution while Amazon's standard product pages (i.e. `/dp` URLs) provide only 500px images for Audible audiobooks.

* Prefer `/hz/audible/mlp/mfpdp` pages for Audible products:
Look for Audible buttons on standard product pages, as we can only extract 500px images from these pages. In that case we immediately redirect the Amazon provider to `/hz/audible/mlp/mfpdp` pages which should have the same image in its full resolution.

Closes #322 (which is also one of the examples that I have used for testing).

I still remember that you had said that we should probably split Amazon audiobooks into a separate provider in case we would find another special case, which has happended now. Although I had considered this idea, I have not found a clean solution to do this as music and audiobook pages can't be told apart by their URLs.
It probably would not have a been a problem to have two providers for the same URL pattern before this change. But now we have to detect Audible product pages _before_ we even try to extract an image because otherwise the provider would happily return the smaller image for Audible audiobooks. (All the other audiobook logic still can be run _after_ all extraction attempts for a music release have failed.)
If you really want to split the provider, it would require having the audiobook provider run before the music provider. This would introduce a delay of an additional request for the common case of a music release if we don't want to introduce a cache for provider requests.