### PR TITLE
test(ecau): fix tests after upstream provider changes

### DIFF
--- a/tests/test-data/__recordings__/apple-music-provider_2401788145/extracting-images_1310741912/throws-on-non-existent-Apple-Music-release_3871375527.warc
+++ b/tests/test-data/__recordings__/apple-music-provider_2401788145/extracting-images_1310741912/throws-on-non-existent-Apple-Music-release_3871375527.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: apple music provider/extracting images/throws on non-existent Apple Music release
-WARC-Date: 2021-12-11T20:26:46.626Z
+WARC-Date: 2022-03-16T09:53:50.260Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:03bc5ad9-531b-495e-ba61-ad9cb35de18b>
+WARC-Record-ID: <urn:uuid:485b9c22-439f-40aa-b319-d2032ca593dd>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,76 +12,76 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:245ed845-0ef7-426d-bad0-1a0fe3951ea6>
-WARC-Target-URI: https://music.apple.com/gb/album/993998924
-WARC-Date: 2021-12-11T20:26:46.626Z
+WARC-Concurrent-To: <urn:uuid:40825ced-579c-4313-8ec8-256a205613ba>
+WARC-Target-URI: https://music.apple.com/gb/album/123456789
+WARC-Date: 2022-03-16T09:53:50.261Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:95a17b41-bb65-4566-ae8d-2387ff4caa2f>
+WARC-Record-ID: <urn:uuid:6bbe731a-42d7-4b03-ab89-02fceec02061>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:c20c829e6ed14b63d2c22710cf6d80628bd5b5851c56f36603704e9d018f0cc7
+WARC-Block-Digest: sha256:ca0251ccb245ae7a9d36399d31f6449e86466a70e14ac124e1efcbda50f6bf18
 Content-Length: 36
 
-GET /gb/album/993998924 HTTP/1.1
+GET /gb/album/123456789 HTTP/1.1
 
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:245ed845-0ef7-426d-bad0-1a0fe3951ea6>
-WARC-Target-URI: https://music.apple.com/gb/album/993998924
-WARC-Date: 2021-12-11T20:26:46.626Z
+WARC-Concurrent-To: <urn:uuid:40825ced-579c-4313-8ec8-256a205613ba>
+WARC-Target-URI: https://music.apple.com/gb/album/123456789
+WARC-Date: 2022-03-16T09:53:50.261Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:19e56dc5-c504-48d5-8041-d14b2eb39be4>
+WARC-Record-ID: <urn:uuid:e86401f6-b411-4b1e-acdb-84a476f57a47>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:7d3e4b7e2f0da1393cb9e167963d4f7eb941c600b3ef5eefff1f1f015c0ad645
-WARC-Block-Digest: sha256:7d3e4b7e2f0da1393cb9e167963d4f7eb941c600b3ef5eefff1f1f015c0ad645
+WARC-Payload-Digest: sha256:9726ace75ac878f373c4b86daada7d37fa301f7424371d664c7e6836560fed02
+WARC-Block-Digest: sha256:9726ace75ac878f373c4b86daada7d37fa301f7424371d664c7e6836560fed02
 Content-Length: 409
 
-harEntryId: 342c8bf8904e846d3f83a1b5f0ce10ca
+harEntryId: 53ade59dbe75100d8953739006c60512
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:46.281Z
-time: 326
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":326,"receive":0,"ssl":-1}
+startedDateTime: 2022-03-16T09:53:49.916Z
+time: 340
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":340,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 61
 warcRequestCookies: []
-warcResponseHeadersSize: 1648
+warcResponseHeadersSize: 1639
 warcResponseCookies: [{"name":"geo","value":"NL","path":"/","domain":".apple.com"}]
 responseDecoded: false
 
 
 WARC/1.1
-WARC-Target-URI: https://music.apple.com/gb/album/993998924
-WARC-Date: 2021-12-11T20:26:46.626Z
+WARC-Target-URI: https://music.apple.com/gb/album/123456789
+WARC-Date: 2022-03-16T09:53:50.260Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:245ed845-0ef7-426d-bad0-1a0fe3951ea6>
+WARC-Record-ID: <urn:uuid:40825ced-579c-4313-8ec8-256a205613ba>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:f6fb7ee2b130ac34e10d4e2e879fd23895cc17fed4e1256860d16db3a7b4f702
-WARC-Block-Digest: sha256:e04932ec61d470915515742cf74a51eb8058da5e532934eec986601b8bc38cf8
-Content-Length: 13317
+WARC-Payload-Digest: sha256:1937279fedcbd6f6892c57b94e20cfe481aed040142ce2301d2e04f0036a23d7
+WARC-Block-Digest: sha256:32ef78ce2a23a156d569505f07dffc3cfc7f4968376a359422a7d2d970fcef6a
+Content-Length: 13306
 
 HTTP/1.1 200 OK
 cache-control: public, max-age=60
 connection: close
 content-encoding: gzip
-content-length: 4037
+content-length: 4039
 content-security-policy: default-src 'self' https://*.apple.com; img-src 'self' https://*.apple.com https://*.mzstatic.com artwork: data:; style-src 'self' https://*.apple.com 'unsafe-inline'; script-src 'self' https://*.apple.com blob: 'sha256-4ywTGAe4rEpoHt8XkjbkdOWklMJ/1Py/x6b3/aGbtSQ=' 'unsafe-eval'; connect-src 'self' https://*.apple.com https://*.applemusic.com https://*.mzstatic.com; media-src 'self' https://*.apple.com https://*.applemusic.com https://*.mzstatic.com blob:; child-src 'self' https://*.apple.com musics: blob: itms: itmss:; frame-ancestors 'none'; block-all-mixed-content ;
 content-type: text/html; charset=utf-8
-date: Sat, 11 Dec 2021 20:26:46 GMT
+date: Wed, 16 Mar 2022 09:53:50 GMT
 server: daiquiri/3.0.0
 set-cookie: geo=NL; path=/; domain=.apple.com
 strict-transport-security: max-age=31536000; includeSubDomains
 vary: Accept-Encoding, X-Apple-Store-Front, Cookie, Accept-Encoding
-x-apple-jingle-correlation-key: JCQII44XD6HSSYEJO6MY4VGA7Q
+x-apple-jingle-correlation-key: 3VLVQZNDLBQSEZVJR6TSAZIVC4
 x-apple-partner: origin.0
-x-cache: TCP_MISS from a2-19-195-44.deploy.akamaitechnologies.com (AkamaiGHost/10.4.6-37171458) (-)
-x-cache-remote: TCP_REFRESH_MISS from a2-19-195-61.deploy.akamaitechnologies.com (AkamaiGHost/10.4.6-37171458) (S)
+x-cache: TCP_MISS from a2-19-195-44.deploy.akamaitechnologies.com (AkamaiGHost/10.7.3-39449967) (-)
+x-cache-remote: TCP_MISS from a2-22-54-207.deploy.akamaitechnologies.com (AkamaiGHost/10.7.3-39449967) (-)
 x-content-type-options: nosniff
-x-daiquiri-instance: daiquiri:47691001:st44p00it-hyhk16124001:7987:21RELEASE198:daiquiri-amp-store-shared-ext-003-st
+x-daiquiri-instance: daiquiri:48215001:st44p00it-hyhk15044901:7987:22RELEASE24:daiquiri-amp-store-shared-ext-001-st
 x-frame-options: DENY
-x-true-cache-key: /L/music.apple.com/gb/album/993998924 vcd=2897 ci2=///USERCOUNTRY=NL
+x-true-cache-key: /L/music.apple.com/gb/album/123456789 vcd=2897 ci2=///USERCOUNTRY=NL
 x-xss-protection: 1; mode=block
-x-pollyjs-finalurl: https://music.apple.com/gb/album/993998924
+x-pollyjs-finalurl: https://music.apple.com/gb/album/123456789
 
 <!DOCTYPE html><html prefix="og: http://ogp.me/ns#"  dir="ltr" lang="en-GB"><head>
     <meta charset="utf-8">
@@ -103,12 +103,12 @@ x-pollyjs-finalurl: https://music.apple.com/gb/album/993998924
     <link rel="preconnect" href="https://js-cdn.music.apple.com" crossorigin="">
 
     
