### PR TITLE
Create a GEMA repertoire handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Blinds editor and voter details before your votes are cast.
 
 ## MB: Bulk copy-paste work codes
 
-Quickly copy-paste work identifiers (ISWC, agency work codes) from CISAC's ISWCNet into a MusicBrainz work.
+Quickly copy-paste work identifiers (ISWC, agency work codes) from [CISAC's ISWCNet](https://iswcnet.cisac.org/search) or [GEMA repertoire search](https://online.gema.de/werke/search.faces?lang=en) into a MusicBrainz work.
 
 [![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_bulk_copy_work_codes.user.js?raw=1)
 [![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_bulk_copy_work_codes.user.js)

--- a/mb_bulk_copy_work_codes.user.js
+++ b/mb_bulk_copy_work_codes.user.js
@@ -308,8 +308,7 @@ class BaseWorkForm {
         return this.findEmptyRow(parentSelector, inputName);
     }
 
-    checkAndFill(rawData) {
-        let data = this.parseData(rawData);
+    checkAndFill(data) {
         console.log(data);
         let externalCodes = extractCodes(data);
         let externalISWCs = data['iswcs'];
@@ -479,17 +478,6 @@ class BaseWorkForm {
         GM_deleteValue('workCodeData');
     }
 
-    parseData(raw) {
-        try {
-            return JSON.parse(raw);
-        } catch(e) {
-            this.log('error', 'Invalid data');
-            console.log(raw);
-            console.log(e);
-            return {};
-        }
-    }
-
     promptForConfirmation(conflicts) {
         const lis = conflicts.reduce((acc, [agency, mbCodes, extCodes]) => {
             return acc + `<li>${agency}: [${mbCodes.join(', ')}] vs [${extCodes.join(', ')}]</li>`
@@ -607,7 +595,7 @@ function storeData(source, iswcs, codes, title) {
     console.log(obj);
 
     // Use GM functions rather than clipboard because reading clipboard in a portable manner is difficult
-    GM_setValue('workCodeData', JSON.stringify(obj));
+    GM_setValue('workCodeData', obj);
 }
 
 


### PR DESCRIPTION
The GEMA repertoire handler is fairly straightforward (there is only one agency code and one ISWC per work which has to be extracted) and works for the English and the German search. Pagination of the results does not cause problems, the mutation observer correctly catches all these events, except for the inital page load which might load the results of the last visit again and requires an inital handler.

It took me a while to figure out why the code of the first commit alone failed to work, although I've implemented it the same way as the CISAC handler. Then I found out that I have to drop the explicit JSON serialization of the "clipboard data" and directly feed the raw object into the GM storage function to make it work.

Violentmonkey and Tampermonkey already do the JSON serialization implicitly while
Greasemonkey v4 has never supported this userscript (which uses GM v3 API).
This is necessary because https://online.gema.de/werke/search.faces apparently overwrites `JSON.stringify()` with a custom implementation (try `JSON.stringify({a:[]})` in a browser console on their page) which causes `JSON.parse()` to fail on MB.