### PR TITLE
fix(ecau): prevent duplicate/broken Apple Music source URLs

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/maximise.ts
+++ b/src/mb_enhanced_cover_art_uploads/maximise.ts
@@ -114,7 +114,7 @@ IMU_EXCEPTIONS.set('*.mzstatic.com', async (smallurl) => {
             sourceUrl.pathname = sourceUrl.pathname.split('/').slice(0, -1).join('/');
         }
 
-        if (sourceUrl.href !== imgGeneric.url.href) {
+        if (sourceUrl.pathname !== imgGeneric.url.pathname) {
             results.push({
                 ...imgGeneric,
                 url: sourceUrl,


### PR DESCRIPTION
As pointed out in https://github.com/ROpdebee/mb-userscripts/pull/327#discussion_r773853556, the URL will always be different because of an unconditional domain change. This changes the check to only compare URL pathnames to prevent problems due to domain names.