-<meta name="desktop-music-app/config/environment" content="%7B%22modulePrefix%22%3A%22desktop-music-app%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22historyLocationType%22%3A%22history%22%2C%22iTunesHistoryLocationType%22%3A%22desktop-music-app%22%2C%22historySupportMiddleware%22%3Atrue%2C%22cwcVersionHash%22%3A%22a7145d35%22%2C%22viewportConfig%22%3A%7B%22viewportDidScroll%22%3Afalse%2C%22viewportTolerance%22%3A%7B%22top%22%3A200%2C%22left%22%3A100%2C%22bottom%22%3A200%2C%22right%22%3A100%7D%7D%2C%22LocaleSwitcher%22%3A%7B%22locKeys%22%3A%7B%22ModalTitleText%22%3A%22FUSE.WEB.CountrySelector.Title%22%2C%22AfricaMiddleEastIndia%22%3A%22FUSE.WEB.CountrySelector.Region.AfricaMiddleEastIndia%22%2C%22AsiaPacific%22%3A%22FUSE.WEB.CountrySelector.Region.AsiaPacific%22%2C%22Europe%22%3A%22FUSE.WEB.CountrySelector.Region.Europe%22%2C%22LatinAmericaCaribbean%22%3A%22FUSE.WEB.CountrySelector.Region.LatinAmericaCaribbean%22%2C%22USCanadaPuertoRico%22%3A%22FUSE.WEB.CountrySelector.Region.USCanadaPuertoRico%22%2C%22HeaderPrompt%22%3A%22FUSE.WEB.CountrySelector.Header.Prompt%22%2C%22HeaderDoneButton%22%3A%22FUSE.WEB.CountrySelector.Done%22%2C%22HeaderDropdownPrompt%22%3A%22FUSE.WEB.CountrySelector.ChooseOption%22%7D%7D%2C%22SASSKIT_GENERATOR%22%3A%7B%22VIEWPORT_CONFIG%22%3A%7B%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%7D%7D%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Function%22%3Afalse%2C%22String%22%3Afalse%2C%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22i18n%22%3A%7B%22defaultLocale%22%3A%22en-us%22%7D%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22routerScroll%22%3A%7B%22MAX_ATTEMPTS%22%3A300%2C%22scrollWhenIdle%22%3Atrue%7D%2C%22APP%22%3A%7B%22SPINNER_DELAY%22%3A1500%2C%22SONGS_LIST_SPINNER_DELAY%22%3A750%2C%22FAIL_SPINNER_DELAY%22%3A5000%2C%22LIBRARY_CHANGE_DELAY_FOR_REFRESH%22%3A3000%2C%22PLAY_SPINNER_DELAY%22%3A2000%2C%22PLAYBACK_DELAY%22%3A2500%2C%22SHARING_TIMER%22%3A1200%2C%22ADD_PRODUCT_TIMER%22%3A5000%2C%22SEARCH_HINTS_TIMER%22%3A200%2C%22COMMERCE_MODAL_OPEN%22%3A250%2C%22SEARCH_METRICS_DELAY%22%3A1000%2C%22SHELF_ITEMS_UNTIL_LAZY%22%3A6%2C%22REFRESH_JS_TIMER%22%3A1800000%2C%22FOLDER_EXPAND_DELAY%22%3A1000%2C%22tvMoviesRatingsUrl%22%3A%22https%3A%2F%2Fdesktop-store.itunes.apple.com%2FmovieTvRatingsAdvisory%2F%22%2C%22socialOnboardingInvite%22%3A%22https%3A%2F%2Fitunes.apple.com%2Fdeeplink%3Fp%3Dsharing%26app%3Dmusic%22%2C%22manageAppleIdURL%22%3A%22https%3A%2F%2Fappleid.apple.com%2Faccount%2Fmanage%22%2C%22iCloudSettingUrl%22%3A%22https%3A%2F%2Fsetup.icloud.com%2Femail%2Fprefs%2FaccountDetails%3Fpath%3DloadPersonalInfoUI%22%2C%22getMusicSDKAuthorizationsSrv%22%3A%22https%3A%2F%2Fplay.itunes.apple.com%2FWebObjects%2FMZPlay.woa%2Fwa%2FgetMusicSDKAuthorizationsSrv%22%2C%22revokeMusicSDKAuthorizationSrv%22%3A%22https%3A%2F%2Fplay.itunes.apple.com%2FWebObjects%2FMZPlay.woa%2Fwa%2FrevokeMusicSDKAuthorizationSrv%22%2C%22REPLAY_LATEST_YEAR%22%3A2020%2C%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%2C%22name%22%3A%22desktop-music-app%22%2C%22version%22%3A%222150.13.0%2B0f90faa8%22%7D%2C%22METRICS%22%3A%7B%22baseFields%22%3A%7B%22appName%22%3A%22web-music-app%22%2C%22constraintProfiles%22%3A%5B%22AMPWeb%22%5D%2C%22delegateApp%22%3A%22web-music-app%22%7D%2C%22clickstream%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_its_music_main%22%5D%2C%22autoTrackClicks%22%3Atrue%2C%22funnel%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_amp_music_cs_unidentified%22%5D%2C%22constraintProfiles%22%3A%5B%22AMPFunnel%22%5D%7D%2C%22impressions%22%3A%7B%22enabled%22%3Afalse%7D%7D%2C%22impressions%22%3A%7B%22viewableThreshold%22%3A1000%2C%22viewablePercentage%22%3A0.5%7D%2C%22performance%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_amp_music_perf%22%5D%7D%2C%22variant%22%3A%22web%22%7D%2C%22MEDIA_SHELF%22%3A%7B%22GRID_CONFIG%22%3A%7B%221-1-1-2%22%3A%7B%22xsmall%22%3A1%2C%22small%22%3A1%2C%22medium%22%3A1%2C%22large%22%3A2%2C%22xlarge%22%3A2%7D%2C%221-1-2-3%22%3A%7B%22xsmall%22%3A1%2C%22small%22%3A1%2C%22medium%22%3A2%2C%22large%22%3A3%2C%22xlarge%22%3A3%7D%2C%222-2-3-4%22%3A%7B%22xsmall%22%3A2%2C%22small%22%3A2%2C%22medium%22%3A3%2C%22large%22%3A4%2C%22xlarge%22%3A4%7D%2C%22music-radio%22%3A%7B%22xsmall%22%3A3%2C%22small%22%3A3%2C%22medium%22%3A3%2C%22large%22%3A3%2C%22xlarge%22%3A3%7D%7D%2C%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%7D%2C%22MEDIA_API%22%3A%7B%22token%22%3A%22eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNjM5MDg1NjY1LCJleHAiOjE2NTQ2Mzc2NjV9.hjX-hCq2xVAgjOyiYvnlT6vbhBWl-RZETjVRZ6fGiVHaPW_yjsHv_jOJs57mrt-7uNa8kODd1Eo8dc179YkYoQ%22%7D%2C%22MUSIC%22%3A%7B%22BASE_URL%22%3A%22https%3A%2F%2Famp-api.music.apple.com%2Fv1%22%2C%22REALM%22%3A%22amp-music%22%2C%22DEFAULT_TRANSITION%22%3A%22index%22%2C%22TOKEN%22%3A%22eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNTY5MjczNzU1LCJleHAiOjE1ODQ4MjU3NTV9.eVPXnwUaRy-6-Vv5EVoGDiQ4EW96y-L3jxMHsiqDyr38t58KdRX_PfnnMReRFbayOUcgrsP_MKNtqvXn7Hn57g%22%2C%22FEATURES%22%3A%7B%22useDevLocalizations%22%3Afalse%2C%22showDevTools%22%3Afalse%2C%22chameleon%22%3Atrue%2C%22captureLogs%22%3Atrue%7D%7D%2C%22features%22%3A%7B%22AMWEB%22%3Atrue%2C%22RESKIN%22%3Atrue%2C%22CARRY%22%3Afalse%2C%22SOW%22%3Afalse%2C%22FY_2021%22%3Atrue%2C%22GAMMA%22%3Afalse%2C%22DELTA%22%3Afalse%2C%22BETA%22%3Afalse%2C%22DEFAULT%22%3Afalse%7D%2C%22ember-cli-mirage%22%3A%7B%22enabled%22%3Afalse%2C%22usingProxy%22%3Afalse%2C%22useDefaultPassthroughs%22%3Atrue%7D%2C%22ember-cli-content-security-policy%22%3A%7B%22policy%22%3A%22default-src%20'self'%20https%3A%2F%2F*.apple.com%3B%20img-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.mzstatic.com%20artwork%3A%20data%3A%3B%20style-src%20'self'%20https%3A%2F%2F*.apple.com%20'unsafe-inline'%3B%20script-src%20'self'%20https%3A%2F%2F*.apple.com%20blob%3A%20'sha256-4ywTGAe4rEpoHt8XkjbkdOWklMJ%2F1Py%2Fx6b3%2FaGbtSQ%3D'%20'unsafe-eval'%3B%20connect-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.applemusic.com%20https%3A%2F%2F*.mzstatic.com%3B%20media-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.applemusic.com%20https%3A%2F%2F*.mzstatic.com%20blob%3A%3B%20child-src%20'self'%20https%3A%2F%2F*.apple.com%20musics%3A%20blob%3A%20itms%3A%20itmss%3A%3B%20frame-ancestors%20'none'%3B%20block-all-mixed-content%20%3B%22%2C%22reportOnly%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Afalse%7D">
+<meta name="desktop-music-app/config/environment" content="%7B%22modulePrefix%22%3A%22desktop-music-app%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22historyLocationType%22%3A%22history%22%2C%22iTunesHistoryLocationType%22%3A%22desktop-music-app%22%2C%22historySupportMiddleware%22%3Atrue%2C%22cwcVersionHash%22%3A%22a7145d35%22%2C%22viewportConfig%22%3A%7B%22viewportDidScroll%22%3Afalse%2C%22viewportTolerance%22%3A%7B%22top%22%3A200%2C%22left%22%3A100%2C%22bottom%22%3A200%2C%22right%22%3A100%7D%7D%2C%22LocaleSwitcher%22%3A%7B%22locKeys%22%3A%7B%22ModalTitleText%22%3A%22FUSE.WEB.CountrySelector.Title%22%2C%22AfricaMiddleEastIndia%22%3A%22FUSE.WEB.CountrySelector.Region.AfricaMiddleEastIndia%22%2C%22AsiaPacific%22%3A%22FUSE.WEB.CountrySelector.Region.AsiaPacific%22%2C%22Europe%22%3A%22FUSE.WEB.CountrySelector.Region.Europe%22%2C%22LatinAmericaCaribbean%22%3A%22FUSE.WEB.CountrySelector.Region.LatinAmericaCaribbean%22%2C%22USCanadaPuertoRico%22%3A%22FUSE.WEB.CountrySelector.Region.USCanadaPuertoRico%22%2C%22HeaderPrompt%22%3A%22FUSE.WEB.CountrySelector.Header.Prompt%22%2C%22HeaderDoneButton%22%3A%22FUSE.WEB.CountrySelector.Done%22%2C%22HeaderDropdownPrompt%22%3A%22FUSE.WEB.CountrySelector.ChooseOption%22%7D%7D%2C%22SASSKIT_GENERATOR%22%3A%7B%22VIEWPORT_CONFIG%22%3A%7B%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%7D%7D%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Function%22%3Afalse%2C%22String%22%3Afalse%2C%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22i18n%22%3A%7B%22defaultLocale%22%3A%22en-us%22%7D%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22routerScroll%22%3A%7B%22MAX_ATTEMPTS%22%3A300%2C%22scrollWhenIdle%22%3Atrue%7D%2C%22APP%22%3A%7B%22SPINNER_DELAY%22%3A1500%2C%22SONGS_LIST_SPINNER_DELAY%22%3A750%2C%22FAIL_SPINNER_DELAY%22%3A5000%2C%22LIBRARY_CHANGE_DELAY_FOR_REFRESH%22%3A3000%2C%22PLAY_SPINNER_DELAY%22%3A2000%2C%22PLAYBACK_DELAY%22%3A2500%2C%22SHARING_TIMER%22%3A1200%2C%22ADD_PRODUCT_TIMER%22%3A5000%2C%22SEARCH_HINTS_TIMER%22%3A200%2C%22COMMERCE_MODAL_OPEN%22%3A250%2C%22SEARCH_METRICS_DELAY%22%3A1000%2C%22SHELF_ITEMS_UNTIL_LAZY%22%3A6%2C%22REFRESH_JS_TIMER%22%3A1800000%2C%22FOLDER_EXPAND_DELAY%22%3A1000%2C%22tvMoviesRatingsUrl%22%3A%22https%3A%2F%2Fdesktop-store.itunes.apple.com%2FmovieTvRatingsAdvisory%2F%22%2C%22socialOnboardingInvite%22%3A%22https%3A%2F%2Fitunes.apple.com%2Fdeeplink%3Fp%3Dsharing%26app%3Dmusic%22%2C%22manageAppleIdURL%22%3A%22https%3A%2F%2Fappleid.apple.com%2Faccount%2Fmanage%22%2C%22iCloudSettingUrl%22%3A%22https%3A%2F%2Fsetup.icloud.com%2Femail%2Fprefs%2FaccountDetails%3Fpath%3DloadPersonalInfoUI%22%2C%22getMusicSDKAuthorizationsSrv%22%3A%22https%3A%2F%2Fplay.itunes.apple.com%2FWebObjects%2FMZPlay.woa%2Fwa%2FgetMusicSDKAuthorizationsSrv%22%2C%22revokeMusicSDKAuthorizationSrv%22%3A%22https%3A%2F%2Fplay.itunes.apple.com%2FWebObjects%2FMZPlay.woa%2Fwa%2FrevokeMusicSDKAuthorizationSrv%22%2C%22REPLAY_LATEST_YEAR%22%3A2020%2C%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%2C%22name%22%3A%22desktop-music-app%22%2C%22version%22%3A%222210.4.0%2B757b0968%22%7D%2C%22METRICS%22%3A%7B%22baseFields%22%3A%7B%22appName%22%3A%22web-music-app%22%2C%22constraintProfiles%22%3A%5B%22AMPWeb%22%5D%2C%22delegateApp%22%3A%22web-music-app%22%7D%2C%22clickstream%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_its_music_main%22%5D%2C%22autoTrackClicks%22%3Atrue%2C%22funnel%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_amp_music_cs_unidentified%22%5D%2C%22constraintProfiles%22%3A%5B%22AMPFunnel%22%5D%7D%2C%22impressions%22%3A%7B%22enabled%22%3Afalse%7D%7D%2C%22impressions%22%3A%7B%22viewableThreshold%22%3A1000%2C%22viewablePercentage%22%3A0.5%7D%2C%22performance%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_amp_music_perf%22%5D%7D%2C%22variant%22%3A%22web%22%7D%2C%22MEDIA_SHELF%22%3A%7B%22GRID_CONFIG%22%3A%7B%221-1-1-2%22%3A%7B%22xsmall%22%3A1%2C%22small%22%3A1%2C%22medium%22%3A1%2C%22large%22%3A2%2C%22xlarge%22%3A2%7D%2C%221-1-2-3%22%3A%7B%22xsmall%22%3A1%2C%22small%22%3A1%2C%22medium%22%3A2%2C%22large%22%3A3%2C%22xlarge%22%3A3%7D%2C%222-2-3-4%22%3A%7B%22xsmall%22%3A2%2C%22small%22%3A2%2C%22medium%22%3A3%2C%22large%22%3A4%2C%22xlarge%22%3A4%7D%2C%22music-radio%22%3A%7B%22xsmall%22%3A3%2C%22small%22%3A3%2C%22medium%22%3A3%2C%22large%22%3A3%2C%22xlarge%22%3A3%7D%7D%2C%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%7D%2C%22MEDIA_API%22%3A%7B%22token%22%3A%22eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNjQ2NDM1NTgxLCJleHAiOjE2NjE5ODc1ODF9.Ob5bfZBWLDlDkR4r5fNXIjp1Y1G0qY5mP9MVBm1mDFjG701_6AcZS6nwjk-CMJE2b8VLv1JWxKR5j5BDkKxQ7w%22%7D%2C%22MUSIC%22%3A%7B%22BASE_URL%22%3A%22https%3A%2F%2Famp-api.music.apple.com%2Fv1%22%2C%22REALM%22%3A%22amp-music%22%2C%22DEFAULT_TRANSITION%22%3A%22index%22%2C%22TOKEN%22%3A%22eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNTY5MjczNzU1LCJleHAiOjE1ODQ4MjU3NTV9.eVPXnwUaRy-6-Vv5EVoGDiQ4EW96y-L3jxMHsiqDyr38t58KdRX_PfnnMReRFbayOUcgrsP_MKNtqvXn7Hn57g%22%2C%22FEATURES%22%3A%7B%22useDevLocalizations%22%3Afalse%2C%22showDevTools%22%3Afalse%2C%22chameleon%22%3Atrue%2C%22captureLogs%22%3Atrue%7D%7D%2C%22features%22%3A%7B%22AMWEB%22%3Atrue%2C%22RESKIN%22%3Atrue%2C%22CARRY%22%3Afalse%2C%22SOW%22%3Afalse%2C%22FY_2021%22%3Atrue%2C%22GAMMA%22%3Afalse%2C%22DELTA%22%3Afalse%2C%22BETA%22%3Afalse%2C%22DEFAULT%22%3Afalse%7D%2C%22ember-cli-mirage%22%3A%7B%22enabled%22%3Afalse%2C%22usingProxy%22%3Afalse%2C%22useDefaultPassthroughs%22%3Atrue%7D%2C%22ember-cli-content-security-policy%22%3A%7B%22policy%22%3A%22default-src%20'self'%20https%3A%2F%2F*.apple.com%3B%20img-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.mzstatic.com%20artwork%3A%20data%3A%3B%20style-src%20'self'%20https%3A%2F%2F*.apple.com%20'unsafe-inline'%3B%20script-src%20'self'%20https%3A%2F%2F*.apple.com%20blob%3A%20'sha256-4ywTGAe4rEpoHt8XkjbkdOWklMJ%2F1Py%2Fx6b3%2FaGbtSQ%3D'%20'unsafe-eval'%3B%20connect-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.applemusic.com%20https%3A%2F%2F*.mzstatic.com%3B%20media-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.applemusic.com%20https%3A%2F%2F*.mzstatic.com%20blob%3A%3B%20child-src%20'self'%20https%3A%2F%2F*.apple.com%20musics%3A%20blob%3A%20itms%3A%20itmss%3A%3B%20frame-ancestors%20'none'%3B%20block-all-mixed-content%20%3B%22%2C%22reportOnly%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Afalse%7D">
 <!-- EMBER_CLI_FASTBOOT_TITLE --><link rel="stylesheet" name="fonts" href="//www.apple.com/wss/fonts?families=SF+Pro,v4|SF+Pro+Icons,v1&amp;display=swap">
