### PR TITLE
Minor updates for the cover art scripts

### DIFF
--- a/mb_supercharged_caa_edits.user.js
+++ b/mb_supercharged_caa_edits.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Supercharged Cover Art Edits
-// @version      2021.10.21
+// @version      2022.5.19
 // @description  Supercharges reviewing cover art edits. Displays release information on CAA edits. Enables image comparisons on removed and added images.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -35,6 +35,8 @@ const STATUSES = {
     2: 'Promotion',
     3: 'Bootleg',
     4: 'Pseudo-Release',
+    5: 'Withdrawn',
+    6: 'Cancelled',
 };
 
 const PACKAGING_TYPES = {
@@ -56,6 +58,9 @@ const PACKAGING_TYPES = {
     18: 'Plastic Sleeve',
     19: 'Box',
     20: 'Slidepack',
+    21: 'SnapPack',
+    54: 'Metal Tin',
+    55: 'Longbox',
 };
 
 const NONSQUARE_PACKAGING_TYPES = [
@@ -66,6 +71,7 @@ const NONSQUARE_PACKAGING_TYPES = [
     10, // Fatbox
     11, // Snap case
     17, // Digibook
+    55, // Longbox
 ];
 
 const NONSQUARE_PACKAGING_COVER_TYPES = [

--- a/src/mb_enhanced_cover_art_uploads/meta.ts
+++ b/src/mb_enhanced_cover_art_uploads/meta.ts
@@ -27,7 +27,7 @@ const metadata: UserscriptMetadata = {
         'GM.getResourceURL',
     ],
     connect: '*',
-    require: ['https://github.com/qsniyg/maxurl/blob/e2b9dc7e3dce254a5b6d645e077aa82cba4570d5/userscript.user.js?raw=true'],
+    require: ['https://github.com/qsniyg/maxurl/blob/96b47410593666efa03aa4979a587818f73d2f3f/userscript.user.js?raw=true'],
     resource: ['amazonFavicon https://www.amazon.com/favicon.ico'],
 };
 

--- a/src/mb_enhanced_cover_art_uploads/providers/archive.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/archive.ts
@@ -99,7 +99,7 @@ export class ArchiveProvider extends CoverArtProvider {
     extractGenericImages(itemMetadata: ArchiveMetadata, baseDownloadUrl: URL): CoverArt[] {
         const originalImagePaths = itemMetadata.files
             .filter((file) => file.source === 'original' && ArchiveProvider.IMAGE_FILE_FORMATS.includes(file.format))
-            .map((file) => file.name);
+            .map((file) => encodeURIComponent(file.name).replaceAll('%2F', '/')); // keep path separators
 
         return originalImagePaths.map((path) => {
             return {

--- a/tests/test-data/__recordings__/archive-provider_3534120302/extracting-images_1310741912/extracts-covers-for-item-with-a-filename-that-requires-URL-encoding_3946155584.warc
+++ b/tests/test-data/__recordings__/archive-provider_3534120302/extracting-images_1310741912/extracts-covers-for-item-with-a-filename-that-requires-URL-encoding_3946155584.warc
@@ -1,0 +1,77 @@
+WARC/1.1
+WARC-Filename: archive provider/extracting images/extracts covers for item with a filename that requires URL encoding
+WARC-Date: 2022-05-19T10:39:00.622Z
+WARC-Type: warcinfo
+WARC-Record-ID: <urn:uuid:21c9d7c8-f25b-48a4-8777-7bc00a815a22>
+Content-Type: application/warc-fields
+Content-Length: 119
+
+software: warcio.js
+harVersion: 1.2
+harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:51717d0a-929e-4f35-9472-c8b65b40679c>
+WARC-Target-URI: https://archive.org/metadata/skd815
+WARC-Date: 2022-05-19T10:39:00.623Z
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:e73bcd0a-81a4-4e5b-9ec0-8261b2362d7f>
+Content-Type: application/http; msgtype=request
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:dc2ac81ff6202376ed7046f4427d43efbc2febb7742e526ca50d07e63074c897
+Content-Length: 33
+
+GET /metadata/skd815 HTTP/1.1
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:51717d0a-929e-4f35-9472-c8b65b40679c>
+WARC-Target-URI: https://archive.org/metadata/skd815
+WARC-Date: 2022-05-19T10:39:00.623Z
+WARC-Type: metadata
+WARC-Record-ID: <urn:uuid:debf5778-a9ce-4d0d-8228-eef2abc783fa>
+Content-Type: application/warc-fields
+WARC-Payload-Digest: sha256:0be7640cb9be6af137cd52a51dee054371a15f3ce08113f7436a3904b43eb31f
+WARC-Block-Digest: sha256:0be7640cb9be6af137cd52a51dee054371a15f3ce08113f7436a3904b43eb31f
+Content-Length: 348
+
+harEntryId: 3e3f07b0bf63463ce16bc5de60dfccba
+harEntryOrder: 0
+cache: {}
+startedDateTime: 2022-05-19T10:38:59.915Z
+time: 703
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":703,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 54
+warcRequestCookies: []
+warcResponseHeadersSize: 375
+warcResponseCookies: []
+responseDecoded: false
+
+
+WARC/1.1
+WARC-Target-URI: https://archive.org/metadata/skd815
+WARC-Date: 2022-05-19T10:39:00.622Z
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:51717d0a-929e-4f35-9472-c8b65b40679c>
+Content-Type: application/http; msgtype=response
+WARC-Payload-Digest: sha256:614dffa05112709fa7e82fde7c56b813d3f55839c14cdc605b1f4dc86440cacd
+WARC-Block-Digest: sha256:991eec14b149d999641cf78fd3221777d34f232e223ab014b72c9bfe6dd0fdfb
+Content-Length: 5040
+
+HTTP/1.1 200 OK
+access-control-allow-origin: *
+connection: close
+content-encoding: gzip
+content-type: application/json
+date: Thu, 19 May 2022 10:38:58 GMT
+referrer-policy: no-referrer-when-downgrade
+server: nginx/1.18.0 (Ubuntu)
+strict-transport-security: max-age=15724800
+transfer-encoding: chunked
+vary: Accept-Encoding
+x-pollyjs-finalurl: https://archive.org/metadata/skd815
+
+{"created":1652955309,"d1":"ia903101.us.archive.org","d2":"ia803101.us.archive.org","dir":"/33/items/skd815","files":[{"name":"#cover.jpg","source":"original","mtime":"1575322205","size":"460781","md5":"c79c5a7aae1dc3250b067a630032ffdf","crc32":"074ce461","sha1":"63e446a5639a8a2364d13f0c7787dd3185831dcc","format":"JPEG","rotation":"0"},{"name":"#cover_thumb.jpg","source":"derivative","format":"JPEG Thumb","original":"#cover.jpg","mtime":"1575322557","size":"11108","md5":"fd8ef258f552eee1b12f58e39081db36","crc32":"f02f0bd4","sha1":"1a642b3de8ec860350092c90a5f0e649b2372f6d"},{"name":"No-Joy - Rape on a Train - 01 Rape on a Train.afpk","source":"derivative","format":"Columbia Peaks","original":"No-Joy - Rape on a Train - 01 Rape on a Train.mp3","mtime":"1575322728","size":"954184","md5":"448846cae1106b1af0293528312fe54e","crc32":"ce9ece78","sha1":"700b6c5bbda92ee781b5c0f9378926c0e366ef99"},{"name":"No-Joy - Rape on a Train - 01 Rape on a Train.mp3","source":"original","mtime":"1575322311","size":"131821959","md5":"10ab44b56d3330c176a72c374adaf72b","crc32":"70701803","sha1":"0c7d0d612aaf160cdc2c70e1fb6a24a7145f1919","format":"VBR MP3","length":"3295.48","height":"700","width":"700","title":"Rape on a Train","creator":"No-Joy","album":"Rape on a Train","track":"1","artist":"No-Joy"},{"name":"No-Joy - Rape on a Train - 01 Rape on a Train.ogg","source":"derivative","format":"Ogg Vorbis","original":"No-Joy - Rape on a Train - 01 Rape on a Train.mp3","mtime":"1575322552","size":"70009822","md5":"783c5af1a8ef1e1a28b6d1ea94e8f25c","crc32":"4c1db9f5","sha1":"34d3992586c18f2fd3da1145e8977b81ada7ef30","length":"3295.45","height":"0","width":"0"},{"name":"No-Joy - Rape on a Train - 01 Rape on a Train.png","source":"derivative","format":"PNG","original":"No-Joy - Rape on a Train - 01 Rape on a Train.mp3","mtime":"1575322585","size":"22886","md5":"9dcd89620bbc45539fb2c2017f92444a","crc32":"1719ddda","sha1":"15e71e9447c0561da8d42017efc0259b65afe595"},{"name":"No-Joy - Rape on a Train - 01 Rape on a Train_spectrogram.png","source":"derivative","format":"Spectrogram","original":"No-Joy - Rape on a Train - 01 Rape on a Train.mp3","mtime":"1575322633","size":"170925","md5":"5fb90e44fb295d33e8fc134b4b629161","crc32":"7fd1746c","sha1":"0925d19562f4447b0cb0956bb7021a643ef5c50d"},{"name":"SKD815.zip","source":"original","mtime":"1575322189","size":"129224255","md5":"034c78975efd5cd2256e4fa02f3a02fd","crc32":"4631732f","sha1":"ebb24673353c8e1d7f3152592b8217a222fc8240","format":"ZIP"},{"name":"__ia_thumb.jpg","source":"original","mtime":"1603241823","size":"17495","md5":"3bfdd95d662bb21fd1c01c693dafda91","crc32":"2aa53257","sha1":"b995e76ef26585a3940bd4f6c7ae687228df1f89","format":"Item Tile","rotation":"0"},{"name":"skd815_archive.torrent","source":"metadata","btih":"54bbce2e78bbbc3b8b2fb34e7cfc41ed0c6e891b","mtime":"1607452190","size":"15785","md5":"b81c564dd4b830835d67307be2a98509","crc32":"c39755d9","sha1":"4efc79b333c450c03e340e10ffd70291c620329f","format":"Archive BitTorrent"},{"name":"skd815_files.xml","source":"original","format":"Metadata","md5":"070d12a8f482a71429097bfc66c43d13"},{"name":"skd815_meta.sqlite","source":"original","mtime":"1575322317","size":"17408","format":"Metadata","md5":"78a16ceb5e7115c41ffdfc41cf8f23e8","crc32":"aaf77216","sha1":"daa62d464d27058f7c2979b3473b87c44d6c3efa"},{"name":"skd815_meta.xml","source":"original","mtime":"1607452188","size":"1294","format":"Metadata","md5":"9618fa6c63058384b77f4a2b9f5c230d","crc32":"6420ceb7","sha1":"533770032909c9f37eb135549754b9ad894e922a"}],"files_count":13,"item_last_updated":1607452190,"item_size":332727902,"metadata":{"identifier":"skd815","mediatype":"audio","collection":["skulldungeon","netlabels"],"description":"<b>SKD815<br /><br />Uncompromising Harsh Noise Wall<br /></b><div><b><br /></b></div><div><b><a href=\"https://archive.org/download/skd815/SKD815.zip\" rel=\"nofollow\"><u>DOWNLOAD HERE</u></a><br /></b></div><div><b><br /></b></div><b>No-Joy: <a href=\"https://no-joy.bandcamp.com/\" rel=\"nofollow\">https://no-joy.bandcamp.com/</a></b><br /><br /><i><b>\"Hey you, are you molesting her? If you're going to do it, take out your cock properly.\"</b></i>","scanner":"Internet Archive HTML5 Uploader 1.6.4","subject":"harsh noise wall;harsh noise;noise;hentai nose wall;power electronics;power noise;rape noise;train rape","title":"No-Joy - Rape on a Train","publicdate":"2019-12-02 21:29:49","uploader":"sickie666@hotmail.it","addeddate":"2019-12-02 21:29:49","backup_location":"ia907007_34"},"server":"ia803101.us.archive.org","uniq":201091659,"workable_servers":["ia803101.us.archive.org","ia903101.us.archive.org"]}
+

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/archive.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/archive.test.ts
@@ -46,6 +46,14 @@ describe('archive provider', () => {
                 urlPart: '/items/20010917Fantmas-MagicStickDetroitMIUSA/Front.jpg',
             }],
         }, {
+            desc: 'item with a filename that requires URL encoding',
+            url: ' https://archive.org/details/skd815',
+            numImages: 1,
+            expectedImages: [{
+                index: 0,
+                urlPart: '/items/skd815/%23cover.jpg',
+            }],
+        }, {
             desc: 'item without images',
             url: 'https://archive.org/details/coverartarchive_audit_20210419',
             numImages: 0,


### PR DESCRIPTION
Various minor improvements for ECAU and supercharged cover art edits, based on the [suggestions by chaban](https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/57?u=kellnerd) in the forums.

- Support new packaging types (one of them is non-square) and release statuses for supercharged cover art edits
- Use the latest version of Image Max URL for compatibility with new Violentmonkey (beta) versions (untested)
- Support filenames on archive.org which require URL encoding in ECAU:
  - New test for the given example to cover this case.
  - I'm restoring path separators after URL encoding to be on the safer side, although I haven't seen examples for full paths "including directory paths" yet, as per https://github.com/ROpdebee/mb-userscripts/blob/d04c2514a93e5a45a61cba0087a1161bf95c875d/src/mb_enhanced_cover_art_uploads/providers/archive.ts#L20