### PR TITLE
fix(ecau): new Discogs image URLs

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/maximise.ts
+++ b/src/mb_enhanced_cover_art_uploads/maximise.ts
@@ -4,7 +4,6 @@ import type { GMxmlHttpRequest } from '@lib/compat';
 import { LOGGER } from '@lib/logging/logger';
 import { retryTimes } from '@lib/util/async';
 import { DispatchMap } from '@lib/util/domain_dispatch';
-import { urlBasename } from '@lib/util/urls';
 
 import { DiscogsProvider } from './providers/discogs';
 
@@ -281,12 +280,12 @@ async function* maximiseGeneric(smallurl: URL): AsyncIterable<MaximisedImage> {
 }
 
 // Discogs
-IMU_EXCEPTIONS.set('img.discogs.com', async (smallurl) => {
+IMU_EXCEPTIONS.set('i.discogs.com', async (smallurl) => {
     // Workaround for maxurl returning broken links and webp images
     const fullSizeURL = await DiscogsProvider.maximiseImage(smallurl);
     return [{
         url: fullSizeURL,
-        filename: urlBasename(fullSizeURL),
+        filename: DiscogsProvider.getFilenameFromUrl(smallurl) ?? '',
         headers: {},
     }];
 });

--- a/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/discogs.ts
@@ -131,7 +131,6 @@ export class DiscogsProvider extends CoverArtProvider {
         /* istanbul ignore if: Should never happen on valid image */
         if (!releaseId) return url;
         const releaseData = await this.getReleaseImages(releaseId);
-        console.log(releaseData.data.release.images.edges);
         const matchedImage = releaseData.data.release.images.edges
             .find((img) => this.getFilenameFromUrl(new URL(img.node.fullsize.sourceUrl)) === imageName);
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/clears-the-cache-entry-on-failure_963532173.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/clears-the-cache-entry-on-failure_963532173.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/clears the cache entry on failure
-WARC-Date: 2021-12-11T20:26:48.779Z
+WARC-Date: 2022-01-26T15:23:44.152Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:47de96e5-dedb-4973-836b-3c5bb1016065>
+WARC-Record-ID: <urn:uuid:668ab8ea-9327-4a6e-aa3d-956139571022>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:dd892440-1ad3-49a8-829c-adbc1128b1a7>
+WARC-Concurrent-To: <urn:uuid:42d2954e-f077-4156-9fc0-12ad2439e9cf>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:48.780Z
+WARC-Date: 2022-01-26T15:23:44.153Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:c85d57bf-45ef-452e-8eb3-855949bc6f3f>
+WARC-Record-ID: <urn:uuid:945e28c2-293b-447c-b04e-dddead5e7e88>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:a1bdef6d1b0f06fe4263adc1f5721a58326bd984be25e93aebddbfc1c4f64504
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:dd892440-1ad3-49a8-829c-adbc1128b1a7>
+WARC-Concurrent-To: <urn:uuid:42d2954e-f077-4156-9fc0-12ad2439e9cf>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:48.780Z
+WARC-Date: 2022-01-26T15:23:44.153Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:07da82b7-1ba3-4d29-9375-ec5f6ad89a32>
+WARC-Record-ID: <urn:uuid:08577968-f1f1-4abc-8413-d8c42374190a>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:fa0baa3699d940fd48648430c7d5b8b79a4449eb8de64bf46c44c176359425f2
-WARC-Block-Digest: sha256:fa0baa3699d940fd48648430c7d5b8b79a4449eb8de64bf46c44c176359425f2
+WARC-Payload-Digest: sha256:b14617dc7247aa0a7f3d6119ba425f0fd97e00a32f3d4577ffda2d76d3a72484
+WARC-Block-Digest: sha256:b14617dc7247aa0a7f3d6119ba425f0fd97e00a32f3d4577ffda2d76d3a72484
 Content-Length: 644
 
 harEntryId: f14af08925617f9c2183cb046a50c703
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:48.010Z
-time: 767
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":767,"receive":0,"ssl":-1}
+startedDateTime: 2022-01-26T15:23:43.686Z
+time: 464
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":464,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 325
 warcRequestCookies: []
 warcResponseHeadersSize: 1066
-warcResponseCookies: [{"name":"__cf_bm","value":"C15mmvzj8jHRs3DmYeXV4ZxTzmfGfRZojNWhpSplRJw-1639254408-0-AcSwykGy5J2u/O8IHh5edS6TFWTB6LoTI6OhOISIG8bHIIN/rICRZ+DetWqi1iLUkshDQ+kuR0KNbc7G8o2oBGE=","path":"/","expires":"2021-12-11T20:56:48.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"19_Qo6YyME2iVNyaO.SFhZOBm9VVzQX1ZV3aRhKc0jo-1643210624-0-AU2E9TSqwM4TF0qif5xogLsXjqhX8LrKWytdzfiw/uDVbTcgQw4VLtaObn+bDRyhGT4UTNzG42oLIXFYD2GHxNM=","path":"/","expires":"2022-01-26T15:53:44.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:48.779Z
+WARC-Date: 2022-01-26T15:23:44.152Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:dd892440-1ad3-49a8-829c-adbc1128b1a7>
+WARC-Record-ID: <urn:uuid:42d2954e-f077-4156-9fc0-12ad2439e9cf>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:9b188d56d52f665713e69be396edc62573dacfb0a14f2bf38532537cc10cebca
-WARC-Block-Digest: sha256:862f9fb634312d6411b385443abc73697290bd047d40c614c12ae8f159d419b7
-Content-Length: 4266
+WARC-Payload-Digest: sha256:28926ad49bc1e2f681558fd8ee9c8be083afedbe78075335146a4fad4e60f706
+WARC-Block-Digest: sha256:88e8c49635f684673b2b28daea73abacb011e7a5e7d4b5bbfd02216aed2de8b9
+Content-Length: 4242
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6bc173335ab56d85-MUC
+cf-ray: 6d3abe7f6809715d-DUS
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Sat, 11 Dec 2021 20:26:48 GMT
+date: Wed, 26 Jan 2022 15:23:44 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=C15mmvzj8jHRs3DmYeXV4ZxTzmfGfRZojNWhpSplRJw-1639254408-0-AcSwykGy5J2u/O8IHh5edS6TFWTB6LoTI6OhOISIG8bHIIN/rICRZ+DetWqi1iLUkshDQ+kuR0KNbc7G8o2oBGE=; path=/; expires=Sat, 11-Dec-21 20:56:48 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=19_Qo6YyME2iVNyaO.SFhZOBm9VVzQX1ZV3aRhKc0jo-1643210624-0-AU2E9TSqwM4TF0qif5xogLsXjqhX8LrKWytdzfiw/uDVbTcgQw4VLtaObn+bDRyhGT4UTNzG42oLIXFYD2GHxNM=; path=/; expires=Wed, 26-Jan-22 15:53:44 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://img.discogs.com/cGX5KW1uJCaiPRzaRY8iE3btV3g=/fit-in/600x624/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","webpUrl":"https://img.discogs.com/uzedxioazWqWsEVFI2w4tC3WtF4=/fit-in/600x624/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/husmGPLvKp_kDmwLCXA_fc75LcM=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","webpUrl":"https://img.discogs.com/IPnzkFn_NCIl1R62mlS6EzGuwcY=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","width":150,"height":156,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://img.discogs.com/GjkwgdSXa6b6KAXHqtt1lrrSebQ=/fit-in/600x601/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","webpUrl":"https://img.discogs.com/DQyqoRqFynV6EL3Cx1DobKplkAk=/fit-in/600x601/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/-aLpw9YFcWdi5zhmevBqNWAJqog=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","webpUrl":"https://img.discogs.com/5NshMTi1zutw9aiig5UTr0ChuLU=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","width":150,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://img.discogs.com/hch5Dfg5ZsgGY7DCxWtNWEpRSs8=/fit-in/600x681/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","webpUrl":"https://img.discogs.com/FFEMgYSNmX5Y9tI1KiY50xfUots=/fit-in/600x681/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/yM8CF3S1SS8cj1C1VImNpbAPBEo=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","webpUrl":"https://img.discogs.com/UwY5O5fcnJUGESXV93tSQyIzV5U=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","width":150,"height":170,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2021-12-11T20:26:48.664Z","endTime":"2021-12-11T20:26:48.694Z","duration":29812620,"execution":{"resolvers":[]}}}}
+{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:44.004Z","endTime":"2022-01-26T15:23:44.064Z","duration":60287324,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-for-subsequent-requests_598889563.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-for-subsequent-requests_598889563.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/reuses the cache entry for subsequent requests
-WARC-Date: 2021-12-11T20:26:47.545Z
+WARC-Date: 2022-01-26T15:23:41.799Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:449d1f38-1541-4591-a126-c04d584dcb98>
+WARC-Record-ID: <urn:uuid:3cf98b62-1cca-4aaf-82ad-3b7a0a0b227d>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:e90d090b-d114-446a-8d61-aace99334082>
+WARC-Concurrent-To: <urn:uuid:15311fb2-073d-4f72-a8e6-d319ea974134>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:47.546Z
+WARC-Date: 2022-01-26T15:23:41.800Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:e6a5c16a-8ed8-4315-a296-63aed3d8941b>
+WARC-Record-ID: <urn:uuid:b1e432de-930a-4efc-9886-d28c98fbf3fd>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:a1bdef6d1b0f06fe4263adc1f5721a58326bd984be25e93aebddbfc1c4f64504
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:e90d090b-d114-446a-8d61-aace99334082>
+WARC-Concurrent-To: <urn:uuid:15311fb2-073d-4f72-a8e6-d319ea974134>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:47.546Z
+WARC-Date: 2022-01-26T15:23:41.800Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:85450709-7b0c-426b-975d-6ec80354c01c>
+WARC-Record-ID: <urn:uuid:b0a270f4-bdf7-4620-b05e-035959b6a3b8>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:bab7b3b785ead47fc6384a8422c6dbd6307e02ba8a6f8af89e717725377b7896
-WARC-Block-Digest: sha256:bab7b3b785ead47fc6384a8422c6dbd6307e02ba8a6f8af89e717725377b7896
+WARC-Payload-Digest: sha256:e20ea4c9f62a09cff5c78edbf7bace1f733bb00a4127af92eb9ae8f97d91a015
+WARC-Block-Digest: sha256:e20ea4c9f62a09cff5c78edbf7bace1f733bb00a4127af92eb9ae8f97d91a015
 Content-Length: 646
 
 harEntryId: f14af08925617f9c2183cb046a50c703
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:46.003Z
-time: 1536
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1536,"receive":0,"ssl":-1}
+startedDateTime: 2022-01-26T15:23:40.623Z
+time: 1171
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1171,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 325
 warcRequestCookies: []
 warcResponseHeadersSize: 1066
-warcResponseCookies: [{"name":"__cf_bm","value":"C9vGTGLgqscPXduwScDM7ClRy7RjEqKvjlKIIGZZ4tE-1639254407-0-AfuCTHsJdAuAdXR80xqx8C4IorHxiESImQ0bVK2ohgGz6THWn3iwQuAQO0pGdBGZNNgBd5ZHloSd6WxRZmCnixc=","path":"/","expires":"2021-12-11T20:56:47.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"vK4YtIXWt9CWO88wyItdjZgD0HHShY3aYHGBfFCyVnc-1643210621-0-AeJXkrL+nV2Wl1HZm45jgL+NnWdU06pEBWpsGEawG6TCrjVzZ5NsvJ438uZQK26T2oQ2MmUg2oasLyxwPVevNZI=","path":"/","expires":"2022-01-26T15:53:41.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:47.545Z
+WARC-Date: 2022-01-26T15:23:41.799Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:e90d090b-d114-446a-8d61-aace99334082>
+WARC-Record-ID: <urn:uuid:15311fb2-073d-4f72-a8e6-d319ea974134>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:d40b701e77ceb8dde8069af1f56e3edbcce4cb55f82fab17f2222f4494f400be
-WARC-Block-Digest: sha256:324dd25147a20ca463b46596826721ab42d5183a8cc179489ab4a0b6698bb990
-Content-Length: 4266
+WARC-Payload-Digest: sha256:f0a32b1941919443b740d6e8202b96cc6464a755c3ac29a0d6000608df81886e
+WARC-Block-Digest: sha256:328b45803f0b206c239ff1b94e648cb2eab06a39710988fa4099a6b051183c09
+Content-Length: 4242
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6bc17326dddf7a5a-DUS
+cf-ray: 6d3abe6eaf6c1e65-MUC
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Sat, 11 Dec 2021 20:26:47 GMT
+date: Wed, 26 Jan 2022 15:23:41 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=C9vGTGLgqscPXduwScDM7ClRy7RjEqKvjlKIIGZZ4tE-1639254407-0-AfuCTHsJdAuAdXR80xqx8C4IorHxiESImQ0bVK2ohgGz6THWn3iwQuAQO0pGdBGZNNgBd5ZHloSd6WxRZmCnixc=; path=/; expires=Sat, 11-Dec-21 20:56:47 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=vK4YtIXWt9CWO88wyItdjZgD0HHShY3aYHGBfFCyVnc-1643210621-0-AeJXkrL+nV2Wl1HZm45jgL+NnWdU06pEBWpsGEawG6TCrjVzZ5NsvJ438uZQK26T2oQ2MmUg2oasLyxwPVevNZI=; path=/; expires=Wed, 26-Jan-22 15:53:41 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://img.discogs.com/cGX5KW1uJCaiPRzaRY8iE3btV3g=/fit-in/600x624/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","webpUrl":"https://img.discogs.com/uzedxioazWqWsEVFI2w4tC3WtF4=/fit-in/600x624/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/husmGPLvKp_kDmwLCXA_fc75LcM=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","webpUrl":"https://img.discogs.com/IPnzkFn_NCIl1R62mlS6EzGuwcY=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","width":150,"height":156,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://img.discogs.com/GjkwgdSXa6b6KAXHqtt1lrrSebQ=/fit-in/600x601/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","webpUrl":"https://img.discogs.com/DQyqoRqFynV6EL3Cx1DobKplkAk=/fit-in/600x601/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/-aLpw9YFcWdi5zhmevBqNWAJqog=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","webpUrl":"https://img.discogs.com/5NshMTi1zutw9aiig5UTr0ChuLU=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","width":150,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://img.discogs.com/hch5Dfg5ZsgGY7DCxWtNWEpRSs8=/fit-in/600x681/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","webpUrl":"https://img.discogs.com/FFEMgYSNmX5Y9tI1KiY50xfUots=/fit-in/600x681/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/yM8CF3S1SS8cj1C1VImNpbAPBEo=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","webpUrl":"https://img.discogs.com/UwY5O5fcnJUGESXV93tSQyIzV5U=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","width":150,"height":170,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2021-12-11T20:26:47.364Z","endTime":"2021-12-11T20:26:47.402Z","duration":38279442,"execution":{"resolvers":[]}}}}
+{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:41.675Z","endTime":"2022-01-26T15:23:41.720Z","duration":45459599,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-while-maximising-images_2688171962.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-while-maximising-images_2688171962.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/reuses the cache entry while maximising images
-WARC-Date: 2021-12-11T20:26:48.002Z
+WARC-Date: 2022-01-26T15:23:43.682Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:a5e86171-339b-4a81-96f2-f27c60bea6ae>
+WARC-Record-ID: <urn:uuid:12de19e9-ca58-41c8-84bd-1c890780de1f>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:b7b9ff3e-1f70-4645-8777-bac5a2ea74db>
+WARC-Concurrent-To: <urn:uuid:510c0164-4dd5-48ee-a2db-e1129cbbbc66>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:48.004Z
+WARC-Date: 2022-01-26T15:23:43.682Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:3c5d6b24-bf76-40a1-b5ac-e197096b11ca>
+WARC-Record-ID: <urn:uuid:f21a34c0-aa71-49cf-a7a7-5f1011a2e8e2>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:a1bdef6d1b0f06fe4263adc1f5721a58326bd984be25e93aebddbfc1c4f64504
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:b7b9ff3e-1f70-4645-8777-bac5a2ea74db>
+WARC-Concurrent-To: <urn:uuid:510c0164-4dd5-48ee-a2db-e1129cbbbc66>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:48.004Z
+WARC-Date: 2022-01-26T15:23:43.682Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:674ba15b-e664-4700-9c18-428998229b90>
+WARC-Record-ID: <urn:uuid:303df317-cd74-41c8-9387-0c4466a96c2c>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:3d3731e20d6b2679e8516f7e8d37f30d2887befc547b2c08c92217fdd0484029
-WARC-Block-Digest: sha256:3d3731e20d6b2679e8516f7e8d37f30d2887befc547b2c08c92217fdd0484029
-Content-Length: 644
+WARC-Payload-Digest: sha256:2b9d97e31599d8cedc19d6dbfd042b6725953726a2737f6102c2a1b2aaf343a3
+WARC-Block-Digest: sha256:2b9d97e31599d8cedc19d6dbfd042b6725953726a2737f6102c2a1b2aaf343a3
+Content-Length: 646
 
 harEntryId: f14af08925617f9c2183cb046a50c703
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:47.552Z
-time: 446
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":446,"receive":0,"ssl":-1}
+startedDateTime: 2022-01-26T15:23:41.805Z
+time: 1874
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1874,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 325
 warcRequestCookies: []
 warcResponseHeadersSize: 1066
-warcResponseCookies: [{"name":"__cf_bm","value":"xVPDrvyh0.0Z9DKphhYGgUzT__HsH1QeT1Lzyndd8N4-1639254407-0-ASn6JK1J+l3oYC503W2kREMxarIZsUVCtkFZNmRa+f/Y+fsgeYilG64S2c5ytYC6yelehm2ARra3XG9ZSy2BYZc=","path":"/","expires":"2021-12-11T20:56:47.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"TEpRsYwK3PzRCp_brsD2O4oQX5EQbuQw2HCRpFCOlOQ-1643210623-0-ActcQSWBj4+Yrc+iWiHpQGYa+g3BssF0alquwLGmv7GzPqDinIwIBc50MYhWxHVh9LLDpt1LL/76P+8OQdu02Qg=","path":"/","expires":"2022-01-26T15:53:43.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:48.003Z
+WARC-Date: 2022-01-26T15:23:43.682Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:b7b9ff3e-1f70-4645-8777-bac5a2ea74db>
+WARC-Record-ID: <urn:uuid:510c0164-4dd5-48ee-a2db-e1129cbbbc66>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:f5a84a3e2b024b1a7b73c830a66dbb68d4a4305fac4b1fab6e3a9e94e09a94fa
-WARC-Block-Digest: sha256:dfdf27972fa86b562b02ac60f951d7eab4f37657e3bbe32890557856a717fddd
-Content-Length: 4266
+WARC-Payload-Digest: sha256:cf1e9d18d9f7414cd6c5debb295e2edc7912581150b82928cbdf90392a15dbb9
+WARC-Block-Digest: sha256:a009750637038a5b980ab1e14327b8bfe218378fbffeb4e5ac2686369288e392
+Content-Length: 4242
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6bc173308c3f6d80-MUC
+cf-ray: 6d3abe73b8ce1bd5-MUC
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Sat, 11 Dec 2021 20:26:47 GMT
+date: Wed, 26 Jan 2022 15:23:43 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=xVPDrvyh0.0Z9DKphhYGgUzT__HsH1QeT1Lzyndd8N4-1639254407-0-ASn6JK1J+l3oYC503W2kREMxarIZsUVCtkFZNmRa+f/Y+fsgeYilG64S2c5ytYC6yelehm2ARra3XG9ZSy2BYZc=; path=/; expires=Sat, 11-Dec-21 20:56:47 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=TEpRsYwK3PzRCp_brsD2O4oQX5EQbuQw2HCRpFCOlOQ-1643210623-0-ActcQSWBj4+Yrc+iWiHpQGYa+g3BssF0alquwLGmv7GzPqDinIwIBc50MYhWxHVh9LLDpt1LL/76P+8OQdu02Qg=; path=/; expires=Wed, 26-Jan-22 15:53:43 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://img.discogs.com/cGX5KW1uJCaiPRzaRY8iE3btV3g=/fit-in/600x624/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","webpUrl":"https://img.discogs.com/uzedxioazWqWsEVFI2w4tC3WtF4=/fit-in/600x624/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/husmGPLvKp_kDmwLCXA_fc75LcM=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","webpUrl":"https://img.discogs.com/IPnzkFn_NCIl1R62mlS6EzGuwcY=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","width":150,"height":156,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://img.discogs.com/GjkwgdSXa6b6KAXHqtt1lrrSebQ=/fit-in/600x601/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","webpUrl":"https://img.discogs.com/DQyqoRqFynV6EL3Cx1DobKplkAk=/fit-in/600x601/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/-aLpw9YFcWdi5zhmevBqNWAJqog=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","webpUrl":"https://img.discogs.com/5NshMTi1zutw9aiig5UTr0ChuLU=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","width":150,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://img.discogs.com/hch5Dfg5ZsgGY7DCxWtNWEpRSs8=/fit-in/600x681/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","webpUrl":"https://img.discogs.com/FFEMgYSNmX5Y9tI1KiY50xfUots=/fit-in/600x681/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/yM8CF3S1SS8cj1C1VImNpbAPBEo=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","webpUrl":"https://img.discogs.com/UwY5O5fcnJUGESXV93tSQyIzV5U=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","width":150,"height":170,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2021-12-11T20:26:47.868Z","endTime":"2021-12-11T20:26:47.905Z","duration":36723398,"execution":{"resolvers":[]}}}}
+{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:43.477Z","endTime":"2022-01-26T15:23:43.520Z","duration":42569575,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/extracts-covers-for-release_2308446907.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/extracts-covers-for-release_2308446907.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/extracting images/extracts covers for release
-WARC-Date: 2021-12-11T20:26:45.538Z
+WARC-Date: 2022-01-26T15:23:39.464Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:a9c4f137-f932-4ee2-83df-4a8f54e8ba4b>
+WARC-Record-ID: <urn:uuid:01f65228-51ee-4cfc-be51-031d299cc024>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:2a266efe-3f47-4716-82b8-8666c641fd5f>
+WARC-Concurrent-To: <urn:uuid:4c10ee8c-f086-4a28-abc1-8329bd132ba0>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:45.539Z
+WARC-Date: 2022-01-26T15:23:39.466Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:b659217a-69d2-44b3-a8e2-e1fb1cfd3872>
+WARC-Record-ID: <urn:uuid:54d5d8e7-593e-4197-8fa0-c8410f7d9535>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:a1bdef6d1b0f06fe4263adc1f5721a58326bd984be25e93aebddbfc1c4f64504
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:2a266efe-3f47-4716-82b8-8666c641fd5f>
+WARC-Concurrent-To: <urn:uuid:4c10ee8c-f086-4a28-abc1-8329bd132ba0>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:45.539Z
+WARC-Date: 2022-01-26T15:23:39.467Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:a0003f36-8148-4056-91d8-695a90b0a666>
+WARC-Record-ID: <urn:uuid:588745e9-34e6-4aed-b8b8-5875a5a3e02d>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:8353e7ba0528bcbc15c3bcc3e9808845113fb6aa17ce8f75f02cd90be50ed38f
-WARC-Block-Digest: sha256:8353e7ba0528bcbc15c3bcc3e9808845113fb6aa17ce8f75f02cd90be50ed38f
-Content-Length: 644
+WARC-Payload-Digest: sha256:45a189e6592eb39bbe08f1ed067cdb0551a80e1eb51649341770d2ee944d1d3a
+WARC-Block-Digest: sha256:45a189e6592eb39bbe08f1ed067cdb0551a80e1eb51649341770d2ee944d1d3a
+Content-Length: 646
 
 harEntryId: f14af08925617f9c2183cb046a50c703
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:44.952Z
-time: 580
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":580,"receive":0,"ssl":-1}
+startedDateTime: 2022-01-26T15:23:37.497Z
+time: 1954
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1954,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 325
 warcRequestCookies: []
 warcResponseHeadersSize: 1066
-warcResponseCookies: [{"name":"__cf_bm","value":"7e4kFhxV3ItF8gE39nfM8vAIPQhHDE3R24w1GkrYfQE-1639254405-0-Aesh8jSmRulwXMbm2D8yDPGofq7uwjoao/0IN/XIJFtlzHrwcpErvmJyHUHS0jFNd8InZNJ3UmQql1OWoLFTA1M=","path":"/","expires":"2021-12-11T20:56:45.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"KbpWQhdGEMc2c6o.OshCr7F3dd2kzNQSFcjCsxCNkIY-1643210619-0-AZvoGHGxa5lPH5m+di36Gd/1SC79F1icILMAMlDZ1PfOcECcp5tKbHSk30z10CWpZVlJG7qU8exPS2WHVeWlSkU=","path":"/","expires":"2022-01-26T15:53:39.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:45.538Z
+WARC-Date: 2022-01-26T15:23:39.465Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:2a266efe-3f47-4716-82b8-8666c641fd5f>
+WARC-Record-ID: <urn:uuid:4c10ee8c-f086-4a28-abc1-8329bd132ba0>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:78c760688e888a83e69d04e071ed8e2d097cd1b68a578217c1ecad50473d6f6b
-WARC-Block-Digest: sha256:4364b7df3157408a4f144eb3572b37c8a6fdd3cde82b159fca97597238c1988e
-Content-Length: 4266
+WARC-Payload-Digest: sha256:cfe840c9d0d78c0b5c302be4fd09705f16c30b6dd11bc04e385489eb874e02aa
+WARC-Block-Digest: sha256:e62d1e32fe0712790bca78b28df26c3263e862ffa90d1bca3d7602a96ed044d5
+Content-Length: 4242
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6bc17320b8296d6e-MUC
+cf-ray: 6d3abe596be96d71-MUC
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Sat, 11 Dec 2021 20:26:45 GMT
+date: Wed, 26 Jan 2022 15:23:39 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=7e4kFhxV3ItF8gE39nfM8vAIPQhHDE3R24w1GkrYfQE-1639254405-0-Aesh8jSmRulwXMbm2D8yDPGofq7uwjoao/0IN/XIJFtlzHrwcpErvmJyHUHS0jFNd8InZNJ3UmQql1OWoLFTA1M=; path=/; expires=Sat, 11-Dec-21 20:56:45 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=KbpWQhdGEMc2c6o.OshCr7F3dd2kzNQSFcjCsxCNkIY-1643210619-0-AZvoGHGxa5lPH5m+di36Gd/1SC79F1icILMAMlDZ1PfOcECcp5tKbHSk30z10CWpZVlJG7qU8exPS2WHVeWlSkU=; path=/; expires=Wed, 26-Jan-22 15:53:39 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://img.discogs.com/cGX5KW1uJCaiPRzaRY8iE3btV3g=/fit-in/600x624/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","webpUrl":"https://img.discogs.com/uzedxioazWqWsEVFI2w4tC3WtF4=/fit-in/600x624/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/husmGPLvKp_kDmwLCXA_fc75LcM=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","webpUrl":"https://img.discogs.com/IPnzkFn_NCIl1R62mlS6EzGuwcY=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg","width":150,"height":156,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://img.discogs.com/GjkwgdSXa6b6KAXHqtt1lrrSebQ=/fit-in/600x601/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","webpUrl":"https://img.discogs.com/DQyqoRqFynV6EL3Cx1DobKplkAk=/fit-in/600x601/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/-aLpw9YFcWdi5zhmevBqNWAJqog=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","webpUrl":"https://img.discogs.com/5NshMTi1zutw9aiig5UTr0ChuLU=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg","width":150,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://img.discogs.com/hch5Dfg5ZsgGY7DCxWtNWEpRSs8=/fit-in/600x681/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","webpUrl":"https://img.discogs.com/FFEMgYSNmX5Y9tI1KiY50xfUots=/fit-in/600x681/filters:strip_icc():format(webp):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://img.discogs.com/yM8CF3S1SS8cj1C1VImNpbAPBEo=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","webpUrl":"https://img.discogs.com/UwY5O5fcnJUGESXV93tSQyIzV5U=/fit-in/300x300/filters:strip_icc():format(webp):mode_rgb():quality(40)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg","width":150,"height":170,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2021-12-11T20:26:45.363Z","endTime":"2021-12-11T20:26:45.393Z","duration":29437897,"execution":{"resolvers":[]}}}}
+{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:39.318Z","endTime":"2022-01-26T15:23:39.347Z","duration":29175813,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/throws-on-non-existent-release_1189313548.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/throws-on-non-existent-release_1189313548.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/extracting images/throws on non-existent release
-WARC-Date: 2021-12-11T20:26:45.996Z
+WARC-Date: 2022-01-26T15:23:40.615Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:83275d4c-d2e0-4681-b482-ecdb29bac831>
+WARC-Record-ID: <urn:uuid:5ea0f631-a249-466e-a818-eaca7162b9f4>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:8a38ec27-ace8-4588-90fc-4085f4270ebb>
+WARC-Concurrent-To: <urn:uuid:1f2935b4-01dc-4b6d-b6ac-586cfbb2987c>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:45.997Z
+WARC-Date: 2022-01-26T15:23:40.616Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:1bc8d110-03e9-49a3-b8a0-f0a8e2fcc181>
+WARC-Record-ID: <urn:uuid:6d6be006-050b-477a-aaa7-2c8177e666ea>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:949bc3a3028bf2521b366401edf458b4b1eb82658136f5fe211ce5a0f974cb97
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:8a38ec27-ace8-4588-90fc-4085f4270ebb>
+WARC-Concurrent-To: <urn:uuid:1f2935b4-01dc-4b6d-b6ac-586cfbb2987c>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:45.997Z
+WARC-Date: 2022-01-26T15:23:40.616Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:11559861-55ee-4fd2-b9eb-c4a9475d6c68>
+WARC-Record-ID: <urn:uuid:8a608943-c4d5-4308-8772-427829bb67f9>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:ebbe98ada282726acc1c07c8749e9377069542f72813ee8ad9347575c64c9a63
-WARC-Block-Digest: sha256:ebbe98ada282726acc1c07c8749e9377069542f72813ee8ad9347575c64c9a63
-Content-Length: 644
+WARC-Payload-Digest: sha256:f8cfdf26a0ccbaa73f58fb7a34104ae816d8aa3bda5e77288534fb72f2a1bc85
+WARC-Block-Digest: sha256:f8cfdf26a0ccbaa73f58fb7a34104ae816d8aa3bda5e77288534fb72f2a1bc85
+Content-Length: 646
 
 harEntryId: 474e9e5a520399c60171a9d1f8584295
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:45.546Z
-time: 447
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":447,"receive":0,"ssl":-1}
+startedDateTime: 2022-01-26T15:23:39.475Z
+time: 1138
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1138,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 326
 warcRequestCookies: []
 warcResponseHeadersSize: 1067
-warcResponseCookies: [{"name":"__cf_bm","value":"xQwAF6aJ7FKWsBWOCvGe.qNPf33FB6w_2iHTWdd.Sgg-1639254405-0-AZaBjsWKkllT2C4tfrnFySlWdZ0wh9oStj7CyDjv2ItJy3OaG0bXAN3rqAYbdg4DXgn8EFWzKy6EnQfC2xxKG0Y=","path":"/","expires":"2021-12-11T20:56:45.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":".MqICMdWBQNYbISo_QklX327SJdB9.QfBlQ_G.9eBQ0-1643210620-0-Aev/ELoC1ZyV0PMwmJIVEZpxEHOFSPXtmolPyhVmaLdVu7aUtciKwEK/JfLZy+k4qhvm6Su/J0gVzXfu6zdxfbk=","path":"/","expires":"2022-01-26T15:53:40.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2021-12-11T20:26:45.996Z
+WARC-Date: 2022-01-26T15:23:40.615Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:8a38ec27-ace8-4588-90fc-4085f4270ebb>
+WARC-Record-ID: <urn:uuid:1f2935b4-01dc-4b6d-b6ac-586cfbb2987c>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:c81602f505fb52755d85a9665df32b794e71d77c3e1ad67a6e570fcb6ea69904
-WARC-Block-Digest: sha256:86edc0ede8602f6bb4207feb6727ec9440588f3407927cd3ea07a43a3afbefb0
+WARC-Payload-Digest: sha256:6d6d18eb4510da5561334e0d4fb7b48e49c55f91ff429520af017588700198af
+WARC-Block-Digest: sha256:6d7727aafcee9fea80fbf24d550b87816227c881561e420be7e7200d76794849
 Content-Length: 1274
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6bc17323f956727c-HAM
+cf-ray: 6d3abe669d1c6d7f-MUC
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Sat, 11 Dec 2021 20:26:45 GMT
+date: Wed, 26 Jan 2022 15:23:40 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=xQwAF6aJ7FKWsBWOCvGe.qNPf33FB6w_2iHTWdd.Sgg-1639254405-0-AZaBjsWKkllT2C4tfrnFySlWdZ0wh9oStj7CyDjv2ItJy3OaG0bXAN3rqAYbdg4DXgn8EFWzKy6EnQfC2xxKG0Y=; path=/; expires=Sat, 11-Dec-21 20:56:45 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=.MqICMdWBQNYbISo_QklX327SJdB9.QfBlQ_G.9eBQ0-1643210620-0-Aev/ELoC1ZyV0PMwmJIVEZpxEHOFSPXtmolPyhVmaLdVu7aUtciKwEK/JfLZy+k4qhvm6Su/J0gVzXfu6zdxfbk=; path=/; expires=Wed, 26-Jan-22 15:53:40 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":null},"extensions":{"tracing":{"version":1,"startTime":"2021-12-11T20:26:45.873Z","endTime":"2021-12-11T20:26:45.891Z","duration":17890383,"execution":{"resolvers":[]}}}}
+{"data":{"release":null},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:40.440Z","endTime":"2022-01-26T15:23:40.458Z","duration":17215960,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/maximise.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/maximise.test.ts
@@ -91,7 +91,7 @@ describe('maximising Discogs images', () => {
     jest.spyOn(DiscogsProvider, 'maximiseImage').mockImplementationOnce(() => Promise.resolve(new URL('https://example.com/discogs')));
 
     it('special-cases Discogs images', async () => {
-        const it = getMaximisedCandidates(new URL('https://img.discogs.com/husmGPLvKp_kDmwLCXA_fc75LcM=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg'));
+        const it = getMaximisedCandidates(new URL('https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg'));
         let result = await it.next();
 
         expect(result.done).toBeFalse();

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/discogs.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/discogs.test.ts
@@ -42,15 +42,15 @@ describe('discogs provider', () => {
             numImages: 3,
             expectedImages: [{
                 index: 0,
-                urlPart: '/cGX5KW1uJCaiPRzaRY8iE3btV3g=/fit-in/600x624/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg',
+                urlPart: '/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg',
                 types: undefined,
             }, {
                 index: 1,
-                urlPart: '/GjkwgdSXa6b6KAXHqtt1lrrSebQ=/fit-in/600x601/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-4048.jpeg.jpg',
+                urlPart: '/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg',
                 types: undefined,
             }, {
                 index: 2,
-                urlPart: '/hch5Dfg5ZsgGY7DCxWtNWEpRSs8=/fit-in/600x681/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1488067341-2872.jpeg.jpg',
+                urlPart: '/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg',
                 types: undefined,
             }],
         }];
@@ -67,9 +67,17 @@ describe('discogs provider', () => {
 
     describe('maximising image', () => {
         it('finds the image', async () => {
-            const maxUrl = await DiscogsProvider.maximiseImage(new URL('https://img.discogs.com/husmGPLvKp_kDmwLCXA_fc75LcM=/fit-in/300x300/filters:strip_icc():format(jpeg):mode_rgb():quality(40)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg'));
+            const maxUrl = await DiscogsProvider.maximiseImage(new URL('https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg'));
 
-            expect(maxUrl.pathname).toBe('/cGX5KW1uJCaiPRzaRY8iE3btV3g=/fit-in/600x624/filters:strip_icc():format(jpeg):mode_rgb():quality(90)/discogs-images/R-9892912-1579456707-2320.jpeg.jpg');
+            expect(maxUrl.pathname).toBe('/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg');
+        });
+    });
+
+    describe('extracting filename from URL', () => {
+        it('extracts the correct filename', async () => {
+            const filename = DiscogsProvider.getFilenameFromUrl(new URL('https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg'));
+
+            expect(filename).toBe('R-9892912-1579456707-2320.jpeg');
         });
     });
 


### PR DESCRIPTION
* Fix maximisation of single URLs.
* Fix displayed filenames.

I don't like that we have to do this, but it is what it is. Stupid Discogs with their security through obscurity.