-    <meta name="version" content="2150.13.0">
+    <meta name="version" content="2210.4.0">
 
     <link integrity="" rel="stylesheet" href="/assets/vendor-8d7965ce24c49d54b974569e37339677.css">
-    <link integrity="" rel="stylesheet" href="/assets/desktop-music-app-08dc8910d1482fe06138acd84c165cb8.css">
+    <link integrity="" rel="stylesheet" href="/assets/desktop-music-app-e4514da44a89adc30bac2126a3f63eea.css">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/favicon-180-f10a76334177ea08c0b3b35b0269fe16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon/favicon-32-283b261ac09e23987aae02bdb3cbbbaa.png">
@@ -126,9 +126,9 @@ x-pollyjs-finalurl: https://music.apple.com/gb/album/993998924
             
     
 
-    <script src="/assets/vendor-c48e9d726242338f5c16fb827bf3aa88.js" integrity="sha256-pX/r+FOClbUWlPOhtX5B0H53izQ82yGjgdE/QCQOsPA= sha512-KDfJP2A/kAMtkEqzVpp7+V8FPHdBqJQa9wsKvQN2ME6+x/MGbp4iwFRdO4ZhdlDpGBBDa07S+18tDrq6MmcyJQ=="></script>
-    <script nomodule src="/assets/desktop-music-app-6ef35cb647e7afd820d73606a73aa595.js" integrity="sha256-M3YkyClsYVXV54FlZSvg9PW6Epr+9yn3Jjtbv3wxVHs= sha512-AYvbGy8OzGrARjQHRmW1G4HTAZ4OLzeO91pQJtasDJo9VeSH0l6/SETznMXBnGBYe8nv6ic8lw6COUJNg8lMnA=="></script>
-    <script type="module" src="/assets/desktop-music-app-56b5e258aa92a54eeef7555543d3dcbc.modern.js" data-modern-src="" integrity="sha256-XYShrXXYcdU0paVqvcuQj3AYF0+WVUGQlRXqK2KPPao= sha512-uKOxBfZbgtrEJ/rTZspSe9DvCdQYKiSm2hKFliBgMgAPxqWjBeugrhRip2srFWKZcBNc/HBKelm1ARZiOcaGHw=="></script>
+    <script src="/assets/vendor-7b48192d50765143debe6fad0a6108f8.js" integrity="sha256-v4mFar9LTGUI+uAIsPSRX9uuRj9tz2gPjfBeT2JpV6E= sha512-5bqp7OmEs5D7xGBTpHUufDozslz4gYR1ghlXSPKUR8XiB0KqNbPHYbL/cPgpGUsmFLXC0F9iHN3RKHv48ephFA=="></script>
+    <script nomodule src="/assets/desktop-music-app-e2739eaba6016e6ee3d0bb9d80f5d5c7.js" integrity="sha256-21FFbaPiYDlgKeYC0XjZP7KO3nCrGW49Fok0jpwJ4V8= sha512-UxXMz3m60S3SYW7pPg6i2fBQJCxbmGb78Nvx0QpI9XeXIKIxSNGDxDrKxeqCgsHiQugEiKxkv/O0jV+WeaRAtA=="></script>
+    <script type="module" src="/assets/desktop-music-app-f004dd1999ef15216154e1a594593e74.modern.js" data-modern-src="" integrity="sha256-vvZmoDhYlNAjE8m5ZqNALwfeX2x1hSVxDSm/4bd2xgA= sha512-/pcezNZGNleeWi91feMS2gNJrfAku+sgNhKRYA9ikfZXV/Tzi+nfBU3GjkxvJs6Fr+f7eJMUEuy7imD+o/+ShQ=="></script>
 
     
     

--- a/tests/test-data/__recordings__/apple-music-provider_2401788145/extracting-images_1310741912/throws-on-non-existent-iTunes-release_3050089140.warc
+++ b/tests/test-data/__recordings__/apple-music-provider_2401788145/extracting-images_1310741912/throws-on-non-existent-iTunes-release_3050089140.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: apple music provider/extracting images/throws on non-existent iTunes release
-WARC-Date: 2021-12-11T20:26:47.439Z
+WARC-Date: 2022-03-16T09:53:51.013Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:0f5a0e41-91d4-4612-bb81-1faf9a34c86c>
+WARC-Record-ID: <urn:uuid:986fa54a-6af3-4515-9ab0-b644385d8197>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,76 +12,76 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:99304f6c-f475-4325-8eae-d3e27ee18635>
-WARC-Target-URI: https://itunes.apple.com/gb/album/id993998924
-WARC-Date: 2021-12-11T20:26:47.440Z
+WARC-Concurrent-To: <urn:uuid:fb7ff7ef-069b-4304-9d3b-5f7ddfbde10b>
+WARC-Target-URI: https://itunes.apple.com/gb/album/id123456789
+WARC-Date: 2022-03-16T09:53:51.013Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:3a78abf1-6374-4e61-b751-60a260f1dbe2>
+WARC-Record-ID: <urn:uuid:f422358f-3d6f-45f7-9aa3-487415611605>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:46cd1ed85ca941848e67e7ae0ff88fec91773bdb4f51830cf96a2967507fcb67
+WARC-Block-Digest: sha256:1390a680649cac0689cebe286f30feec08a58d6d8b932009667ea8f6b30df510
 Content-Length: 38
 
-GET /gb/album/id993998924 HTTP/1.1
+GET /gb/album/id123456789 HTTP/1.1
 
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:99304f6c-f475-4325-8eae-d3e27ee18635>
-WARC-Target-URI: https://itunes.apple.com/gb/album/id993998924
-WARC-Date: 2021-12-11T20:26:47.440Z
+WARC-Concurrent-To: <urn:uuid:fb7ff7ef-069b-4304-9d3b-5f7ddfbde10b>
+WARC-Target-URI: https://itunes.apple.com/gb/album/id123456789
+WARC-Date: 2022-03-16T09:53:51.013Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:92274617-91a5-4f9e-a9da-bb6dc34f7e14>
+WARC-Record-ID: <urn:uuid:3f08bf2f-65d9-4705-bd6a-1c31758a8f20>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:79d0157bce2b59419482637aaa8dda0fbbadf68f3e58989a786ac1ca41903543
-WARC-Block-Digest: sha256:79d0157bce2b59419482637aaa8dda0fbbadf68f3e58989a786ac1ca41903543
+WARC-Payload-Digest: sha256:46f5245bb00b2930e2a398145a571cf81d0942d10fb93510d0df234bad0bb560
+WARC-Block-Digest: sha256:46f5245bb00b2930e2a398145a571cf81d0942d10fb93510d0df234bad0bb560
 Content-Length: 409
 
-harEntryId: c9aeae4f214a71d9cdceadba4f0bcb5b
+harEntryId: f2d41230e981702c4ecb552d41741fbf
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:46.631Z
-time: 784
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":784,"receive":0,"ssl":-1}
+startedDateTime: 2022-03-16T09:53:50.264Z
+time: 742
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":742,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 64
 warcRequestCookies: []
-warcResponseHeadersSize: 1640
+warcResponseHeadersSize: 1638
 warcResponseCookies: [{"name":"geo","value":"NL","path":"/","domain":".apple.com"}]
 responseDecoded: false
 
 
 WARC/1.1
-WARC-Target-URI: https://itunes.apple.com/gb/album/id993998924
-WARC-Date: 2021-12-11T20:26:47.439Z
+WARC-Target-URI: https://itunes.apple.com/gb/album/id123456789
+WARC-Date: 2022-03-16T09:53:51.013Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:99304f6c-f475-4325-8eae-d3e27ee18635>
+WARC-Record-ID: <urn:uuid:fb7ff7ef-069b-4304-9d3b-5f7ddfbde10b>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:f6fb7ee2b130ac34e10d4e2e879fd23895cc17fed4e1256860d16db3a7b4f702
-WARC-Block-Digest: sha256:a406c0906cbbc217433fce5582f705dd68c7f3f740a364269b373db45aa130ae
-Content-Length: 13309
+WARC-Payload-Digest: sha256:1937279fedcbd6f6892c57b94e20cfe481aed040142ce2301d2e04f0036a23d7
+WARC-Block-Digest: sha256:6d0d957059e9987d75d29e061044878e79350fe0bb6beb7958d1d83bc4eb8022
+Content-Length: 13305
 
 HTTP/1.1 200 OK
