### PR TITLE
feat(ecau): bump IMU to latest version

### DIFF
--- a/src/lib/util/urls.ts
+++ b/src/lib/util/urls.ts
@@ -12,8 +12,3 @@ export function urlJoin(base: string | URL, ...subPaths: string[]): URL {
     }
     return newUrl;
 }
-
-export function urlDirname(url: string | URL): string {
-    if (typeof url !== 'string') url = url.pathname;
-    return url.split('/').slice(0, -1).join('/');
-}

--- a/src/lib/util/urls.ts
+++ b/src/lib/util/urls.ts
@@ -12,3 +12,8 @@ export function urlJoin(base: string | URL, ...subPaths: string[]): URL {
     }
     return newUrl;
 }
+
+export function urlDirname(url: string | URL): string {
+    if (typeof url !== 'string') url = url.pathname;
+    return url.split('/').slice(0, -1).join('/');
+}

--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -94,6 +94,7 @@ export class ImageFetcher {
                     }
                     break;
                 } catch (err) {
+                    // istanbul ignore if: Fine.
                     if (maxCandidate.likely_broken) continue;
                     LOGGER.warn(`Skipping maximised candidate ${maxCandidate.url}`, err);
                 }

--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -94,6 +94,7 @@ export class ImageFetcher {
                     }
                     break;
                 } catch (err) {
+                    if (maxCandidate.likely_broken) continue;
                     LOGGER.warn(`Skipping maximised candidate ${maxCandidate.url}`, err);
                 }
             }

--- a/src/mb_enhanced_cover_art_uploads/maximise.ts
+++ b/src/mb_enhanced_cover_art_uploads/maximise.ts
@@ -331,21 +331,6 @@ IMU_EXCEPTIONS.set('*.mzstatic.com', async (smallurl) => {
     return results;
 });
 
