### PR TITLE
fix(ecau): improve wording of unsupported provider page messages

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -213,7 +213,7 @@ export class ImageFetcher {
             // could still point to an actual image.
             const candidateProvider = getProviderByDomain(url);
             if (typeof candidateProvider !== 'undefined') {
-                throw new Error(`This page is not (yet) supported by the ${candidateProvider.name} provider, are you sure this is an album?`);
+                throw new Error(`This page is not (yet) supported by the ${candidateProvider.name} provider, are you sure this page corresponds to a MusicBrainz release?`);
             }
 
             throw new Error('Expected to receive an image, but received text. Perhaps this provider is not supported yet?');

--- a/tests/unit/mb_enhanced_cover_art_uploads/fetch.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/fetch.test.ts
@@ -99,7 +99,7 @@ describe('fetching image contents', () => {
         mockGetProviderByDomain.mockImplementationOnce(() => fakeProvider);
 
         await expect(fetcher.fetchImageContents(new URL('https://example.com/not-an-album'), 'test.jpg', {}))
-            .rejects.toThrow('This page is not (yet) supported by the test provider, are you sure this is an album?');
+            .rejects.toThrow('This page is not (yet) supported by the test provider, are you sure this page corresponds to a MusicBrainz release?');
     });
 
     it('rejects on invalid image', async () => {


### PR DESCRIPTION
"Album" is an overloaded term. AllMusic calls MB-style release groups "albums", but those URLs aren't supported. So asking whether such URLs are "albums" doesn't help explain why they're not supported.

Intended to address [AllMusic-related confusion](https://chatlogs.metabrainz.org/libera/musicbrainz/msg/5012735/) but perhaps custom messaging for certain confusion-prone providers (Discogs, AllMusic, ???) might be more robust in the future.