### PR TITLE
fix(ecau): maintain MB domain when seeding from cover art page

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/seeding/musicbrainz.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/musicbrainz.tsx
@@ -28,7 +28,7 @@ export const MusicBrainzSeeder: Seeder = {
                 const favicon = await provider.favicon;
                 const seedUrl = new SeedParameters([{
                     url,
-                }]).createSeedURL(mbid);
+                }]).createSeedURL(mbid, window.location.host);
 
                 return <a
                     title={url.href}

--- a/src/mb_enhanced_cover_art_uploads/seeding/parameters.ts
+++ b/src/mb_enhanced_cover_art_uploads/seeding/parameters.ts
@@ -60,8 +60,8 @@ export class SeedParameters {
         return seedParams;
     }
 
-    createSeedURL(releaseId: string): string {
-        return `https://musicbrainz.org/release/${releaseId}/add-cover-art?${this.encode()}`;
+    createSeedURL(releaseId: string, domain = 'musicbrainz.org'): string {
+        return `https://${domain}/release/${releaseId}/add-cover-art?${this.encode()}`;
     }
 
     static decode(seedParams: URLSearchParams): SeedParameters {

--- a/tests/unit/mb_enhanced_cover_art_uploads/seeding/parameters.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/seeding/parameters.test.ts
@@ -96,4 +96,20 @@ describe('seed parameters', () => {
                 url: new URL('https://example.com/123'),
             }]);
     });
+
+    describe('creating seeding URL', () => {
+        const params = new SeedParameters([dummyImageWithTypeAndComment]);
+
+        it('should default to main MB', () => {
+            const url = params.createSeedURL('dummy-id');
+
+            expect(new URL(url)).toHaveProperty('host', 'musicbrainz.org');
+        });
+
+        it('should be customisable', () => {
+            const url = params.createSeedURL('dummy-id', 'custom.musicbrainz.instance.com');
+
+            expect(new URL(url)).toHaveProperty('host', 'custom.musicbrainz.instance.com');
+        });
+    });
 });


### PR DESCRIPTION
Closes #444

This doesn't change the behaviour on atisket, and redirecting to the preferred MBS version is supported by jesus2099's script there.