### PR TITLE
fix(build): properly transpile async generators

### DIFF
--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -16,6 +16,12 @@ const prodConfig = {
         ['@babel/preset-env', {
             corejs: '3.19',
             useBuiltIns: 'entry',
+            exclude: [
+                // Don't transform async functions and async generators using
+                // babel itself, this is handled by a plugin.
+                '@babel/plugin-transform-async-to-generator',
+                '@babel/plugin-proposal-async-generator-functions',
+            ],
         }],
     ],
     plugins: [


### PR DESCRIPTION
Previously, there would be transpilations performed by both babel
itself and the transform-async-to-promises plugin. This led to
conflicts. Instead, we'll let the plugin do all transformations for
async generators, and babel will only do plain generators.

For ECAU, this also completely removes the need for the regenerator
runtime, yet again shrinking the compiled script size significantly.

This is a proper fix for #351 and should allow us to update to 0.8.18 of babel-plugin-transform-async-to-promises.