-cache-control: public, max-age=58
+cache-control: public, max-age=54
 connection: close
 content-encoding: gzip
-content-length: 4037
+content-length: 4039
 content-security-policy: default-src 'self' https://*.apple.com; img-src 'self' https://*.apple.com https://*.mzstatic.com artwork: data:; style-src 'self' https://*.apple.com 'unsafe-inline'; script-src 'self' https://*.apple.com blob: 'sha256-4ywTGAe4rEpoHt8XkjbkdOWklMJ/1Py/x6b3/aGbtSQ=' 'unsafe-eval'; connect-src 'self' https://*.apple.com https://*.applemusic.com https://*.mzstatic.com; media-src 'self' https://*.apple.com https://*.applemusic.com https://*.mzstatic.com blob:; child-src 'self' https://*.apple.com musics: blob: itms: itmss:; frame-ancestors 'none'; block-all-mixed-content ;
 content-type: text/html; charset=utf-8
-date: Sat, 11 Dec 2021 20:26:47 GMT
+date: Wed, 16 Mar 2022 09:53:51 GMT
 server: daiquiri/3.0.0
 set-cookie: geo=NL; path=/; domain=.apple.com
 strict-transport-security: max-age=31536000; includeSubDomains
 vary: Accept-Encoding, X-Apple-Store-Front, Cookie, Accept-Encoding
-x-apple-jingle-correlation-key: JCQII44XD6HSSYEJO6MY4VGA7Q
+x-apple-jingle-correlation-key: 3VLVQZNDLBQSEZVJR6TSAZIVC4
 x-apple-partner: origin.0
-x-cache: TCP_MISS from a2-19-195-103.deploy.akamaitechnologies.com (AkamaiGHost/10.4.6-37171458) (-)
-x-cache-remote: TCP_HIT from a2-19-195-44.deploy.akamaitechnologies.com (AkamaiGHost/10.4.6-37171458) (-)
+x-cache: TCP_MISS from a2-19-195-13.deploy.akamaitechnologies.com (AkamaiGHost/10.7.3-39449967) (-)
+x-cache-remote: TCP_HIT from a2-19-195-44.deploy.akamaitechnologies.com (AkamaiGHost/10.7.3-39449967) (-)
 x-content-type-options: nosniff
-x-daiquiri-instance: daiquiri:47691001:st44p00it-hyhk16124001:7987:21RELEASE198:daiquiri-amp-store-shared-ext-003-st
+x-daiquiri-instance: daiquiri:48215001:st44p00it-hyhk15044901:7987:22RELEASE24:daiquiri-amp-store-shared-ext-001-st
 x-frame-options: DENY
-x-true-cache-key: /L/music.apple.com/gb/album/993998924 vcd=2897 ci2=///USERCOUNTRY=NL
+x-true-cache-key: /L/music.apple.com/gb/album/123456789 vcd=2897 ci2=///USERCOUNTRY=NL
 x-xss-protection: 1; mode=block
-x-pollyjs-finalurl: https://music.apple.com/gb/album/993998924
+x-pollyjs-finalurl: https://music.apple.com/gb/album/123456789
 
 <!DOCTYPE html><html prefix="og: http://ogp.me/ns#"  dir="ltr" lang="en-GB"><head>
     <meta charset="utf-8">
@@ -103,12 +103,12 @@ x-pollyjs-finalurl: https://music.apple.com/gb/album/993998924
     <link rel="preconnect" href="https://js-cdn.music.apple.com" crossorigin="">
 
     
