### PR TITLE
fix(ecau): filter out more placeholder images in Amazon provider

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/amazon.ts
@@ -8,7 +8,13 @@ import { GMgetResourceUrl } from '@src/compat';
 import type { CoverArt } from './base';
 import { CoverArtProvider } from './base';
 
-const PLACEHOLDER_IMG_REGEX = /01RmK(?:\+|%2B)J4pJL/;
+const PLACEHOLDER_IMG_NAMES = [
+    '01RmK+J4pJL',  // .com via B000Q3KSMQ
+    '01QFb8SNuTL',  // .de via B08F6QNPJ4
+    '01PkLIhTX3L',  // .fr via B08F6QNPJ4
+    '01MKUOLsA5L',  // .co.jp via B003XZRSAE
+    '31CTP6oiIBL',  // Found on .pl and .es, e.g. B00E6GJAE6
+];
 
 // Incomplete, only what we need
 interface AmazonImage {
@@ -72,7 +78,7 @@ export class AmazonProvider extends CoverArtProvider {
         }
 
         const covers = await finder.bind(this)(url, pageContent, pageDom);
-        return covers.filter((img) => !PLACEHOLDER_IMG_REGEX.test(img.url.href));
+        return covers.filter((img) => !PLACEHOLDER_IMG_NAMES.some((name) => decodeURIComponent(img.url.pathname).includes(name)));
     }
 
     async findGenericPhysicalImages(_url: URL, pageContent: string): Promise<CoverArt[]> {


### PR DESCRIPTION
Not an exhaustive list, it's super tedious to find these. The IDs that work on .com don't work on .fr and others, so you'd need to scroll through a whole bunch of search results to find a placeholder image. These should include the most common ones. If anyone finds new placeholders, they can report them and we can add them.

Also, amazon.ca doesn't use placeholder images but instead shows an error, e.g. on https://www.amazon.ca/dp/B000Q3KSMQ. The JSON contains `null`, so the provider will show an error message. Perhaps we should handle this edge case better through some better logging calls, but that should probably wait until #81 to make sure the logging messages are actually displayed.

Fixes #324 (partially, at least).