### PR TITLE
feat(ecau): improve error message on unsupported provider URLs

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/index.ts
@@ -53,6 +53,10 @@ function extractDomain(url: URL): string {
 }
 
 export function getProvider(url: URL): CoverArtProvider | undefined {
-    const provider = PROVIDER_DISPATCH.get(extractDomain(url));
+    const provider = getProviderByDomain(url);
     return provider?.supportsUrl(url) ? provider : undefined;
+}
+
+export function getProviderByDomain(url: URL): CoverArtProvider | undefined {
+    return PROVIDER_DISPATCH.get(extractDomain(url));
 }


### PR DESCRIPTION
When a user e.g. inputs a Discogs master URL, we should indicate that it's not a valid URL for the Discogs provider, rather than suggest that the provider does not yet exist.