-<meta name="desktop-music-app/config/environment" content="%7B%22modulePrefix%22%3A%22desktop-music-app%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22historyLocationType%22%3A%22history%22%2C%22iTunesHistoryLocationType%22%3A%22desktop-music-app%22%2C%22historySupportMiddleware%22%3Atrue%2C%22cwcVersionHash%22%3A%22a7145d35%22%2C%22viewportConfig%22%3A%7B%22viewportDidScroll%22%3Afalse%2C%22viewportTolerance%22%3A%7B%22top%22%3A200%2C%22left%22%3A100%2C%22bottom%22%3A200%2C%22right%22%3A100%7D%7D%2C%22LocaleSwitcher%22%3A%7B%22locKeys%22%3A%7B%22ModalTitleText%22%3A%22FUSE.WEB.CountrySelector.Title%22%2C%22AfricaMiddleEastIndia%22%3A%22FUSE.WEB.CountrySelector.Region.AfricaMiddleEastIndia%22%2C%22AsiaPacific%22%3A%22FUSE.WEB.CountrySelector.Region.AsiaPacific%22%2C%22Europe%22%3A%22FUSE.WEB.CountrySelector.Region.Europe%22%2C%22LatinAmericaCaribbean%22%3A%22FUSE.WEB.CountrySelector.Region.LatinAmericaCaribbean%22%2C%22USCanadaPuertoRico%22%3A%22FUSE.WEB.CountrySelector.Region.USCanadaPuertoRico%22%2C%22HeaderPrompt%22%3A%22FUSE.WEB.CountrySelector.Header.Prompt%22%2C%22HeaderDoneButton%22%3A%22FUSE.WEB.CountrySelector.Done%22%2C%22HeaderDropdownPrompt%22%3A%22FUSE.WEB.CountrySelector.ChooseOption%22%7D%7D%2C%22SASSKIT_GENERATOR%22%3A%7B%22VIEWPORT_CONFIG%22%3A%7B%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%7D%7D%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Function%22%3Afalse%2C%22String%22%3Afalse%2C%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22i18n%22%3A%7B%22defaultLocale%22%3A%22en-us%22%7D%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22routerScroll%22%3A%7B%22MAX_ATTEMPTS%22%3A300%2C%22scrollWhenIdle%22%3Atrue%7D%2C%22APP%22%3A%7B%22SPINNER_DELAY%22%3A1500%2C%22SONGS_LIST_SPINNER_DELAY%22%3A750%2C%22FAIL_SPINNER_DELAY%22%3A5000%2C%22LIBRARY_CHANGE_DELAY_FOR_REFRESH%22%3A3000%2C%22PLAY_SPINNER_DELAY%22%3A2000%2C%22PLAYBACK_DELAY%22%3A2500%2C%22SHARING_TIMER%22%3A1200%2C%22ADD_PRODUCT_TIMER%22%3A5000%2C%22SEARCH_HINTS_TIMER%22%3A200%2C%22COMMERCE_MODAL_OPEN%22%3A250%2C%22SEARCH_METRICS_DELAY%22%3A1000%2C%22SHELF_ITEMS_UNTIL_LAZY%22%3A6%2C%22REFRESH_JS_TIMER%22%3A1800000%2C%22FOLDER_EXPAND_DELAY%22%3A1000%2C%22tvMoviesRatingsUrl%22%3A%22https%3A%2F%2Fdesktop-store.itunes.apple.com%2FmovieTvRatingsAdvisory%2F%22%2C%22socialOnboardingInvite%22%3A%22https%3A%2F%2Fitunes.apple.com%2Fdeeplink%3Fp%3Dsharing%26app%3Dmusic%22%2C%22manageAppleIdURL%22%3A%22https%3A%2F%2Fappleid.apple.com%2Faccount%2Fmanage%22%2C%22iCloudSettingUrl%22%3A%22https%3A%2F%2Fsetup.icloud.com%2Femail%2Fprefs%2FaccountDetails%3Fpath%3DloadPersonalInfoUI%22%2C%22getMusicSDKAuthorizationsSrv%22%3A%22https%3A%2F%2Fplay.itunes.apple.com%2FWebObjects%2FMZPlay.woa%2Fwa%2FgetMusicSDKAuthorizationsSrv%22%2C%22revokeMusicSDKAuthorizationSrv%22%3A%22https%3A%2F%2Fplay.itunes.apple.com%2FWebObjects%2FMZPlay.woa%2Fwa%2FrevokeMusicSDKAuthorizationSrv%22%2C%22REPLAY_LATEST_YEAR%22%3A2020%2C%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%2C%22name%22%3A%22desktop-music-app%22%2C%22version%22%3A%222150.13.0%2B0f90faa8%22%7D%2C%22METRICS%22%3A%7B%22baseFields%22%3A%7B%22appName%22%3A%22web-music-app%22%2C%22constraintProfiles%22%3A%5B%22AMPWeb%22%5D%2C%22delegateApp%22%3A%22web-music-app%22%7D%2C%22clickstream%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_its_music_main%22%5D%2C%22autoTrackClicks%22%3Atrue%2C%22funnel%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_amp_music_cs_unidentified%22%5D%2C%22constraintProfiles%22%3A%5B%22AMPFunnel%22%5D%7D%2C%22impressions%22%3A%7B%22enabled%22%3Afalse%7D%7D%2C%22impressions%22%3A%7B%22viewableThreshold%22%3A1000%2C%22viewablePercentage%22%3A0.5%7D%2C%22performance%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_amp_music_perf%22%5D%7D%2C%22variant%22%3A%22web%22%7D%2C%22MEDIA_SHELF%22%3A%7B%22GRID_CONFIG%22%3A%7B%221-1-1-2%22%3A%7B%22xsmall%22%3A1%2C%22small%22%3A1%2C%22medium%22%3A1%2C%22large%22%3A2%2C%22xlarge%22%3A2%7D%2C%221-1-2-3%22%3A%7B%22xsmall%22%3A1%2C%22small%22%3A1%2C%22medium%22%3A2%2C%22large%22%3A3%2C%22xlarge%22%3A3%7D%2C%222-2-3-4%22%3A%7B%22xsmall%22%3A2%2C%22small%22%3A2%2C%22medium%22%3A3%2C%22large%22%3A4%2C%22xlarge%22%3A4%7D%2C%22music-radio%22%3A%7B%22xsmall%22%3A3%2C%22small%22%3A3%2C%22medium%22%3A3%2C%22large%22%3A3%2C%22xlarge%22%3A3%7D%7D%2C%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%7D%2C%22MEDIA_API%22%3A%7B%22token%22%3A%22eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNjM5MDg1NjY1LCJleHAiOjE2NTQ2Mzc2NjV9.hjX-hCq2xVAgjOyiYvnlT6vbhBWl-RZETjVRZ6fGiVHaPW_yjsHv_jOJs57mrt-7uNa8kODd1Eo8dc179YkYoQ%22%7D%2C%22MUSIC%22%3A%7B%22BASE_URL%22%3A%22https%3A%2F%2Famp-api.music.apple.com%2Fv1%22%2C%22REALM%22%3A%22amp-music%22%2C%22DEFAULT_TRANSITION%22%3A%22index%22%2C%22TOKEN%22%3A%22eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNTY5MjczNzU1LCJleHAiOjE1ODQ4MjU3NTV9.eVPXnwUaRy-6-Vv5EVoGDiQ4EW96y-L3jxMHsiqDyr38t58KdRX_PfnnMReRFbayOUcgrsP_MKNtqvXn7Hn57g%22%2C%22FEATURES%22%3A%7B%22useDevLocalizations%22%3Afalse%2C%22showDevTools%22%3Afalse%2C%22chameleon%22%3Atrue%2C%22captureLogs%22%3Atrue%7D%7D%2C%22features%22%3A%7B%22AMWEB%22%3Atrue%2C%22RESKIN%22%3Atrue%2C%22CARRY%22%3Afalse%2C%22SOW%22%3Afalse%2C%22FY_2021%22%3Atrue%2C%22GAMMA%22%3Afalse%2C%22DELTA%22%3Afalse%2C%22BETA%22%3Afalse%2C%22DEFAULT%22%3Afalse%7D%2C%22ember-cli-mirage%22%3A%7B%22enabled%22%3Afalse%2C%22usingProxy%22%3Afalse%2C%22useDefaultPassthroughs%22%3Atrue%7D%2C%22ember-cli-content-security-policy%22%3A%7B%22policy%22%3A%22default-src%20'self'%20https%3A%2F%2F*.apple.com%3B%20img-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.mzstatic.com%20artwork%3A%20data%3A%3B%20style-src%20'self'%20https%3A%2F%2F*.apple.com%20'unsafe-inline'%3B%20script-src%20'self'%20https%3A%2F%2F*.apple.com%20blob%3A%20'sha256-4ywTGAe4rEpoHt8XkjbkdOWklMJ%2F1Py%2Fx6b3%2FaGbtSQ%3D'%20'unsafe-eval'%3B%20connect-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.applemusic.com%20https%3A%2F%2F*.mzstatic.com%3B%20media-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.applemusic.com%20https%3A%2F%2F*.mzstatic.com%20blob%3A%3B%20child-src%20'self'%20https%3A%2F%2F*.apple.com%20musics%3A%20blob%3A%20itms%3A%20itmss%3A%3B%20frame-ancestors%20'none'%3B%20block-all-mixed-content%20%3B%22%2C%22reportOnly%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Afalse%7D">
+<meta name="desktop-music-app/config/environment" content="%7B%22modulePrefix%22%3A%22desktop-music-app%22%2C%22environment%22%3A%22production%22%2C%22rootURL%22%3A%22%2F%22%2C%22historyLocationType%22%3A%22history%22%2C%22iTunesHistoryLocationType%22%3A%22desktop-music-app%22%2C%22historySupportMiddleware%22%3Atrue%2C%22cwcVersionHash%22%3A%22a7145d35%22%2C%22viewportConfig%22%3A%7B%22viewportDidScroll%22%3Afalse%2C%22viewportTolerance%22%3A%7B%22top%22%3A200%2C%22left%22%3A100%2C%22bottom%22%3A200%2C%22right%22%3A100%7D%7D%2C%22LocaleSwitcher%22%3A%7B%22locKeys%22%3A%7B%22ModalTitleText%22%3A%22FUSE.WEB.CountrySelector.Title%22%2C%22AfricaMiddleEastIndia%22%3A%22FUSE.WEB.CountrySelector.Region.AfricaMiddleEastIndia%22%2C%22AsiaPacific%22%3A%22FUSE.WEB.CountrySelector.Region.AsiaPacific%22%2C%22Europe%22%3A%22FUSE.WEB.CountrySelector.Region.Europe%22%2C%22LatinAmericaCaribbean%22%3A%22FUSE.WEB.CountrySelector.Region.LatinAmericaCaribbean%22%2C%22USCanadaPuertoRico%22%3A%22FUSE.WEB.CountrySelector.Region.USCanadaPuertoRico%22%2C%22HeaderPrompt%22%3A%22FUSE.WEB.CountrySelector.Header.Prompt%22%2C%22HeaderDoneButton%22%3A%22FUSE.WEB.CountrySelector.Done%22%2C%22HeaderDropdownPrompt%22%3A%22FUSE.WEB.CountrySelector.ChooseOption%22%7D%7D%2C%22SASSKIT_GENERATOR%22%3A%7B%22VIEWPORT_CONFIG%22%3A%7B%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%7D%7D%2C%22EmberENV%22%3A%7B%22FEATURES%22%3A%7B%7D%2C%22EXTEND_PROTOTYPES%22%3A%7B%22Function%22%3Afalse%2C%22String%22%3Afalse%2C%22Date%22%3Afalse%7D%2C%22_APPLICATION_TEMPLATE_WRAPPER%22%3Afalse%2C%22_DEFAULT_ASYNC_OBSERVERS%22%3Atrue%2C%22_JQUERY_INTEGRATION%22%3Afalse%2C%22_TEMPLATE_ONLY_GLIMMER_COMPONENTS%22%3Atrue%7D%2C%22i18n%22%3A%7B%22defaultLocale%22%3A%22en-us%22%7D%2C%22fastboot%22%3A%7B%22hostWhitelist%22%3A%5B%7B%7D%5D%7D%2C%22routerScroll%22%3A%7B%22MAX_ATTEMPTS%22%3A300%2C%22scrollWhenIdle%22%3Atrue%7D%2C%22APP%22%3A%7B%22SPINNER_DELAY%22%3A1500%2C%22SONGS_LIST_SPINNER_DELAY%22%3A750%2C%22FAIL_SPINNER_DELAY%22%3A5000%2C%22LIBRARY_CHANGE_DELAY_FOR_REFRESH%22%3A3000%2C%22PLAY_SPINNER_DELAY%22%3A2000%2C%22PLAYBACK_DELAY%22%3A2500%2C%22SHARING_TIMER%22%3A1200%2C%22ADD_PRODUCT_TIMER%22%3A5000%2C%22SEARCH_HINTS_TIMER%22%3A200%2C%22COMMERCE_MODAL_OPEN%22%3A250%2C%22SEARCH_METRICS_DELAY%22%3A1000%2C%22SHELF_ITEMS_UNTIL_LAZY%22%3A6%2C%22REFRESH_JS_TIMER%22%3A1800000%2C%22FOLDER_EXPAND_DELAY%22%3A1000%2C%22tvMoviesRatingsUrl%22%3A%22https%3A%2F%2Fdesktop-store.itunes.apple.com%2FmovieTvRatingsAdvisory%2F%22%2C%22socialOnboardingInvite%22%3A%22https%3A%2F%2Fitunes.apple.com%2Fdeeplink%3Fp%3Dsharing%26app%3Dmusic%22%2C%22manageAppleIdURL%22%3A%22https%3A%2F%2Fappleid.apple.com%2Faccount%2Fmanage%22%2C%22iCloudSettingUrl%22%3A%22https%3A%2F%2Fsetup.icloud.com%2Femail%2Fprefs%2FaccountDetails%3Fpath%3DloadPersonalInfoUI%22%2C%22getMusicSDKAuthorizationsSrv%22%3A%22https%3A%2F%2Fplay.itunes.apple.com%2FWebObjects%2FMZPlay.woa%2Fwa%2FgetMusicSDKAuthorizationsSrv%22%2C%22revokeMusicSDKAuthorizationSrv%22%3A%22https%3A%2F%2Fplay.itunes.apple.com%2FWebObjects%2FMZPlay.woa%2Fwa%2FrevokeMusicSDKAuthorizationSrv%22%2C%22REPLAY_LATEST_YEAR%22%3A2020%2C%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%2C%22name%22%3A%22desktop-music-app%22%2C%22version%22%3A%222210.4.0%2B757b0968%22%7D%2C%22METRICS%22%3A%7B%22baseFields%22%3A%7B%22appName%22%3A%22web-music-app%22%2C%22constraintProfiles%22%3A%5B%22AMPWeb%22%5D%2C%22delegateApp%22%3A%22web-music-app%22%7D%2C%22clickstream%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_its_music_main%22%5D%2C%22autoTrackClicks%22%3Atrue%2C%22funnel%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_amp_music_cs_unidentified%22%5D%2C%22constraintProfiles%22%3A%5B%22AMPFunnel%22%5D%7D%2C%22impressions%22%3A%7B%22enabled%22%3Afalse%7D%7D%2C%22impressions%22%3A%7B%22viewableThreshold%22%3A1000%2C%22viewablePercentage%22%3A0.5%7D%2C%22performance%22%3A%7B%22enabled%22%3Atrue%2C%22topic%22%3A%5B%22xp_amp_music_perf%22%5D%7D%2C%22variant%22%3A%22web%22%7D%2C%22MEDIA_SHELF%22%3A%7B%22GRID_CONFIG%22%3A%7B%221-1-1-2%22%3A%7B%22xsmall%22%3A1%2C%22small%22%3A1%2C%22medium%22%3A1%2C%22large%22%3A2%2C%22xlarge%22%3A2%7D%2C%221-1-2-3%22%3A%7B%22xsmall%22%3A1%2C%22small%22%3A1%2C%22medium%22%3A2%2C%22large%22%3A3%2C%22xlarge%22%3A3%7D%2C%222-2-3-4%22%3A%7B%22xsmall%22%3A2%2C%22small%22%3A2%2C%22medium%22%3A3%2C%22large%22%3A4%2C%22xlarge%22%3A4%7D%2C%22music-radio%22%3A%7B%22xsmall%22%3A3%2C%22small%22%3A3%2C%22medium%22%3A3%2C%22large%22%3A3%2C%22xlarge%22%3A3%7D%7D%2C%22BREAKPOINTS%22%3A%7B%22xsmall%22%3A%7B%22min%22%3A320%2C%22max%22%3A999%7D%2C%22small%22%3A%7B%22min%22%3A1000%2C%22max%22%3A1259%7D%2C%22medium%22%3A%7B%22min%22%3A1260%2C%22max%22%3A1579%7D%2C%22large%22%3A%7B%22min%22%3A1580%2C%22max%22%3A1939%7D%2C%22xlarge%22%3A%7B%22min%22%3A1940%2C%22content%22%3A1680%7D%7D%7D%2C%22MEDIA_API%22%3A%7B%22token%22%3A%22eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNjQ2NDM1NTgxLCJleHAiOjE2NjE5ODc1ODF9.Ob5bfZBWLDlDkR4r5fNXIjp1Y1G0qY5mP9MVBm1mDFjG701_6AcZS6nwjk-CMJE2b8VLv1JWxKR5j5BDkKxQ7w%22%7D%2C%22MUSIC%22%3A%7B%22BASE_URL%22%3A%22https%3A%2F%2Famp-api.music.apple.com%2Fv1%22%2C%22REALM%22%3A%22amp-music%22%2C%22DEFAULT_TRANSITION%22%3A%22index%22%2C%22TOKEN%22%3A%22eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6IldlYlBsYXlLaWQifQ.eyJpc3MiOiJBTVBXZWJQbGF5IiwiaWF0IjoxNTY5MjczNzU1LCJleHAiOjE1ODQ4MjU3NTV9.eVPXnwUaRy-6-Vv5EVoGDiQ4EW96y-L3jxMHsiqDyr38t58KdRX_PfnnMReRFbayOUcgrsP_MKNtqvXn7Hn57g%22%2C%22FEATURES%22%3A%7B%22useDevLocalizations%22%3Afalse%2C%22showDevTools%22%3Afalse%2C%22chameleon%22%3Atrue%2C%22captureLogs%22%3Atrue%7D%7D%2C%22features%22%3A%7B%22AMWEB%22%3Atrue%2C%22RESKIN%22%3Atrue%2C%22CARRY%22%3Afalse%2C%22SOW%22%3Afalse%2C%22FY_2021%22%3Atrue%2C%22GAMMA%22%3Afalse%2C%22DELTA%22%3Afalse%2C%22BETA%22%3Afalse%2C%22DEFAULT%22%3Afalse%7D%2C%22ember-cli-mirage%22%3A%7B%22enabled%22%3Afalse%2C%22usingProxy%22%3Afalse%2C%22useDefaultPassthroughs%22%3Atrue%7D%2C%22ember-cli-content-security-policy%22%3A%7B%22policy%22%3A%22default-src%20'self'%20https%3A%2F%2F*.apple.com%3B%20img-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.mzstatic.com%20artwork%3A%20data%3A%3B%20style-src%20'self'%20https%3A%2F%2F*.apple.com%20'unsafe-inline'%3B%20script-src%20'self'%20https%3A%2F%2F*.apple.com%20blob%3A%20'sha256-4ywTGAe4rEpoHt8XkjbkdOWklMJ%2F1Py%2Fx6b3%2FaGbtSQ%3D'%20'unsafe-eval'%3B%20connect-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.applemusic.com%20https%3A%2F%2F*.mzstatic.com%3B%20media-src%20'self'%20https%3A%2F%2F*.apple.com%20https%3A%2F%2F*.applemusic.com%20https%3A%2F%2F*.mzstatic.com%20blob%3A%3B%20child-src%20'self'%20https%3A%2F%2F*.apple.com%20musics%3A%20blob%3A%20itms%3A%20itmss%3A%3B%20frame-ancestors%20'none'%3B%20block-all-mixed-content%20%3B%22%2C%22reportOnly%22%3Afalse%7D%2C%22exportApplicationGlobal%22%3Afalse%7D">
 <!-- EMBER_CLI_FASTBOOT_TITLE --><link rel="stylesheet" name="fonts" href="//www.apple.com/wss/fonts?families=SF+Pro,v4|SF+Pro+Icons,v1&amp;display=swap">
