### PR TITLE
build(renovate): monthly lock file maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,11 +8,18 @@
   ],
   "packageRules": [
     {
-      "description": "Automatically merge pinning dependencies and lock file maintenance",
-      "matchUpdateTypes": ["pin", "lockFileMaintenance"],
+      "description": "Automatically merge pinning dependencies",
+      "matchUpdateTypes": ["pin"],
       "automerge": true,
       "automergeType": "branch",
       "schedule": ["at any time"]
+    },
+    {
+      "description": "Automatically merge lock file maintenance every month",
+      "matchUpdateTypes": ["lockFileMaintenance"],
+      "automerge": true,
+      "automergeType": "branch",
+      "schedule": ["on the first day of the month"]
     },
     {
       "description": "Automatically merge patch and minor updates to dev dependencies",


### PR DESCRIPTION
The previous changes caused renovate to perform lock file maintenance every time it ran, leading to too much commits on `main`.