### PR TITLE
feat(ecau): improved logging message display

### DIFF
--- a/src/lib/logging/guiSink.scss
+++ b/src/lib/logging/guiSink.scss
@@ -1,0 +1,40 @@
+#ROpdebee_log_container {
+    margin: 1.5rem auto;
+    width: 75%;
+
+    .msg {
+        padding: .5rem .75rem;
+        margin-bottom: .5rem;
+        width: 100%;
+        display: block;
+        border: 1px solid;
+        border-radius: 4px;
+        font-weight: 500;
+
+        // Colours come from bootstrap.
+        &.error {
+            background-color: #f8d7da;
+            color: #721c24;
+            font-weight: 600;
+            border-color: #f5c6cb;
+        }
+
+        &.warning {
+            background-color: #fff3cd;
+            color: #856404;
+            border-color: #ffeeba;
+        }
+
+        &.success {
+            background-color: #d4edda;
+            color: #155724;
+            border-color: #c3e6cb;
+        }
+
+        &.info {
+            background-color: #e2e3e5;
+            color: #383d41;
+            border-color: #d6d8db;
+        }
+    }
+}

--- a/src/lib/logging/guiSink.tsx
+++ b/src/lib/logging/guiSink.tsx
@@ -1,0 +1,65 @@
+import type { LoggingSink } from './sink';
+
+import css from './guiSink.scss';
+
+export class GuiSink implements LoggingSink {
+    readonly rootElement: HTMLElement;
+    private lastTransientMessage?: HTMLSpanElement;
+
+    constructor() {
+        // Inject our custom CSS
+        document.head.append(<style id={'ROpdebee_GUI_Logger'}>
+            {css}
+        </style>);
+
+        this.rootElement = <div id='ROpdebee_log_container' style={{ display: 'none' }} />;
+    }
+
+    private createMessage(className: string, message: string, exception?: unknown): HTMLSpanElement {
+        let content: string;
+        if (exception && exception instanceof Error) {
+            content = message + ': ' + exception.message;
+        } else {
+            content = message;
+        }
+
+        return <span className={`msg ${className}`}>{content}</span>;
+    }
+
+    private addMessage(el: HTMLSpanElement): void {
+        this.rootElement.appendChild(el);
+        this.rootElement.style.display = 'block';
+    }
+
+    private addPersistentMessage(el: HTMLSpanElement): void {
+        this.addMessage(el);
+    }
+
+    private addTransientMessage(el: HTMLSpanElement): void {
+        // Remove existing transient message to replace it by the new one.
+        if (typeof this.lastTransientMessage !== 'undefined') {
+            this.lastTransientMessage.remove();
+        }
+
+        this.lastTransientMessage = el;
+        this.addMessage(el);
+    }
+
+    onLog(message: string): void {
+        this.addTransientMessage(this.createMessage('info', message));
+    }
+
+    onInfo = this.onLog.bind(this);
+
+    onSuccess(message: string): void {
+        this.addTransientMessage(this.createMessage('success', message));
+    }
+
+    onWarn(message: string, exception?: unknown): void {
+        this.addPersistentMessage(this.createMessage('warning', message, exception));
+    }
+
+    onError(message: string, exception?: unknown): void {
+        this.addPersistentMessage(this.createMessage('error', message, exception));
+    }
+}

--- a/src/lib/util/array.ts
+++ b/src/lib/util/array.ts
@@ -40,3 +40,10 @@ export function collatedSort(array: string[]): string[] {
     const coll = new Intl.Collator('en', { numeric: true });
     return array.sort(coll.compare.bind(coll));
 }
+
+export function* enumerate<T>(array: T[]): Iterable<[number, T]> {
+    let idx = 0;
+    for (const el of array) {
+        yield [idx++, el];
+    }
+}

--- a/src/mb_enhanced_cover_art_uploads/App.ts
+++ b/src/mb_enhanced_cover_art_uploads/App.ts
@@ -1,9 +1,11 @@
 /* istanbul ignore file: Covered by E2E */
 
+import { GuiSink } from '@lib/logging/guiSink';
 import { LOGGER } from '@lib/logging/logger';
 import { EditNote } from '@lib/MB/EditNote';
 import { getURLsForRelease } from '@lib/MB/URLs';
 import { assertHasValue } from '@lib/util/assert';
+import { qs } from '@lib/util/dom';
 
 import type { FetchedImages } from './fetch';
 import type { CoverArt } from './providers/base';
@@ -12,7 +14,6 @@ import { enqueueImages, fillEditNote } from './form';
 import { getProvider } from './providers';
 import { SeedParameters } from './seeding/parameters';
 import { InputForm } from './ui/main';
