### PR TITLE
fix(ecau): properly sort track numbers in track image comment

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -82,6 +82,7 @@ module.exports = {
                 '@typescript-eslint/prefer-optional-chain': ['error'],
                 '@typescript-eslint/prefer-reduce-type-parameter': ['error'],
                 '@typescript-eslint/prefer-ts-expect-error': ['error'],
+                '@typescript-eslint/require-array-sort-compare': ['error'],
                 '@typescript-eslint/type-annotation-spacing': ['error'],
             }
         }, { // Override per eslint-plugin-jest documentation.

--- a/src/lib/util/array.ts
+++ b/src/lib/util/array.ts
@@ -31,3 +31,12 @@ export function groupBy<T, K, V>(array: T[], keyFn: (el: T) => K, valTransform: 
 
     return map;
 }
+
+/**
+ * Sort an array of strings using `Intl.Collator`. Array is modified in-place,
+ * and returned.
+ */
+export function collatedSort(array: string[]): string[] {
+    const coll = new Intl.Collator('en', { numeric: true });
+    return array.sort(coll.compare.bind(coll));
+}

--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -1,6 +1,6 @@
 import { LOGGER } from '@lib/logging/logger';
 import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
-import { filterNonNull, groupBy } from '@lib/util/array';
+import { collatedSort, filterNonNull, groupBy } from '@lib/util/array';
 import { blobToDigest } from '@lib/util/blob';
 import { parseDOM, qs } from '@lib/util/dom';
 import { gmxhr } from '@lib/util/xhr';
@@ -255,6 +255,9 @@ export abstract class ProviderWithTrackImages extends CoverArtProvider {
         if (!definedTrackNumbers.length) return '';
 
         const prefix = definedTrackNumbers.length === 1 ? 'Track' : 'Tracks';
-        return `${prefix} ${definedTrackNumbers.sort().join(', ')}`;
+        // Use a collated sort here to make sure we keep numeric ordering.
+        // We can't just parse track numbers to actual numbers here, as the
+        // tracks may reasonably be numbered as strings (e.g. Vinyl sides)
+        return `${prefix} ${collatedSort(definedTrackNumbers).join(', ')}`;
     }
 }

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/base.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/base.test.ts
@@ -258,6 +258,26 @@ describe('providers with track images', () => {
                 .toBe('Tracks 1, 3');
         });
 
+        it('properly sorts track numbers in comment', async () => {
+            const trackImages = [{
+                url: 'https://example.com/123',
+                trackNumber: '3',
+            }, {
+                url: 'https://example.com/123',
+                trackNumber: '10',
+            }, {
+                url: 'https://example.com/123',
+                trackNumber: '2',
+            }, {
+                url: 'https://example.com/123',
+                trackNumber: '1',
+            }];
+            const results = await fakeProvider.mergeTrackImages(trackImages, 'https://example.com/x', false);
+
+            expect(results.find((img) => img.url.pathname === '/123')?.comment)
+                .toBe('Tracks 1, 2, 3, 10');
+        });
+
         it('sets no comment if track image cannot be determined', async () => {
             const trackImages = [{
                 url: 'https://example.com/123',


### PR DESCRIPTION
Also adds an ESLint rule to warn about this next time.

Fixes #330