-    <meta name="version" content="2150.13.0">
+    <meta name="version" content="2210.4.0">
 
     <link integrity="" rel="stylesheet" href="/assets/vendor-8d7965ce24c49d54b974569e37339677.css">
-    <link integrity="" rel="stylesheet" href="/assets/desktop-music-app-08dc8910d1482fe06138acd84c165cb8.css">
+    <link integrity="" rel="stylesheet" href="/assets/desktop-music-app-e4514da44a89adc30bac2126a3f63eea.css">
 
     <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/favicon-180-f10a76334177ea08c0b3b35b0269fe16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/favicon/favicon-32-283b261ac09e23987aae02bdb3cbbbaa.png">
@@ -126,9 +126,9 @@ x-pollyjs-finalurl: https://music.apple.com/gb/album/993998924
             
     
 
-    <script src="/assets/vendor-c48e9d726242338f5c16fb827bf3aa88.js" integrity="sha256-pX/r+FOClbUWlPOhtX5B0H53izQ82yGjgdE/QCQOsPA= sha512-KDfJP2A/kAMtkEqzVpp7+V8FPHdBqJQa9wsKvQN2ME6+x/MGbp4iwFRdO4ZhdlDpGBBDa07S+18tDrq6MmcyJQ=="></script>
-    <script nomodule src="/assets/desktop-music-app-6ef35cb647e7afd820d73606a73aa595.js" integrity="sha256-M3YkyClsYVXV54FlZSvg9PW6Epr+9yn3Jjtbv3wxVHs= sha512-AYvbGy8OzGrARjQHRmW1G4HTAZ4OLzeO91pQJtasDJo9VeSH0l6/SETznMXBnGBYe8nv6ic8lw6COUJNg8lMnA=="></script>
-    <script type="module" src="/assets/desktop-music-app-56b5e258aa92a54eeef7555543d3dcbc.modern.js" data-modern-src="" integrity="sha256-XYShrXXYcdU0paVqvcuQj3AYF0+WVUGQlRXqK2KPPao= sha512-uKOxBfZbgtrEJ/rTZspSe9DvCdQYKiSm2hKFliBgMgAPxqWjBeugrhRip2srFWKZcBNc/HBKelm1ARZiOcaGHw=="></script>
+    <script src="/assets/vendor-7b48192d50765143debe6fad0a6108f8.js" integrity="sha256-v4mFar9LTGUI+uAIsPSRX9uuRj9tz2gPjfBeT2JpV6E= sha512-5bqp7OmEs5D7xGBTpHUufDozslz4gYR1ghlXSPKUR8XiB0KqNbPHYbL/cPgpGUsmFLXC0F9iHN3RKHv48ephFA=="></script>
+    <script nomodule src="/assets/desktop-music-app-e2739eaba6016e6ee3d0bb9d80f5d5c7.js" integrity="sha256-21FFbaPiYDlgKeYC0XjZP7KO3nCrGW49Fok0jpwJ4V8= sha512-UxXMz3m60S3SYW7pPg6i2fBQJCxbmGb78Nvx0QpI9XeXIKIxSNGDxDrKxeqCgsHiQugEiKxkv/O0jV+WeaRAtA=="></script>
+    <script type="module" src="/assets/desktop-music-app-f004dd1999ef15216154e1a594593e74.modern.js" data-modern-src="" integrity="sha256-vvZmoDhYlNAjE8m5ZqNALwfeX2x1hSVxDSm/4bd2xgA= sha512-/pcezNZGNleeWi91feMS2gNJrfAku+sgNhKRYA9ikfZXV/Tzi+nfBU3GjkxvJs6Fr+f7eJMUEuy7imD+o/+ShQ=="></script>
 
     
     

--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/clears-the-cache-entry-on-failure_963532173.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/clears-the-cache-entry-on-failure_963532173.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/clears the cache entry on failure
-WARC-Date: 2022-01-26T15:23:44.152Z
+WARC-Date: 2022-03-16T09:36:20.622Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:668ab8ea-9327-4a6e-aa3d-956139571022>
+WARC-Record-ID: <urn:uuid:e7c39335-1bf9-4a2a-9274-7757c78b01c8>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:42d2954e-f077-4156-9fc0-12ad2439e9cf>
+WARC-Concurrent-To: <urn:uuid:03d9011a-b2a3-4aab-afbf-e2f4bb5e5fc9>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:44.153Z
+WARC-Date: 2022-03-16T09:36:20.622Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:945e28c2-293b-447c-b04e-dddead5e7e88>
+WARC-Record-ID: <urn:uuid:b4511086-dbe6-44e3-b5b6-7455281bcc6b>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:a1bdef6d1b0f06fe4263adc1f5721a58326bd984be25e93aebddbfc1c4f64504
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:42d2954e-f077-4156-9fc0-12ad2439e9cf>
+WARC-Concurrent-To: <urn:uuid:03d9011a-b2a3-4aab-afbf-e2f4bb5e5fc9>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:44.153Z
+WARC-Date: 2022-03-16T09:36:20.623Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:08577968-f1f1-4abc-8413-d8c42374190a>
+WARC-Record-ID: <urn:uuid:39671028-12d8-404d-9cce-2c08297e2f2c>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:b14617dc7247aa0a7f3d6119ba425f0fd97e00a32f3d4577ffda2d76d3a72484
-WARC-Block-Digest: sha256:b14617dc7247aa0a7f3d6119ba425f0fd97e00a32f3d4577ffda2d76d3a72484
+WARC-Payload-Digest: sha256:b283bd036df8feff9e32859f702f4a8c56f3dfd530bd6783fa64ec5f0e2ea957
+WARC-Block-Digest: sha256:b283bd036df8feff9e32859f702f4a8c56f3dfd530bd6783fa64ec5f0e2ea957
 Content-Length: 644
 
 harEntryId: f14af08925617f9c2183cb046a50c703
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2022-01-26T15:23:43.686Z
+startedDateTime: 2022-03-16T09:36:20.156Z
 time: 464
 timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":464,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 325
 warcRequestCookies: []
 warcResponseHeadersSize: 1066