-// IMU has no definitions for 7digital yet, so adding an exception here as a workaround
-// Upstream issue: https://github.com/qsniyg/maxurl/issues/922
-IMU_EXCEPTIONS.set('artwork-cdn.7static.com', async (smallurl) => {
-    // According to https://docs.7digital.com/reference#image-sizes, 800x800
-    // and 500x500 aren't available on some images, so add 350 as well as a
-    // backup.
-    return ['800', '500', '350'].map((size) => {
-        return {
-            url: new URL(smallurl.href.replace(/_\d+\.jpg$/, `_${size}.jpg`)),
-            filename: '',
-            headers: {},
-        };
-    });
-});
-
 IMU_EXCEPTIONS.set('usercontent.jamendo.com', async (smallurl) => {
     return [{
         url: new URL(smallurl.href.replace(/([&?])width=\d+/, '$1width=0')),

--- a/src/mb_enhanced_cover_art_uploads/maximise.ts
+++ b/src/mb_enhanced_cover_art_uploads/maximise.ts
@@ -287,7 +287,7 @@ IMU_EXCEPTIONS.set('i.discogs.com', async (smallurl) => {
     const fullSizeURL = await DiscogsProvider.maximiseImage(smallurl);
     return [{
         url: fullSizeURL,
-        filename: DiscogsProvider.getFilenameFromUrl(smallurl) ?? '',
+        filename: DiscogsProvider.getFilenameFromUrl(smallurl),
         headers: {},
     }];
 });

--- a/src/mb_enhanced_cover_art_uploads/meta.ts
+++ b/src/mb_enhanced_cover_art_uploads/meta.ts
@@ -27,7 +27,7 @@ const metadata: UserscriptMetadata = {
         'GM.getResourceURL',
     ],
     connect: '*',
-    require: ['https://github.com/qsniyg/maxurl/blob/563626fe3b7c5ed3f6dc19d90a356746c68b5b4b/userscript.user.js?raw=true'],
+    require: ['https://github.com/qsniyg/maxurl/blob/e2b9dc7e3dce254a5b6d645e077aa82cba4570d5/userscript.user.js?raw=true'],
     resource: ['amazonFavicon https://www.amazon.com/favicon.ico'],
 };
 

--- a/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
@@ -108,7 +108,7 @@ export class DiscogsProvider extends CoverArtProvider {
         return metadata;
     }
 
-    static getFilenameFromUrl(url: URL): string | undefined {
+    static getFilenameFromUrl(url: URL): string {
         // E.g. https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg
         // First part is signature, everything following containing colon is param.
         // Last part is base64-encoded S3 URL, split with slashes.
@@ -119,14 +119,14 @@ export class DiscogsProvider extends CoverArtProvider {
         // Cut off the extension added by Discogs, this leads to decoding errors.
         // eslint-disable-next-line @delagen/deprecation/deprecation -- Incorrect environment
         const s3UrlDecoded = atob(s3Url.slice(0, s3Url.indexOf('.')));
-        return s3UrlDecoded.split('/').pop();
+        return s3UrlDecoded.split('/').pop()!;
     }
 
     static async maximiseImage(url: URL): Promise<URL> {
         // Maximising by querying the API for all images of the release, finding
         // the right one, and extracting the "full size" (i.e., 600x600 JPEG) URL.
         const imageName = this.getFilenameFromUrl(url);
-        const releaseId = imageName?.match(/^R-(\d+)/)?.[1];
+        const releaseId = imageName.match(/^R-(\d+)/)?.[1];
 
         /* istanbul ignore if: Should never happen on valid image */
         if (!releaseId) return url;

--- a/tests/unit/mb_enhanced_cover_art_uploads/maximise.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/maximise.test.ts
@@ -178,38 +178,6 @@ describe('maximising Apple Music images', () => {
     });
 });
 
-describe('maximising 7digital images', () => {
-    it('returns 800x800 image first', async () => {
-        const it = getMaximisedCandidates(new URL('https://artwork-cdn.7static.com/static/img/sleeveart/00/143/859/0014385941_350.jpg'));
-        const result = await it.next();
-
-        expect(result.done).toBeFalse();
-        expect(result.value!.url.href).toBe('https://artwork-cdn.7static.com/static/img/sleeveart/00/143/859/0014385941_800.jpg');
-    });
-
-    it('includes smaller images as backup', async () => {
-        const it = getMaximisedCandidates(new URL('https://artwork-cdn.7static.com/static/img/sleeveart/00/143/859/0014385941_350.jpg'));
-        let result = await it.next();
-
-        expect(result.done).toBeFalse();
-        expect(result.value!.url.pathname).toEndWith('_800.jpg');
-
-        result = await it.next();
-
-        expect(result.done).toBeFalse();
-        expect(result.value!.url.pathname).toEndWith('_500.jpg');
-
-        result = await it.next();
-
-        expect(result.done).toBeFalse();
-        expect(result.value!.url.pathname).toEndWith('_350.jpg');
-
-        result = await it.next();
-
-        expect(result.done).toBeTrue();
-    });
-});
-
 describe('maximising Jamendo images', () => {
     it('returns width=0 image', async () => {
         const it = getMaximisedCandidates(new URL('https://usercontent.jamendo.com/?cid=1632996942&type=album&id=453609&width=300'));

--- a/tests/unit/mb_enhanced_cover_art_uploads/maximise.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/maximise.test.ts
@@ -110,7 +110,7 @@ describe('maximising Apple Music images', () => {
         });
     });
 
-    it('marks /source URLs as likely broken if followed by real URL', async () => {
+    it('marks /source URLs as likely broken if original name is not "source"', async () => {
         fakeImu.mockImplementation((url, options) => {
             options.cb?.([{
                 url: 'https://a1.mzstatic.com/us/r1000/063/Music114/v4/cc/fc/dc/ccfcdc3b-5d9b-6305-8d59-687db6c67fd2/source',
@@ -133,7 +133,7 @@ describe('maximising Apple Music images', () => {
         expect(result.value!.likely_broken).toBeFalsy();
     });
 
-    it('does not mark /source URLs as likely broken if not followed by real URL', async () => {
+    it('does not mark /source URLs as likely broken if original name is "source"', async () => {
         fakeImu.mockImplementation((url, options) => {
             options.cb?.([{
                 url: 'https://a1.mzstatic.com/us/r1000/063/Music114/v4/6e/ff/f5/6efff51c-17f2-1d8b-21f3-b8029fa28434/source',
@@ -148,6 +148,21 @@ describe('maximising Apple Music images', () => {
         expect(result.done).toBeFalse();
         expect(result.value!.url.href).toEndWith('/source');
         expect(result.value!.likely_broken).toBeFalsy();
+    });
+
+    it('marks /source URL as likely broken if smallurl is already maximised', async () => {
+        fakeImu.mockImplementation((url, options) => {
+            options.cb?.([{
+                url: 'https://a1.mzstatic.com/us/r1000/063/Music111/v4/e1/dc/68/e1dc6808-6d55-1e38-a34d-a3807d488859/source',
+            }] as unknown as maxurlResult[]);
+        });
+
+        const it = getMaximisedCandidates(new URL('https://a1.mzstatic.com/us/r1000/063/Music111/v4/e1/dc/68/e1dc6808-6d55-1e38-a34d-a3807d488859/191061355977.jpg'));
+        const result = await it.next();
+
+        expect(result.done).toBeFalse();
+        expect(result.value!.url.href).toEndWith('/source');
+        expect(result.value!.likely_broken).toBeTrue();
     });
 });
 


### PR DESCRIPTION
More maximisation!

Exceptions for 7digital have been removed, exception for Apple Music has been changed to mark the `/source` URLs that are likely broken as such, and we'll skip warning the user when we can't fetch a likely broken image.

Closes #392.

We should also perhaps create some more IMU tickets to add Jamendo and DatPiff.