### PR TITLE
fix: don't overwrite global jQuery

### DIFF
--- a/mb_blind_votes.user.js
+++ b/mb_blind_votes.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Blind Votes
-// @version      2021.3.30
+// @version      2022.6.1
 // @description  Blinds editor details before your votes are cast.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -13,7 +13,7 @@
 // @run-at       document-body
 // ==/UserScript==
 
-let $ = this.$ = this.jQuery = jQuery.noConflict(true);
+const $ = jQuery.noConflict(true);
 
 function setupStyle() {
     let style = document.createElement('style');

--- a/mb_qol_inline_recording_tracks.user.js
+++ b/mb_qol_inline_recording_tracks.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: QoL: Inline all recording's tracks on releases
-// @version      2021.12.18
+// @version      2022.6.1
 // @description  Display all tracks and releases on which a recording appears from the release page.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -15,7 +15,7 @@
 // @grant        none
 // ==/UserScript==
 
-let $ = this.$ = this.jQuery = jQuery.noConflict(true);
+const $ = jQuery.noConflict(true);
 
 function splitChunks(arr, chunkSize) {
     let chunks = [];

--- a/mb_qol_select_all_update_recordings.user.js
+++ b/mb_qol_select_all_update_recordings.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: QoL: Select All Update Recordings
-// @version      2021.10.24
+// @version      2022.6.1
 // @description  Add buttons to release editor to select all "Update recordings" checkboxes.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -14,7 +14,7 @@
 // @grant        none
 // ==/UserScript==
 
-let $ = this.$ = this.jQuery = jQuery.noConflict(true);
+const $ = jQuery.noConflict(true);
 
 function changeToTargetState($checkbox, targetState) {
     if ($checkbox.prop('checked') != targetState) {

--- a/mb_supercharged_caa_edits.user.js
+++ b/mb_supercharged_caa_edits.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Supercharged Cover Art Edits
-// @version      2022.5.19
+// @version      2022.6.1
 // @description  Supercharges reviewing cover art edits. Displays release information on CAA edits. Enables image comparisons on removed and added images.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -17,7 +17,7 @@
 // @grant        none
 // ==/UserScript==
 
-let $ = this.$ = this.jQuery = jQuery.noConflict(true);
+const $ = jQuery.noConflict(true);
 resemble.outputSettings({
     errorColor: {red: 0, green: 0, blue: 0},
     errorType: 'movementDifferenceIntensity',

--- a/mb_validate_work_codes.user.js
+++ b/mb_validate_work_codes.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Validate Work Codes
-// @version      2021.12.18
+// @version      2022.6.1
 // @description  Validate work identifier codes: Highlight invalid or ill-formatted work codes.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -21,7 +21,7 @@
 
 // A bit too similar to mb_collapse_work_attributes to my liking, but eh.
 
-let $ = this.$ = this.jQuery = jQuery.noConflict(true);
+const $ = jQuery.noConflict(true);
 
 const ATTR_TRANSLATIONS = [
     'Attributes',


### PR DESCRIPTION
The `this.$ = jQuery...` stuff caused `window.$` to be overwritten in Violentmonkey Beta 2.13.0.18 and above. Closes #440 (at least as far as I can fix it).

If any other script is doing `this.$ = ...` (which I'm not sure why I was doing it, I guess I copied it from somewhere else), ECAU will still break, but we can't do much about that except for asking others to change this too when we find the conflicts.

I was going to drop jQuery altogether but at this point it's been so long since I've looked at these scripts that I might break too many things if I try, so I'll postpone that until an _"eventual"_ TS rewrite.