-warcResponseCookies: [{"name":"__cf_bm","value":"19_Qo6YyME2iVNyaO.SFhZOBm9VVzQX1ZV3aRhKc0jo-1643210624-0-AU2E9TSqwM4TF0qif5xogLsXjqhX8LrKWytdzfiw/uDVbTcgQw4VLtaObn+bDRyhGT4UTNzG42oLIXFYD2GHxNM=","path":"/","expires":"2022-01-26T15:53:44.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"HlTxMGKHJshee3kBq0my52AI5cSSfUhehbgzpZkGyRI-1647423380-0-AUt/Ezs8ViX7rPhsN/26QU+cBk0Nl7rQ21984r6JZO9zfVSxVGtxd8r0nHradvzXhGdLdP2aYwxvaAqhs4vAy0U=","path":"/","expires":"2022-03-16T10:06:20.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:44.152Z
+WARC-Date: 2022-03-16T09:36:20.622Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:42d2954e-f077-4156-9fc0-12ad2439e9cf>
+WARC-Record-ID: <urn:uuid:03d9011a-b2a3-4aab-afbf-e2f4bb5e5fc9>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:28926ad49bc1e2f681558fd8ee9c8be083afedbe78075335146a4fad4e60f706
-WARC-Block-Digest: sha256:88e8c49635f684673b2b28daea73abacb011e7a5e7d4b5bbfd02216aed2de8b9
-Content-Length: 4242
+WARC-Payload-Digest: sha256:3e0947317ef82b7f909497f251b171df2165d77cbaba2939e9ae4b802d8fd1b9
+WARC-Block-Digest: sha256:bc9cb976934e02b7a13f9146bf742b1cffddcebd9de9ce4b9bd1f2b2b17c79a6
+Content-Length: 4386
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6d3abe7f6809715d-DUS
+cf-ray: 6ecc80ffcbf0416f-HAM
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Wed, 26 Jan 2022 15:23:44 GMT
+date: Wed, 16 Mar 2022 09:36:20 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=19_Qo6YyME2iVNyaO.SFhZOBm9VVzQX1ZV3aRhKc0jo-1643210624-0-AU2E9TSqwM4TF0qif5xogLsXjqhX8LrKWytdzfiw/uDVbTcgQw4VLtaObn+bDRyhGT4UTNzG42oLIXFYD2GHxNM=; path=/; expires=Wed, 26-Jan-22 15:53:44 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=HlTxMGKHJshee3kBq0my52AI5cSSfUhehbgzpZkGyRI-1647423380-0-AUt/Ezs8ViX7rPhsN/26QU+cBk0Nl7rQ21984r6JZO9zfVSxVGtxd8r0nHradvzXhGdLdP2aYwxvaAqhs4vAy0U=; path=/; expires=Wed, 16-Mar-22 10:06:20 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:44.004Z","endTime":"2022-01-26T15:23:44.064Z","duration":60287324,"execution":{"resolvers":[]}}}}
+{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-03-16T09:36:20.581Z","endTime":"2022-03-16T09:36:20.622Z","duration":41102199,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-for-subsequent-requests_598889563.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-for-subsequent-requests_598889563.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/reuses the cache entry for subsequent requests
-WARC-Date: 2022-01-26T15:23:41.799Z
+WARC-Date: 2022-03-16T09:36:18.908Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:3cf98b62-1cca-4aaf-82ad-3b7a0a0b227d>
+WARC-Record-ID: <urn:uuid:f53af0fe-ff0c-46f8-84c4-1f89d8c54abe>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:15311fb2-073d-4f72-a8e6-d319ea974134>
+WARC-Concurrent-To: <urn:uuid:35ef15bd-8f90-4283-9619-63d59aa8dc4e>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:41.800Z
+WARC-Date: 2022-03-16T09:36:18.909Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:b1e432de-930a-4efc-9886-d28c98fbf3fd>
+WARC-Record-ID: <urn:uuid:3b014a59-f629-4441-8d89-5686b6a9b13f>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:a1bdef6d1b0f06fe4263adc1f5721a58326bd984be25e93aebddbfc1c4f64504
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:15311fb2-073d-4f72-a8e6-d319ea974134>
+WARC-Concurrent-To: <urn:uuid:35ef15bd-8f90-4283-9619-63d59aa8dc4e>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:41.800Z
+WARC-Date: 2022-03-16T09:36:18.909Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:b0a270f4-bdf7-4620-b05e-035959b6a3b8>
+WARC-Record-ID: <urn:uuid:1a62ef8b-5092-48f2-b288-dbfe14553465>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:e20ea4c9f62a09cff5c78edbf7bace1f733bb00a4127af92eb9ae8f97d91a015
-WARC-Block-Digest: sha256:e20ea4c9f62a09cff5c78edbf7bace1f733bb00a4127af92eb9ae8f97d91a015
-Content-Length: 646
+WARC-Payload-Digest: sha256:d26d9be8b7a7cb8674bf8eec5d489daa1ce8fa560dbdf71cbe0f4425c6e63d24
+WARC-Block-Digest: sha256:d26d9be8b7a7cb8674bf8eec5d489daa1ce8fa560dbdf71cbe0f4425c6e63d24
+Content-Length: 644
 
 harEntryId: f14af08925617f9c2183cb046a50c703
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2022-01-26T15:23:40.623Z
-time: 1171
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1171,"receive":0,"ssl":-1}
+startedDateTime: 2022-03-16T09:36:18.123Z
+time: 782
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":782,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 325
 warcRequestCookies: []
 warcResponseHeadersSize: 1066
-warcResponseCookies: [{"name":"__cf_bm","value":"vK4YtIXWt9CWO88wyItdjZgD0HHShY3aYHGBfFCyVnc-1643210621-0-AeJXkrL+nV2Wl1HZm45jgL+NnWdU06pEBWpsGEawG6TCrjVzZ5NsvJ438uZQK26T2oQ2MmUg2oasLyxwPVevNZI=","path":"/","expires":"2022-01-26T15:53:41.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"325v7H0benK1uw2WOtCwu0EaTkWpAG9Ot6hXTKbsK6g-1647423378-0-AfsXcQgBS/hz4oL/eGkQhkTtLyWWWO/w8e6wNKNlXawrf6CHbTYgOiFNy3W+YaduTXoTcU+bydRL9YCX0IIBft8=","path":"/","expires":"2022-03-16T10:06:18.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:41.799Z
+WARC-Date: 2022-03-16T09:36:18.909Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:15311fb2-073d-4f72-a8e6-d319ea974134>
+WARC-Record-ID: <urn:uuid:35ef15bd-8f90-4283-9619-63d59aa8dc4e>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:f0a32b1941919443b740d6e8202b96cc6464a755c3ac29a0d6000608df81886e
-WARC-Block-Digest: sha256:328b45803f0b206c239ff1b94e648cb2eab06a39710988fa4099a6b051183c09
-Content-Length: 4242
+WARC-Payload-Digest: sha256:d37da967e8b9846ef1f789966ea3e271b6da2665f84ecdbba3a76d2890fea7d6
+WARC-Block-Digest: sha256:66db0b2f57faf30f144f3cb9f5830a73af3c931cc8ff086ddb4354d81a52fbb2
+Content-Length: 4386
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6d3abe6eaf6c1e65-MUC
+cf-ray: 6ecc80f2fa566d79-MUC
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Wed, 26 Jan 2022 15:23:41 GMT
+date: Wed, 16 Mar 2022 09:36:18 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=vK4YtIXWt9CWO88wyItdjZgD0HHShY3aYHGBfFCyVnc-1643210621-0-AeJXkrL+nV2Wl1HZm45jgL+NnWdU06pEBWpsGEawG6TCrjVzZ5NsvJ438uZQK26T2oQ2MmUg2oasLyxwPVevNZI=; path=/; expires=Wed, 26-Jan-22 15:53:41 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=325v7H0benK1uw2WOtCwu0EaTkWpAG9Ot6hXTKbsK6g-1647423378-0-AfsXcQgBS/hz4oL/eGkQhkTtLyWWWO/w8e6wNKNlXawrf6CHbTYgOiFNy3W+YaduTXoTcU+bydRL9YCX0IIBft8=; path=/; expires=Wed, 16-Mar-22 10:06:18 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:41.675Z","endTime":"2022-01-26T15:23:41.720Z","duration":45459599,"execution":{"resolvers":[]}}}}
+{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-03-16T09:36:18.855Z","endTime":"2022-03-16T09:36:18.893Z","duration":38040338,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-while-maximising-images_2688171962.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-while-maximising-images_2688171962.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/reuses the cache entry while maximising images
-WARC-Date: 2022-01-26T15:23:43.682Z
+WARC-Date: 2022-03-16T09:36:20.147Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:12de19e9-ca58-41c8-84bd-1c890780de1f>
+WARC-Record-ID: <urn:uuid:506970de-f818-4409-92e4-dd6a07edeade>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:510c0164-4dd5-48ee-a2db-e1129cbbbc66>
+WARC-Concurrent-To: <urn:uuid:7e20ef98-2de1-4837-81b2-6e3dc46f9e34>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:43.682Z
+WARC-Date: 2022-03-16T09:36:20.148Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:f21a34c0-aa71-49cf-a7a7-5f1011a2e8e2>
+WARC-Record-ID: <urn:uuid:f0ba40bf-f350-44a9-be90-018d26fece50>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:a1bdef6d1b0f06fe4263adc1f5721a58326bd984be25e93aebddbfc1c4f64504
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:510c0164-4dd5-48ee-a2db-e1129cbbbc66>
+WARC-Concurrent-To: <urn:uuid:7e20ef98-2de1-4837-81b2-6e3dc46f9e34>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:43.682Z
+WARC-Date: 2022-03-16T09:36:20.148Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:303df317-cd74-41c8-9387-0c4466a96c2c>
+WARC-Record-ID: <urn:uuid:a573f5e9-b8ba-48e8-9190-2192e51a2539>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:2b9d97e31599d8cedc19d6dbfd042b6725953726a2737f6102c2a1b2aaf343a3
-WARC-Block-Digest: sha256:2b9d97e31599d8cedc19d6dbfd042b6725953726a2737f6102c2a1b2aaf343a3
+WARC-Payload-Digest: sha256:99a34896c15763f423d7a0cf3de71c7566167a823fe8c80dd36b1f4f500f1af8
+WARC-Block-Digest: sha256:99a34896c15763f423d7a0cf3de71c7566167a823fe8c80dd36b1f4f500f1af8
 Content-Length: 646
 
 harEntryId: f14af08925617f9c2183cb046a50c703
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2022-01-26T15:23:41.805Z
-time: 1874
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1874,"receive":0,"ssl":-1}
+startedDateTime: 2022-03-16T09:36:18.913Z
+time: 1224
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1224,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 325
 warcRequestCookies: []
 warcResponseHeadersSize: 1066
-warcResponseCookies: [{"name":"__cf_bm","value":"TEpRsYwK3PzRCp_brsD2O4oQX5EQbuQw2HCRpFCOlOQ-1643210623-0-ActcQSWBj4+Yrc+iWiHpQGYa+g3BssF0alquwLGmv7GzPqDinIwIBc50MYhWxHVh9LLDpt1LL/76P+8OQdu02Qg=","path":"/","expires":"2022-01-26T15:53:43.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"q9YmZHr5..VvWycxzfyBFLGfTz.uqK_Cp149xVgvnf8-1647423380-0-AZgn4+go7I5GLKzKUqX7Ip69NR0HNrp6KXqTUhV7OYi7OeHC4RHwQw/88LWaFzHbDfrfI4AHzHJdCRfVaXkIPAI=","path":"/","expires":"2022-03-16T10:06:20.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:43.682Z
+WARC-Date: 2022-03-16T09:36:20.147Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:510c0164-4dd5-48ee-a2db-e1129cbbbc66>
+WARC-Record-ID: <urn:uuid:7e20ef98-2de1-4837-81b2-6e3dc46f9e34>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:cf1e9d18d9f7414cd6c5debb295e2edc7912581150b82928cbdf90392a15dbb9
-WARC-Block-Digest: sha256:a009750637038a5b980ab1e14327b8bfe218378fbffeb4e5ac2686369288e392
-Content-Length: 4242
+WARC-Payload-Digest: sha256:19b30bfd5146903ab0eca110a46ba67353fdd2b470d13033efdb32e8d014600d
+WARC-Block-Digest: sha256:90b53cfef28749958853b23d225ecc75eaf9d5176833fca6969fd9bcf51fb777
+Content-Length: 4386
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6d3abe73b8ce1bd5-MUC
+cf-ray: 6ecc80f7e93a1e5d-MUC
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Wed, 26 Jan 2022 15:23:43 GMT
+date: Wed, 16 Mar 2022 09:36:20 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=TEpRsYwK3PzRCp_brsD2O4oQX5EQbuQw2HCRpFCOlOQ-1643210623-0-ActcQSWBj4+Yrc+iWiHpQGYa+g3BssF0alquwLGmv7GzPqDinIwIBc50MYhWxHVh9LLDpt1LL/76P+8OQdu02Qg=; path=/; expires=Wed, 26-Jan-22 15:53:43 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=q9YmZHr5..VvWycxzfyBFLGfTz.uqK_Cp149xVgvnf8-1647423380-0-AZgn4+go7I5GLKzKUqX7Ip69NR0HNrp6KXqTUhV7OYi7OeHC4RHwQw/88LWaFzHbDfrfI4AHzHJdCRfVaXkIPAI=; path=/; expires=Wed, 16-Mar-22 10:06:20 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:43.477Z","endTime":"2022-01-26T15:23:43.520Z","duration":42569575,"execution":{"resolvers":[]}}}}
+{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-03-16T09:36:19.813Z","endTime":"2022-03-16T09:36:19.853Z","duration":40661850,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/extracts-covers-for-release_2308446907.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/extracts-covers-for-release_2308446907.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/extracting images/extracts covers for release
-WARC-Date: 2022-01-26T15:23:39.464Z
+WARC-Date: 2022-03-16T09:36:17.251Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:01f65228-51ee-4cfc-be51-031d299cc024>
+WARC-Record-ID: <urn:uuid:b45207a5-a98f-4958-8b20-3ca771b10ebd>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:4c10ee8c-f086-4a28-abc1-8329bd132ba0>
+WARC-Concurrent-To: <urn:uuid:0dfcc507-ca3f-4fc3-8dc7-e4aadd063c12>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:39.466Z
+WARC-Date: 2022-03-16T09:36:17.252Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:54d5d8e7-593e-4197-8fa0-c8410f7d9535>
+WARC-Record-ID: <urn:uuid:ea667777-15d0-44d5-960d-4cde66fc9536>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:a1bdef6d1b0f06fe4263adc1f5721a58326bd984be25e93aebddbfc1c4f64504
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:4c10ee8c-f086-4a28-abc1-8329bd132ba0>
+WARC-Concurrent-To: <urn:uuid:0dfcc507-ca3f-4fc3-8dc7-e4aadd063c12>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:39.467Z
+WARC-Date: 2022-03-16T09:36:17.253Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:588745e9-34e6-4aed-b8b8-5875a5a3e02d>
+WARC-Record-ID: <urn:uuid:da5eded1-453f-4f0c-b9d6-66f3062c700a>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:45a189e6592eb39bbe08f1ed067cdb0551a80e1eb51649341770d2ee944d1d3a
-WARC-Block-Digest: sha256:45a189e6592eb39bbe08f1ed067cdb0551a80e1eb51649341770d2ee944d1d3a
+WARC-Payload-Digest: sha256:203bc818c2da5f59ea38a51e1a1b10ab0abad8b26327cb49c8d930f9aa5d2b69
+WARC-Block-Digest: sha256:203bc818c2da5f59ea38a51e1a1b10ab0abad8b26327cb49c8d930f9aa5d2b69
 Content-Length: 646
 
 harEntryId: f14af08925617f9c2183cb046a50c703
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2022-01-26T15:23:37.497Z
-time: 1954
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1954,"receive":0,"ssl":-1}
+startedDateTime: 2022-03-16T09:36:15.622Z
+time: 1619
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1619,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 325
 warcRequestCookies: []
 warcResponseHeadersSize: 1066
-warcResponseCookies: [{"name":"__cf_bm","value":"KbpWQhdGEMc2c6o.OshCr7F3dd2kzNQSFcjCsxCNkIY-1643210619-0-AZvoGHGxa5lPH5m+di36Gd/1SC79F1icILMAMlDZ1PfOcECcp5tKbHSk30z10CWpZVlJG7qU8exPS2WHVeWlSkU=","path":"/","expires":"2022-01-26T15:53:39.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"i4YldSm6ZkNrFzD926kOCbRCxFCpx9yYDZ2.bx49RqM-1647423377-0-AbtI34Ue+z42w8nLBuiZSKYWQAWzOBqmlAjkRWF4xBzOvWxwS4IIO/3YwDaiax2lGSePLy9Xirb2jTu1QjjqJYw=","path":"/","expires":"2022-03-16T10:06:17.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:39.465Z
+WARC-Date: 2022-03-16T09:36:17.251Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:4c10ee8c-f086-4a28-abc1-8329bd132ba0>
+WARC-Record-ID: <urn:uuid:0dfcc507-ca3f-4fc3-8dc7-e4aadd063c12>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:cfe840c9d0d78c0b5c302be4fd09705f16c30b6dd11bc04e385489eb874e02aa
-WARC-Block-Digest: sha256:e62d1e32fe0712790bca78b28df26c3263e862ffa90d1bca3d7602a96ed044d5
-Content-Length: 4242
+WARC-Payload-Digest: sha256:48cd6bc690793c517ee16445191943e78d335abf3301fcd278b0b239c89d1125
+WARC-Block-Digest: sha256:a1c205a947f66bad71c513e1c59693a84dc24a236013cb1cda326d68967b3476
+Content-Length: 4386
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6d3abe596be96d71-MUC
+cf-ray: 6ecc80e40a139b83-FRA
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Wed, 26 Jan 2022 15:23:39 GMT
+date: Wed, 16 Mar 2022 09:36:17 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=KbpWQhdGEMc2c6o.OshCr7F3dd2kzNQSFcjCsxCNkIY-1643210619-0-AZvoGHGxa5lPH5m+di36Gd/1SC79F1icILMAMlDZ1PfOcECcp5tKbHSk30z10CWpZVlJG7qU8exPS2WHVeWlSkU=; path=/; expires=Wed, 26-Jan-22 15:53:39 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=i4YldSm6ZkNrFzD926kOCbRCxFCpx9yYDZ2.bx49RqM-1647423377-0-AbtI34Ue+z42w8nLBuiZSKYWQAWzOBqmlAjkRWF4xBzOvWxwS4IIO/3YwDaiax2lGSePLy9Xirb2jTu1QjjqJYw=; path=/; expires=Wed, 16-Mar-22 10:06:17 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/5DRUAf2hnDKQ9X8eCha7SGNgcRoQdLPOy5Gk3IWwB3o/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","webpUrl":"https://i.discogs.com/inFmofNjSqpna_BBL4eMZc_3tZdzR3jMbpeA_srVw2c/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:39.318Z","endTime":"2022-01-26T15:23:39.347Z","duration":29175813,"execution":{"resolvers":[]}}}}
+{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}},"extensions":{"tracing":{"version":1,"startTime":"2022-03-16T09:36:17.121Z","endTime":"2022-03-16T09:36:17.160Z","duration":38982950,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/throws-on-non-existent-release_1189313548.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/throws-on-non-existent-release_1189313548.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/extracting images/throws on non-existent release
-WARC-Date: 2022-01-26T15:23:40.615Z
+WARC-Date: 2022-03-16T09:36:18.108Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:5ea0f631-a249-466e-a818-eaca7162b9f4>
+WARC-Record-ID: <urn:uuid:56ef83d9-1013-4460-85bc-f5a704831441>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:1f2935b4-01dc-4b6d-b6ac-586cfbb2987c>
+WARC-Concurrent-To: <urn:uuid:b2ae7818-dd7a-489c-bb36-5fbb530d99ee>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:40.616Z
+WARC-Date: 2022-03-16T09:36:18.109Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:6d6be006-050b-477a-aaa7-2c8177e666ea>
+WARC-Record-ID: <urn:uuid:944b56d3-01fe-424a-aaf0-91e51e127c67>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:949bc3a3028bf2521b366401edf458b4b1eb82658136f5fe211ce5a0f974cb97
@@ -27,55 +27,55 @@ GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:1f2935b4-01dc-4b6d-b6ac-586cfbb2987c>
+WARC-Concurrent-To: <urn:uuid:b2ae7818-dd7a-489c-bb36-5fbb530d99ee>
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:40.616Z
+WARC-Date: 2022-03-16T09:36:18.109Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:8a608943-c4d5-4308-8772-427829bb67f9>
+WARC-Record-ID: <urn:uuid:84194334-0b12-4a2f-afed-f29211f26365>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:f8cfdf26a0ccbaa73f58fb7a34104ae816d8aa3bda5e77288534fb72f2a1bc85
-WARC-Block-Digest: sha256:f8cfdf26a0ccbaa73f58fb7a34104ae816d8aa3bda5e77288534fb72f2a1bc85
-Content-Length: 646
+WARC-Payload-Digest: sha256:554f017ddc4861766f039bc22f551a376ccd81ab509ad1a021376b5f795695ea
+WARC-Block-Digest: sha256:554f017ddc4861766f039bc22f551a376ccd81ab509ad1a021376b5f795695ea
+Content-Length: 644
 
 harEntryId: 474e9e5a520399c60171a9d1f8584295
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2022-01-26T15:23:39.475Z
-time: 1138
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1138,"receive":0,"ssl":-1}
+startedDateTime: 2022-03-16T09:36:17.259Z
+time: 848
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":848,"receive":0,"ssl":-1}
 warcRequestHeadersSize: 326
 warcRequestCookies: []
 warcResponseHeadersSize: 1067
-warcResponseCookies: [{"name":"__cf_bm","value":".MqICMdWBQNYbISo_QklX327SJdB9.QfBlQ_G.9eBQ0-1643210620-0-Aev/ELoC1ZyV0PMwmJIVEZpxEHOFSPXtmolPyhVmaLdVu7aUtciKwEK/JfLZy+k4qhvm6Su/J0gVzXfu6zdxfbk=","path":"/","expires":"2022-01-26T15:53:40.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseCookies: [{"name":"__cf_bm","value":"Vj3LdtQthrnT61e5uDwRGS6GF.lxmR86PvQwE.nx6YM-1647423378-0-AQnWHWSh49LgFNoP8UYEkB2TdSf5+mz8WhDavosujmqJaa6oP59TCvO87GonITZQaF7sp0HdkJ1MvBqkemUI5JI=","path":"/","expires":"2022-03-16T10:06:18.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
-WARC-Date: 2022-01-26T15:23:40.615Z
+WARC-Date: 2022-03-16T09:36:18.108Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:1f2935b4-01dc-4b6d-b6ac-586cfbb2987c>
+WARC-Record-ID: <urn:uuid:b2ae7818-dd7a-489c-bb36-5fbb530d99ee>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:6d6d18eb4510da5561334e0d4fb7b48e49c55f91ff429520af017588700198af
-WARC-Block-Digest: sha256:6d7727aafcee9fea80fbf24d550b87816227c881561e420be7e7200d76794849
-Content-Length: 1274
+WARC-Payload-Digest: sha256:eea37aafeb465a51dada6519d223930a95ac2e766bac31b8e4e3878da3a23215
+WARC-Block-Digest: sha256:a4d6490178c2cdc131f5248a265faee9476e30dfd9f5ff9d3ab5980b401f5885
+Content-Length: 1275
 
 HTTP/1.1 200 OK
 cf-cache-status: DYNAMIC
-cf-ray: 6d3abe669d1c6d7f-MUC
+cf-ray: 6ecc80ed9bb8995d-FRA
 connection: close
 content-encoding: gzip
 content-type: application/json; charset=utf-8
-date: Wed, 26 Jan 2022 15:23:40 GMT
+date: Wed, 16 Mar 2022 09:36:18 GMT
 expect-ct: max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
 server: cloudflare
-set-cookie: __cf_bm=.MqICMdWBQNYbISo_QklX327SJdB9.QfBlQ_G.9eBQ0-1643210620-0-Aev/ELoC1ZyV0PMwmJIVEZpxEHOFSPXtmolPyhVmaLdVu7aUtciKwEK/JfLZy+k4qhvm6Su/J0gVzXfu6zdxfbk=; path=/; expires=Wed, 26-Jan-22 15:53:40 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+set-cookie: __cf_bm=Vj3LdtQthrnT61e5uDwRGS6GF.lxmR86PvQwE.nx6YM-1647423378-0-AQnWHWSh49LgFNoP8UYEkB2TdSf5+mz8WhDavosujmqJaa6oP59TCvO87GonITZQaF7sp0HdkJ1MvBqkemUI5JI=; path=/; expires=Wed, 16-Mar-22 10:06:18 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
 strict-transport-security: max-age=15724800
 transfer-encoding: chunked
 vary: Origin
 x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, sentry=0
 x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%2213e41f41a02b02d0a7e855a71e1a02478fd2fb0a2d104b54931d649e1d7c6ecd%22%7D%7D
 
-{"data":{"release":null},"extensions":{"tracing":{"version":1,"startTime":"2022-01-26T15:23:40.440Z","endTime":"2022-01-26T15:23:40.458Z","duration":17215960,"execution":{"resolvers":[]}}}}
+{"data":{"release":null},"extensions":{"tracing":{"version":1,"startTime":"2022-03-16T09:36:17.931Z","endTime":"2022-03-16T09:36:18.108Z","duration":176848731,"execution":{"resolvers":[]}}}}
 
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/apple_music.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/apple_music.test.ts
@@ -95,11 +95,11 @@ describe('apple music provider', () => {
 
         const extractionFailedCases = [{
             desc: 'non-existent Apple Music release',
-            url: 'https://music.apple.com/gb/album/993998924',
+            url: 'https://music.apple.com/gb/album/123456789',
             errorMessage: 'Apple Music release does not exist',
         }, {
             desc: 'non-existent iTunes release',
-            url: 'https://itunes.apple.com/gb/album/id993998924',
+            url: 'https://itunes.apple.com/gb/album/id123456789',
             errorMessage: 'Apple Music release does not exist',
         }];
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/discogs.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/discogs.test.ts
@@ -42,15 +42,15 @@ describe('discogs provider', () => {
             numImages: 3,
             expectedImages: [{
                 index: 0,
-                urlPart: '/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg',
+                urlPart: '/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg',
                 types: undefined,
             }, {
                 index: 1,
-                urlPart: '/VKFNcm02R4h4UfP9lF4qVq7KkdR8XGTrSyn2sGUH8xU/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy00MDQ4Lmpw/ZWc.jpeg',
+                urlPart: '/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg',
                 types: undefined,
             }, {
                 index: 2,
-                urlPart: '/kL5esHGWNIcGaRvR2m-B1sK2OqvKJro8t2zRrsqQzOs/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTQ4ODA2/NzM0MS0yODcyLmpw/ZWc.jpeg',
+                urlPart: '/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg',
                 types: undefined,
             }],
         }];
@@ -67,15 +67,15 @@ describe('discogs provider', () => {
 
     describe('maximising image', () => {
         it('finds the image', async () => {
-            const maxUrl = await DiscogsProvider.maximiseImage(new URL('https://i.discogs.com/_xL4yC-gjc-awYVWmO4dDmOv-Za3oICJweuYqpnEzwk/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg'));
+            const maxUrl = await DiscogsProvider.maximiseImage(new URL('https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg'));
 
-            expect(maxUrl.pathname).toBe('/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg');
+            expect(maxUrl.pathname).toBe('/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg');
         });
     });
 
     describe('extracting filename from URL', () => {
         it('extracts the correct filename', async () => {
-            const filename = DiscogsProvider.getFilenameFromUrl(new URL('https://i.discogs.com/aRe2RbRXu0g4PvRjrPgQKb_YmFWO3Y0CYc098S8Q1go/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWltYWdlcy9SLTk4/OTI5MTItMTU3OTQ1/NjcwNy0yMzIwLmpw/ZWc.jpeg'));
+            const filename = DiscogsProvider.getFilenameFromUrl(new URL('https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg'));
 
             expect(filename).toBe('R-9892912-1579456707-2320.jpeg');
         });


### PR DESCRIPTION
No production changes this time around, but two test fixes:
* Discogs changed their URL format so our test data needed to be evolved. Prod code still works fine.
* The Apple Music release we were using to test 404 pages is online again, so we need to use another release for this test.

Affected HTTP recordings are updated as well. I've regenerated all of the other recordings too, but haven't committed these changes since they don't affect the script.

Closes #419.

Adding [skip-cd] tag since no prod code is touched and otherwise it'd deploy the changes from #422 in this PR.