-import { StatusBanner } from './ui/status_banner';
 
 export class App {
     private readonly note: EditNote;
@@ -26,9 +27,11 @@ export class App {
         this.fetcher = new ImageFetcher();
         this.urlsInProgress = new Set();
 
-        const banner = new StatusBanner();
-        LOGGER.addSink(banner);
-        this.ui = new InputForm(banner.htmlElement, this);
+        // Set up logging banner
+        const loggingSink = new GuiSink();
+        LOGGER.addSink(loggingSink);
+        qs('.add-files').insertAdjacentElement('afterend', loggingSink.rootElement);
+        this.ui = new InputForm(this);
     }
 
     async processURL(url: URL): Promise<void> {

--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -7,6 +7,7 @@ import { gmxhr } from '@lib/util/xhr';
 import type { CoverArt, CoverArtProvider } from './providers/base';
 import { getMaximisedCandidates } from './maximise';
 import { getProvider, getProviderByDomain } from './providers';
+import { enumerate } from '@lib/util/array';
 
 interface ImageContents {
     requestedUrl: URL;
@@ -61,6 +62,7 @@ export class ImageFetcher {
             return this.fetchImagesFromProvider(url, provider, onlyFront);
         }
 
+        LOGGER.info(`Attempting to fetch ${getFilename(url)}`);
         const result = await this.fetchImageFromURL(url);
         if (!result) {
             return { images: [] };
@@ -125,12 +127,13 @@ export class ImageFetcher {
 
         LOGGER.info(`Found ${finalImages.length || 'no'} image(s) in ${provider.name} release`);
         const fetchResults: FetchedImage[] = [];
-        for (const img of finalImages) {
+        for (const [idx, img] of enumerate(finalImages)) {
             if (this.urlAlreadyAdded(img.url)) {
                 LOGGER.warn(`${getFilename(img.url)} has already been added`);
                 continue;
             }
 
+            LOGGER.info(`Fetching ${getFilename(img.url)} (${idx + 1}/${finalImages.length})`);
             try {
                 const result = await this.fetchImageFromURL(img.url, img.skipMaximisation);
                 // Maximised image already added

--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -1,13 +1,13 @@
 import { getFromPageContext } from '@lib/compat';
 import { LOGGER } from '@lib/logging/logger';
 import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
+import { enumerate } from '@lib/util/array';
 import { urlBasename } from '@lib/util/urls';
 import { gmxhr } from '@lib/util/xhr';
 
 import type { CoverArt, CoverArtProvider } from './providers/base';
 import { getMaximisedCandidates } from './maximise';
 import { getProvider, getProviderByDomain } from './providers';
-import { enumerate } from '@lib/util/array';
 
 interface ImageContents {
     requestedUrl: URL;

--- a/src/mb_enhanced_cover_art_uploads/ui/main.scss
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.scss
@@ -37,24 +37,3 @@
         margin: 4px;
     }
 }
-
-#ROpdebee_paste_url_status {
-    &.info {
-        color: black;
-    }
-
-    &.warning {
-        color: orange;
-    }
-
-    // Not defining custom CSS for success and error: MB already defines its
-    // own styles for span.success and span.error and their colours are nicer
-    // than the standard red and green. We'll customise in #81.
-    /*&.success {
-        color: green;
-    }
-
-    &.error {
-        color: red;
-    }*/
-}

--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -13,7 +13,7 @@ export class InputForm {
     private readonly buttonContainer: HTMLDivElement;
     private readonly orSpan: HTMLSpanElement;
 
-    constructor(banner: HTMLElement, app: App) {
+    constructor(app: App) {
         // Inject our custom CSS
         document.head.append(<style id={'ROpdebee_' + USERSCRIPT_NAME}>
             {css}
@@ -69,7 +69,6 @@ export class InputForm {
             </a>
             {onlyFrontCheckbox}
             {onlyFrontLabel}
-            {banner}
         </div>;
 
         this.buttonContainer = <div className='ROpdebee_import_url_buttons buttons'/> as HTMLDivElement;

--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -43,6 +43,7 @@ export class InputForm {
 
                     await app.processURL(url);
                 }
+                app.clearLogLater();
 
                 if (this.urlInput.value === oldValue) {
                     this.urlInput.value = '';


### PR DESCRIPTION
I finally went ahead and did it, the new status message GUI has arrived 🎉
Also improves logging of current progress while fetching.
Fixes #81.

Now that we have a bit more real estate to work with, perhaps it's time to rewrite the log messages to log the full URL instead of just the filename? E.g. Discogs changed their URLs _again_ and now they always have the same filename for the same release.