### PR TITLE
build: reduce renovate spam

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,22 @@
     ":semanticCommitTypeAll(build)",
     ":maintainLockFilesMonthly",
     ":label(dependencies)"
+  ],
+  "packageRules": [
+    {
+      "description": "Automatically merge pinning dependencies and lock file maintenance",
+      "matchUpdateTypes": ["pin", "lockFileMaintenance"],
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": ["at any time"]
+    },
+    {
+      "description": "Automatically merge patch and minor updates to dev dependencies",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": ["at any time"]
+    }
   ]
 }

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
         run: npm run deploy repoDist
 
       - name: Report deployment status
-        if: always() && steps.deploy-step.result != 'cancelled'
+        if: always() && steps.active-pr.outputs.result && steps.deploy-step.result != 'cancelled'
         env:
           PR_INFO: ${{ steps.active-pr.outputs.result }}
           TEST_RESULT: ${{ inputs.test-result }}

--- a/.github/workflows/renovate-check.yml
+++ b/.github/workflows/renovate-check.yml
@@ -1,0 +1,32 @@
+---
+name: Check renovate auto-merge applicability
+on:
+  push:
+    branches:
+      - renovate/*
+
+jobs:
+  build-and-test:
+    name: Build and test
+    uses: ROpdebee/mb-userscripts/.github/workflows/build-and-test.yml@main
+
+  fail-changed-userscript:
+    name: Fail if userscript are changed by update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Set up environment
+        uses: ./.github/actions/setup
+      - name: Checkout second dist copy
+        uses: actions/checkout@v2
+        with:
+          path: repoDist
+          ref: dist
+
+      - name: Deploy new userscript versions
+        id: deploy-step
+        if: inputs.test-result == 'success'
+        env:
+          PR_INFO: ${{ steps.active-pr.outputs.result }}
+        run: npx ts-node -r tsconfig-paths/register build/check-scripts-unchanged.ts

--- a/build/check-scripts-unchanged.ts
+++ b/build/check-scripts-unchanged.ts
@@ -1,0 +1,32 @@
+import fs from 'fs/promises';
+
+import { getPreviousReleaseVersion, userscriptHasChanged } from './versions';
+
+if (!process.env.GITHUB_ACTIONS) {
+    throw new Error('Refusing to run outside of CI, sorry :(');
+}
+
+const distRepo = process.argv[2];
+
+async function checkUserscriptsChanged(): Promise<void> {
+    const userscriptDirs = (await fs.readdir('./src'))
+        .filter((name) => name.startsWith('mb_'));
+
+    for (const scriptName of userscriptDirs) {
+        console.log(`Checking ${scriptName}`);
+        const previousVersion = await getPreviousReleaseVersion(scriptName, distRepo);
+
+        if (!previousVersion) {
+            throw new Error('I encountered a userscript which has not been deployed yet!');
+        }
+
+        if (await userscriptHasChanged(scriptName, previousVersion, distRepo)) {
+            throw new Error(`Userscript ${scriptName} would be changed`);
+        }
+    }
+}
+
+checkUserscriptsChanged().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT; https://opensource.org/licenses/MIT",
       "dependencies": {
-        "core-js": "3.20.2",
         "jquery": "3.6.0",
         "p-throttle": "5.0.0",
         "ts-custom-error": "3.2.0"
@@ -46,6 +45,7 @@
         "@typescript-eslint/parser": "5.8.1",
         "babel-plugin-transform-async-to-promises": "0.8.16",
         "confusing-browser-globals": "1.0.11",
+        "core-js": "3.20.2",
         "eslint": "8.6.0",
         "eslint-plugin-eslint-comments": "3.2.0",
         "eslint-plugin-jest": "25.3.4",
@@ -4526,6 +4526,7 @@
       "version": "3.20.2",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
       "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==",
+      "dev": true,
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -16087,7 +16088,8 @@
     "core-js": {
       "version": "3.20.2",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.20.2.tgz",
-      "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw=="
+      "integrity": "sha512-nuqhq11DcOAbFBV4zCbKeGbKQsUDRqTX0oqx7AttUBuqe3h20ixsE039QHelbL6P4h+9kytVqyEtyZ6gsiwEYw==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.19.3",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/parser": "5.8.1",
     "babel-plugin-transform-async-to-promises": "0.8.16",
     "confusing-browser-globals": "1.0.11",
+    "core-js": "3.20.2",
     "eslint": "8.6.0",
     "eslint-plugin-eslint-comments": "3.2.0",
     "eslint-plugin-jest": "25.3.4",
@@ -83,7 +84,6 @@
     "warcio": "1.5.0"
   },
   "dependencies": {
-    "core-js": "3.20.2",
     "jquery": "3.6.0",
     "p-throttle": "5.0.0",
     "ts-custom-error": "3.2.0"


### PR DESCRIPTION
Allow renovate to automatically merge certain dependency updates (patch and minor bumps to dev dependencies; pinning dependencies, and lock file maintenance) without even creating a PR. This should reduce many of the notifications.

Renovate will check that all CI jobs pass before attempting to merge. I've added a new CI job that will fail build/test/lint/typecheck as normal, but will also fail if the built scripts would be changed in any way. This ensures that we don't let Renovate automatically merge updates to dev dependencies that cause changes in production (e.g. babel). In case of failures, Renovate will open a real PR instead.

We'll still get real PRs in the following cases:
* Major bumps to dev dependencies (on weekends)
* Any update to prod dependencies (on weekends)
* Any dev patch/minor which causes a change in the userscripts or otherwise fails CI (could happen during the week)

The reason I didn't go with grouped updates is because of the issues we've already faced with `node-fetch` and because the whole group is one big commit, meaning that if anything goes wrong, we'd have to revert _all_ updates only to re-apply them later on again. Grouping is a good way to reduce spam, but allowing renovate to automerge when it is safe to do so just by merging branches without creating PRs will reduce it even more.