### PR TITLE
feat(ecau): seed from marlonob's atisket

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/meta.ts
+++ b/src/mb_enhanced_cover_art_uploads/meta.ts
@@ -10,6 +10,7 @@ const metadata: UserscriptMetadata = {
         'release/*/add-cover-art?*',
     ].map(transformMBMatchURL).concat([
         '*://atisket.pulsewidth.org.uk/*',
+        '*://etc.marlonob.info/atisket/*',
         '*://vgmdb.net/album/*',
     ]),
     exclude: ['*://atisket.pulsewidth.org.uk/'],


### PR DESCRIPTION
Contrary to atj's mirror, since we can't easily get the release ID from marlonob's original version, we don't seed the release URL but seed the direct image URL instead. We did the release URL workaround for atj's mirror so that we could properly maximise the Apple Music images to JPEG/PNG depending on source format, but we now have a better maximisation strategy for Apple Music, so it's no longer relevant.

Closes #251 