### PR TITLE
feat(ecau): include full URL in logging messages

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -51,7 +51,7 @@ export class ImageFetcher {
 
     async fetchImages(url: URL, onlyFront: boolean): Promise<FetchedImages> {
         if (this.urlAlreadyAdded(url)) {
-            LOGGER.warn(`${getFilename(url)} has already been added`);
+            LOGGER.warn(`${url} has already been added`);
             return {
                 images: [],
             };
@@ -62,7 +62,7 @@ export class ImageFetcher {
             return this.fetchImagesFromProvider(url, provider, onlyFront);
         }
 
-        LOGGER.info(`Attempting to fetch ${getFilename(url)}`);
+        LOGGER.info(`Attempting to fetch ${url}`);
         const result = await this.fetchImageFromURL(url);
         if (!result) {
             return { images: [] };
@@ -81,16 +81,20 @@ export class ImageFetcher {
             for await (const maxCandidate of getMaximisedCandidates(url)) {
                 const candidateName = maxCandidate.filename || getFilename(maxCandidate.url);
                 if (this.urlAlreadyAdded(maxCandidate.url)) {
-                    LOGGER.warn(`${candidateName} has already been added`);
+                    LOGGER.warn(`${maxCandidate.url} has already been added`);
                     return;
                 }
 
                 try {
                     fetchResult = await this.fetchImageContents(maxCandidate.url, candidateName, maxCandidate.headers);
-                    LOGGER.debug(`Maximised ${url.href} to ${maxCandidate.url.href}`);
+                    // IMU might return the same URL as was inputted, no use in logging that.
+                    // istanbul ignore next: Logging
+                    if (maxCandidate.url.href !== url.href) {
+                        LOGGER.info(`Maximised ${url.href} to ${maxCandidate.url.href}`);
+                    }
                     break;
                 } catch (err) {
-                    LOGGER.warn(`Skipping maximised candidate ${candidateName}`, err);
+                    LOGGER.warn(`Skipping maximised candidate ${maxCandidate.url}`, err);
                 }
             }
         }
@@ -129,11 +133,11 @@ export class ImageFetcher {
         const fetchResults: FetchedImage[] = [];
         for (const [idx, img] of enumerate(finalImages)) {
             if (this.urlAlreadyAdded(img.url)) {
-                LOGGER.warn(`${getFilename(img.url)} has already been added`);
+                LOGGER.warn(`${img.url} has already been added`);
                 continue;
             }
 
-            LOGGER.info(`Fetching ${getFilename(img.url)} (${idx + 1}/${finalImages.length})`);
+            LOGGER.info(`Fetching ${img.url} (${idx + 1}/${finalImages.length})`);
             try {
                 const result = await this.fetchImageFromURL(img.url, img.skipMaximisation);
                 // Maximised image already added
@@ -145,7 +149,7 @@ export class ImageFetcher {
                     comment: img.comment,
                 });
             } catch (err) {
-                LOGGER.warn(`Skipping ${getFilename(img.url)}`, err);
+                LOGGER.warn(`Skipping ${img.url}`, err);
             }
         }
 

--- a/src/mb_enhanced_cover_art_uploads/providers/7digital.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/7digital.ts
@@ -18,7 +18,7 @@ export class SevenDigitalProvider extends HeadMetaPropertyProvider {
             // with ID 0000000016. This is a placeholder image.
             .filter((image) => {
                 if (/\/0000000016_\d+/.test(image.fetchedUrl.pathname)) {
-                    LOGGER.warn(`Skipping "${image.content.name}" as it matches a placeholder cover`);
+                    LOGGER.warn(`Skipping "${image.fetchedUrl}" as it matches a placeholder cover`);
                     return false;
                 }
                 return true;

--- a/src/mb_enhanced_cover_art_uploads/providers/datpiff.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/datpiff.ts
@@ -62,7 +62,7 @@ export class DatPiffProvider extends CoverArtProvider {
         const withoutPlaceholders = await Promise.all(images.map(async (image) => {
             const digest = await blobToDigest(image.content);
             if (DatPiffProvider.placeholderDigests.includes(digest)) {
-                LOGGER.warn(`Skipping "${image.content.name}" as it matches a placeholder cover`);
+                LOGGER.warn(`Skipping "${image.fetchedUrl}" as it matches a placeholder cover`);
                 return null;
             } else {
                 return image;


### PR DESCRIPTION
Many providers return nonsensical image names, so the logging messages
weren't really informative. We now have some more real estate in the
logging display, so we may as well show the full URL everywhere.