### PR TITLE
Restore `JSON.stringify()` for GEMA repertoire search

### DIFF
--- a/mb_bulk_copy_work_codes.user.js
+++ b/mb_bulk_copy_work_codes.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Bulk copy-paste work codes
-// @version      2022.2.28
+// @version      2022.3.31
 // @description  Copy work identifiers from various online repertoires and paste them into MB works with ease.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -760,6 +760,12 @@ function handleGEMA() {
         if (searchResults.nodeType !== Node.ELEMENT_NODE) return;
 
         injectButtons(searchResults);
+    }
+
+    // GEMA overwrites `JSON.stringify()` with a custom implementation which causes `JSON.parse()` to fail on MB.
+    // Restore it again using the original implementation which seems to be backed up as `Object.toJSON()`.
+    if (Object.toJSON) {
+        JSON.stringify = Object.toJSON;
     }
 
     const observer = new MutationObserver(handleChangeGEMA);

--- a/mb_bulk_copy_work_codes.user.js
+++ b/mb_bulk_copy_work_codes.user.js
@@ -308,7 +308,8 @@ class BaseWorkForm {
         return this.findEmptyRow(parentSelector, inputName);
     }
 
-    checkAndFill(data) {
+    checkAndFill(rawData) {
+        let data = this.parseData(rawData);
         console.log(data);
         let externalCodes = extractCodes(data);
         let externalISWCs = data['iswcs'];
@@ -478,6 +479,17 @@ class BaseWorkForm {
         GM_deleteValue('workCodeData');
     }
 
+    parseData(raw) {
+        try {
+            return JSON.parse(raw);
+        } catch(e) {
+            this.log('error', 'Invalid data');
+            console.log(raw);
+            console.log(e);
+            return {};
+        }
+    }
+
     promptForConfirmation(conflicts) {
         const lis = conflicts.reduce((acc, [agency, mbCodes, extCodes]) => {
             return acc + `<li>${agency}: [${mbCodes.join(', ')}] vs [${extCodes.join(', ')}]</li>`
@@ -595,7 +607,7 @@ function storeData(source, iswcs, codes, title) {
     console.log(obj);
 
     // Use GM functions rather than clipboard because reading clipboard in a portable manner is difficult
-    GM_setValue('workCodeData', obj);
+    GM_setValue('workCodeData', JSON.stringify(obj));
 }
 
 


### PR DESCRIPTION
See https://github.com/ROpdebee/mb-userscripts/commit/1a163ace55acb4cd29d04c3e6dae8b6c0ea8dc74#commitcomment-69876519.

A dirty workaround for a dirty hack which is used by the GEMA website. I would have preferred my original solution to simply drop the JSON serialization, but if this helps to make the userscript work again with Chrome+Tampermonkey, let's do that 😝