### PR TITLE
feat: update notifications

### DIFF
--- a/build/changelog.ts
+++ b/build/changelog.ts
@@ -3,6 +3,8 @@ import path from 'path';
 
 import conventionalCommitsParser from 'conventional-commits-parser';
 
+import { filterNonNull } from '@lib/util/array';
+
 import type { PullRequestInfo } from './types-deploy';
 
 const CC_TYPE_TO_TITLE: Record<string, string | undefined> = {
@@ -58,13 +60,44 @@ export async function updateChangelog(scriptName: string, version: string, distR
 }
 
 async function renderChangelog(changelogPath: string, changelogEntry: string): Promise<string> {
+    const existing = await readChangelog(changelogPath);
+    return `${changelogEntry}\n${existing}`;
+}
+
+async function readChangelog(changelogPath: string): Promise<string> {
     try {
-        const existing = await fs.readFile(changelogPath, {
+        return await fs.readFile(changelogPath, {
             encoding: 'utf-8',
         });
-        return `${changelogEntry}\n${existing}`;
     } catch (e) {
         // Changelog doesn't exist yet
-        return changelogEntry + '\n';
+        return '';
     }
+}
+
+interface ChangelogEntry {
+    version: string;
+    title: string;
+    subject: string;
+    prNumber: number;
+}
+
+export async function parseChangelogEntries(changelogPath: string): Promise<ChangelogEntry[]> {
+    const contents = await readChangelog(changelogPath);
+    return filterNonNull(contents.split('\n').map(parseChangelogEntry));
+}
+
+function parseChangelogEntry(line: string): ChangelogEntry | null {
+    const re = /- \*\*([\d.]+)\*\*: ([\w\s]+): (.+?) \(#(\d+)\)/;
+    const match = line.match(re);
+    if (match === null) {
+        // Malformed
+        return null;
+    }
+    return {
+        version: match[1],
+        title: match[2],
+        subject: match[3],
+        prNumber: parseInt(match[4]),
+    };
 }

--- a/build/changelog.ts
+++ b/build/changelog.ts
@@ -88,7 +88,7 @@ export async function parseChangelogEntries(changelogPath: string): Promise<Chan
 }
 
 function parseChangelogEntry(line: string): ChangelogEntry | null {
-    const re = /- \*\*([\d.]+)\*\*: ([\w\s]+): (.+?) \(#(\d+)\)/;
+    const re = /- \*\*([\d.]+)\*\*: ([\w\s]+): (.+?) \(\[#(\d+)\]\(.+\)\)/;
     const match = line.match(re);
     if (match === null) {
         // Malformed

--- a/build/plugin-update-notifications.ts
+++ b/build/plugin-update-notifications.ts
@@ -1,0 +1,46 @@
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
+import { createFilter } from '@rollup/pluginutils';
+
+interface PluginOptions {
+    include?: FilterPattern;
+    exclude?: FilterPattern;
+}
+
+const UPDATE_NOTIFICATION_CODE = `
+import { maybeDisplayNewFeatures } from '@lib/update-notifications';
+import { onDocumentLoaded } from '@lib/util/dom';
+
+if (document.location.hostname === 'musicbrainz.org' || document.location.hostname.endsWith('.musicbrainz.org')) {
+    onDocumentLoaded(maybeDisplayNewFeatures);
+}`;
+
+/**
+ * Transformer plugin to automatically inject the update notifications.
+ *
+ * @param      {Readonly<PluginOptions>}  options  The options
+ * @return     {Plugin}  The plugin.
+ */
+export function updateNotifications(options?: Readonly<PluginOptions>): Plugin {
+    const { include, exclude } = options ?? {};
+    const filter = createFilter(include, exclude);
+
+    return {
+        name: 'UpdateNotificationsPlugin',
+
+        /**
+         * Transform hook for the plugin.
+         *
+         * Injects the update notification helpers.
+         *
+         * @param      {string}                       code    The code
+         * @param      {string}                       id      The identifier
+         * @return     {Promise<undefined | string>}  The transformed result.
+         */
+        async transform(code: string, id: string): Promise<undefined | string> {
+            if (!filter(id)) return;
+
+            return [code, UPDATE_NOTIFICATION_CODE].join('\n\n');
+        },
+    };
+}

--- a/build/plugin-userscript.ts
+++ b/build/plugin-userscript.ts
@@ -62,6 +62,10 @@ export /* for tests */ class GitURLs {
         return 'https://github.com/' + [this.owner, this.repoName, 'tree/main/src', userscriptName].join('/');
     }
 
+    constructBlobURL(branchName: string, filePath: string): string {
+        return 'https://github.com/' + [this.owner, this.repoName, 'blob', branchName, filePath].join('/');
+    }
+
     static fromPackageJson(npmPackage: PackageJson): GitURLs {
         if (!npmPackage.repository) {
             throw new Error('No repository defined in package.json');

--- a/build/plugin-userscript.ts
+++ b/build/plugin-userscript.ts
@@ -85,14 +85,20 @@ async function loadPackageJson(): Promise<PackageJson> {
 export class MetadataGenerator {
     readonly options: Readonly<_UserscriptOptionsWithDefaults>;
     readonly longestMetadataFieldLength: number;
+    readonly npmPackage: Readonly<PackageJson>;
+    readonly gitURLs: Readonly<GitURLs>;
 
-    constructor(options: Readonly<_UserscriptOptionsWithDefaults>) {
+    constructor(options: Readonly<_UserscriptOptionsWithDefaults>, npmPackage: Readonly<PackageJson>) {
         this.options = options;
         this.longestMetadataFieldLength = Math.max(...options.metadataOrder.map((field) => field.length));
+
+        this.npmPackage = npmPackage;
+        this.gitURLs = GitURLs.fromPackageJson(npmPackage);
     }
 
-    static create(options: Readonly<UserscriptOptions>): MetadataGenerator {
-        return new MetadataGenerator({ ...DEFAULT_OPTIONS, ...options });
+    static async create(options: Readonly<UserscriptOptions>): Promise<MetadataGenerator> {
+        const npmPackage = await loadPackageJson();
+        return new MetadataGenerator({ ...DEFAULT_OPTIONS, ...options }, npmPackage);
     }
 
     transformGMFunction(name: string): string[] {
@@ -119,26 +125,23 @@ export class MetadataGenerator {
     /**
      * Insert missing metadata from defaults.
      *
-     * @param      {UserscriptMetadata}              specificMetadata  The userscript-specific metadata.
-     * @return     {Promise<AllUserscriptMetadata>}  The specific metadata amended with defaults.
+     * @param      {UserscriptMetadata}     specificMetadata  The userscript-specific metadata.
+     * @return     {AllUserscriptMetadata}  The specific metadata amended with defaults.
      */
-    private async insertDefaultMetadata(specificMetadata: Readonly<UserscriptMetadata>): Promise<AllUserscriptMetadata> {
-        const npmPackage = await loadPackageJson();
-        const gitURLs = GitURLs.fromPackageJson(npmPackage);
-
-        if (!npmPackage.author) {
+    private insertDefaultMetadata(specificMetadata: Readonly<UserscriptMetadata>): AllUserscriptMetadata {
+        if (!this.npmPackage.author) {
             throw new Error('No author set in package.json');
         }
 
         const defaultMetadata = {
             version: this.options.version,
-            author: typeof npmPackage.author === 'string' ? npmPackage.author : npmPackage.author.name,
-            license: npmPackage.license,
-            supportURL: (typeof npmPackage.bugs === 'string' ? npmPackage.bugs : npmPackage.bugs?.url) ?? gitURLs.issuesURL,
-            homepageURL: gitURLs.homepageURL,
-            downloadURL: gitURLs.constructRawURL(this.options.branchName, `${this.options.userscriptName}.user.js`),
-            updateURL: gitURLs.constructRawURL(this.options.branchName, `${this.options.userscriptName}.meta.js`),
-            namespace: gitURLs.homepageURL, // often used as homepage URL (has the widest support)
+            author: typeof this.npmPackage.author === 'string' ? this.npmPackage.author : this.npmPackage.author.name,
+            license: this.npmPackage.license,
+            supportURL: (typeof this.npmPackage.bugs === 'string' ? this.npmPackage.bugs : this.npmPackage.bugs?.url) ?? this.gitURLs.issuesURL,
+            homepageURL: this.gitURLs.homepageURL,
+            downloadURL: this.gitURLs.constructRawURL(this.options.branchName, `${this.options.userscriptName}.user.js`),
+            updateURL: this.gitURLs.constructRawURL(this.options.branchName, `${this.options.userscriptName}.meta.js`),
+            namespace: this.gitURLs.homepageURL, // often used as homepage URL (has the widest support)
             grant: ['none'],
         };
 

--- a/build/rollup.ts
+++ b/build/rollup.ts
@@ -94,7 +94,7 @@ async function buildUserscriptPassOne(userscriptDir: string): Promise<RollupOutp
                 },
             }),
             consts({
-                'userscript-name': userscriptDir,
+                'userscript-id': userscriptDir,
                 'debug-mode': process.env.NODE_ENV !== 'production',
             }),
             // To resolve node_modules imports

--- a/build/rollup.ts
+++ b/build/rollup.ts
@@ -44,6 +44,7 @@ const TERSER_OPTIONS: MinifyOptions = {
 };
 
 const SKIP_PACKAGES = new Set(['lib', 'types']);
+const MAX_FEATURE_HISTORY = 10;  // Include only the last 10 new features of the changelog
 
 export async function buildUserscripts(version: string, outputDir: string = OUTPUT_DIR): Promise<void> {
     const userscriptDirs = await fs.promises.readdir('./src');
@@ -89,7 +90,9 @@ async function buildUserscriptPassOne(userscriptDir: string, outputDir: string):
         .map((entry) => ({
             versionAdded: entry.version,
             description: entry.subject,
-        }));
+        }))
+        // Limit the number of entries we store, otherwise the scripts might grow very large.
+        .slice(0, MAX_FEATURE_HISTORY - 1);
 
     const bundle = await rollup({
         input: inputPath,

--- a/build/rollup.ts
+++ b/build/rollup.ts
@@ -98,6 +98,11 @@ async function buildUserscriptPassOne(userscriptDir: string, userscriptMetaGener
         }))
         // Limit the number of entries we store, otherwise the scripts might grow very large.
         .slice(0, MAX_FEATURE_HISTORY - 1);
+    const changelogUrl = userscriptMetaGenerator.gitURLs
+        .constructBlobURL(
+            userscriptMetaGenerator.options.branchName,
+            `${userscriptDir}.changelog.md`,
+        );
 
     const bundle = await rollup({
         input: inputPath,
@@ -113,6 +118,7 @@ async function buildUserscriptPassOne(userscriptDir: string, userscriptMetaGener
             consts({
                 'userscript-id': userscriptDir,
                 'userscript-feature-history': featureHistory,
+                'changelog-url': changelogUrl,
                 'debug-mode': process.env.NODE_ENV !== 'production',
             }),
             // To resolve node_modules imports

--- a/build/rollup.ts
+++ b/build/rollup.ts
@@ -17,7 +17,7 @@ import progress from 'rollup-plugin-progress';
 import { minify } from 'terser';
 
 import { nativejsx } from './plugin-nativejsx';
-import { userscript } from './plugin-userscript';
+import { MetadataGenerator, userscript } from './plugin-userscript';
 
 const OUTPUT_DIR = 'dist';
 const VENDOR_CHUNK_NAME = 'vendor';
@@ -163,17 +163,19 @@ async function buildUserscriptPassTwo(passOneResult: Readonly<RollupOutput>, use
         return acc;
     }, {});
 
+    const userscriptMetaGenerator = MetadataGenerator.create({
+        userscriptName: userscriptDir,
+        version,
+        branchName: 'dist',
+    });
     const bundle = await rollup({
         input: 'index.js',
         plugins: [
             // Feed the code of the previous pass as virtual files
             virtual(fileMapping),
             userscript({
-                userscriptName: userscriptDir,
-                version: version,
-                branchName: 'dist',
                 include: /index\.js/,
-            }),
+            }, userscriptMetaGenerator),
         ],
     });
 

--- a/build/rollup.ts
+++ b/build/rollup.ts
@@ -56,7 +56,7 @@ export async function buildUserscripts(version: string, outputDir: string = OUTP
 
 export async function buildUserscript(userscriptName: string, version: string, outputDir: string): Promise<void> {
     console.log(`Building ${userscriptName}`);
-    const userscriptMetaGenerator = MetadataGenerator.create({
+    const userscriptMetaGenerator = await MetadataGenerator.create({
         userscriptName,
         version,
         branchName: 'dist',

--- a/build/rollup.ts
+++ b/build/rollup.ts
@@ -18,6 +18,7 @@ import { minify } from 'terser';
 
 import { parseChangelogEntries } from './changelog';
 import { nativejsx } from './plugin-nativejsx';
+import { updateNotifications } from './plugin-update-notifications';
 import { MetadataGenerator, userscript } from './plugin-userscript';
 
 const OUTPUT_DIR = 'dist';
@@ -151,6 +152,9 @@ async function buildUserscriptPassOne(userscriptDir: string, userscriptMetaGener
                     postcssPresetEnv,
                 ],
                 extensions: ['.css', '.scss', '.sass'],
+            }),
+            updateNotifications({
+                include: inputPath,
             }),
         ],
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -9822,7 +9822,7 @@
     },
     "node_modules/nativejsx": {
       "version": "4.3.0",
-      "resolved": "git+ssh://git@github.com/ROpdebee/nativejsx.git#c4fb7561cb02f64b8d3cddd20c288b1c93932286",
+      "resolved": "git+ssh://git@github.com/ROpdebee/nativejsx.git#a0fbd686865e424bd34e54e070d7c1f571a0a728",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20762,7 +20762,7 @@
       "dev": true
     },
     "nativejsx": {
-      "version": "git+ssh://git@github.com/ROpdebee/nativejsx.git#c4fb7561cb02f64b8d3cddd20c288b1c93932286",
+      "version": "git+ssh://git@github.com/ROpdebee/nativejsx.git#a0fbd686865e424bd34e54e070d7c1f571a0a728",
       "dev": true,
       "from": "nativejsx@github:ROpdebee/nativejsx",
       "requires": {

--- a/src/lib/update-notifications/banner.scss
+++ b/src/lib/update-notifications/banner.scss
@@ -1,0 +1,14 @@
+// Make the feature list centered, but each item in the list still left-aligned.
+.ROpdebee_feature_list {
+    margin: 0 auto;
+    width: fit-content;
+    font-weight: 300;
+
+    ul {
+        // Center with the paragraph, need a bit of a margin for the button on the right
+        margin: 0px;
+        margin-right: 28px;
+        margin-top: 6px;
+        text-align: left;
+    }
+}

--- a/src/lib/update-notifications/index.tsx
+++ b/src/lib/update-notifications/index.tsx
@@ -1,0 +1,68 @@
+// istanbul ignore file: Covered by E2E
+
+import { qs, qsMaybe } from '@lib/util/dom';
+import { parseVersion, versionLessThan } from '@lib/util/versions';
+
+import USERSCRIPT_FEATURE_HISTORY from 'consts:userscript-feature-history';
+import USERSCRIPT_ID from 'consts:userscript-id';
+import bannerStyle from './banner.scss';
+
+const LAST_DISPLAYED_KEY = `ROpdebee_${USERSCRIPT_ID}_last_notified_update`;
+
+export function maybeDisplayNewFeatures(): void {
+    const lastDisplayedVersionString = localStorage.getItem(LAST_DISPLAYED_KEY);
+    // eslint-disable-next-line no-restricted-globals
+    const scriptInfo = GM.info.script;
+
+    // If we've never shown a notification before, don't show one. Otherwise
+    // a couple of years down the line, someone might get spammed with a huge
+    // banner if we've made many updates.
+    if (!lastDisplayedVersionString) {
+        // Set the userscript version so that the next update will be displayed.
+        localStorage.setItem(LAST_DISPLAYED_KEY, scriptInfo.version);
+        return;
+    }
+
+    const lastDisplayedVersion = parseVersion(lastDisplayedVersionString);
+    const newFeatures = USERSCRIPT_FEATURE_HISTORY
+        .filter((feat) => versionLessThan(lastDisplayedVersion, parseVersion(feat.versionAdded)));
+
+    showFeatureNotification(scriptInfo.name, scriptInfo.version, newFeatures.map((feat) => feat.description));
+}
+
+
+function insertStyle(): void {
+    const STYLE_ID = 'ROpdebee_Update_Banner';
+
+    // Skip if already inserted by other script
+    if (qsMaybe(`style#${STYLE_ID}`) !== null) return;
+
+    const style = <style id={STYLE_ID}>{bannerStyle}</style>;
+    document.head.insertAdjacentElement('beforeend', style);
+}
+
+function showFeatureNotification(scriptName: string, newVersion: string, newFeatures: string[]): void {
+    insertStyle();
+    const banner = <div className={'banner warning-header'}>
+        <p>
+            {scriptName + ' was updated to v' + newVersion + '! New features since last update:'}
+        </p>
+        <div className={'ROpdebee_feature_list'}>
+            <ul>
+                {newFeatures.map((feat) => <li>{feat}</li>)}
+            </ul>
+        </div>
+        <button
+            className='dismiss-banner remove-item icon'
+            data-banner-name='alert'
+            type='button'
+            onClick={(): void => {
+                banner.remove();
+                // eslint-disable-next-line no-restricted-globals
+                localStorage.setItem(LAST_DISPLAYED_KEY, GM.info.script.version);
+            }}
+        />
+    </div>;
+
+    qs('#page').insertAdjacentElement('beforebegin', banner);
+}

--- a/src/lib/update-notifications/index.tsx
+++ b/src/lib/update-notifications/index.tsx
@@ -3,6 +3,7 @@
 import { qs, qsMaybe } from '@lib/util/dom';
 import { parseVersion, versionLessThan } from '@lib/util/versions';
 
+import CHANGELOG_URL from 'consts:changelog-url';
 import USERSCRIPT_FEATURE_HISTORY from 'consts:userscript-feature-history';
 import USERSCRIPT_ID from 'consts:userscript-id';
 import bannerStyle from './banner.scss';
@@ -43,9 +44,12 @@ function insertStyle(): void {
 
 function showFeatureNotification(scriptName: string, newVersion: string, newFeatures: string[]): void {
     insertStyle();
+
     const banner = <div className={'banner warning-header'}>
         <p>
-            {scriptName + ' was updated to v' + newVersion + '! New features since last update:'}
+            {`${scriptName} was updated to v${newVersion}! `}
+            <a href={CHANGELOG_URL}>See full changelog here</a>
+            {'. New features since last update:'}
         </p>
         <div className={'ROpdebee_feature_list'}>
             <ul>

--- a/src/lib/util/dom.ts
+++ b/src/lib/util/dom.ts
@@ -40,7 +40,7 @@ export function qsa<T extends Element>(query: string, element?: Document | Eleme
  * is already loaded, will be fired immediately.
  */
 export function onDocumentLoaded(listener: () => void): void {
-    if (document.readyState === 'complete') {
+    if (document.readyState !== 'loading') {
         listener();
     } else {
         document.addEventListener('DOMContentLoaded', listener);

--- a/src/lib/util/versions.ts
+++ b/src/lib/util/versions.ts
@@ -1,0 +1,21 @@
+type Version = number[];
+
+export function parseVersion(vString: string): Version {
+    // Can't use a bare function reference because parseInt will interpret the
+    // index as the base.
+    return vString.split('.').map((i) => parseInt(i));
+}
+
+export function versionLessThan(v1: Version, v2: Version): boolean {
+    let i = 0;
+    while (i < v1.length && i < v2.length) {
+        if (v1[i] < v2[i]) return true;
+        if (v1[i] > v2[i]) return false;
+        // Check next part
+        i++;
+    }
+
+    // Same prefix. If v1 has less parts than v2, v2 is newer.
+    return v1.length < v2.length;
+}
+

--- a/src/mb_enhanced_cover_art_uploads/App.ts
+++ b/src/mb_enhanced_cover_art_uploads/App.ts
@@ -4,7 +4,6 @@ import { GuiSink } from '@lib/logging/guiSink';
 import { LOGGER } from '@lib/logging/logger';
 import { EditNote } from '@lib/MB/EditNote';
 import { getURLsForRelease } from '@lib/MB/URLs';
-import { maybeDisplayNewFeatures } from '@lib/update-notifications';
 import { assertHasValue } from '@lib/util/assert';
 import { qs } from '@lib/util/dom';
 
@@ -33,7 +32,6 @@ export class App {
         LOGGER.addSink(this.loggingSink);
         qs('.add-files').insertAdjacentElement('afterend', this.loggingSink.rootElement);
         this.ui = new InputForm(this);
-        maybeDisplayNewFeatures();
     }
 
     async processURL(url: URL): Promise<void> {

--- a/src/mb_enhanced_cover_art_uploads/App.ts
+++ b/src/mb_enhanced_cover_art_uploads/App.ts
@@ -4,6 +4,7 @@ import { GuiSink } from '@lib/logging/guiSink';
 import { LOGGER } from '@lib/logging/logger';
 import { EditNote } from '@lib/MB/EditNote';
 import { getURLsForRelease } from '@lib/MB/URLs';
+import { maybeDisplayNewFeatures } from '@lib/update-notifications';
 import { assertHasValue } from '@lib/util/assert';
 import { qs } from '@lib/util/dom';
 
@@ -32,6 +33,7 @@ export class App {
         LOGGER.addSink(this.loggingSink);
         qs('.add-files').insertAdjacentElement('afterend', this.loggingSink.rootElement);
         this.ui = new InputForm(this);
+        maybeDisplayNewFeatures();
     }
 
     async processURL(url: URL): Promise<void> {

--- a/src/mb_enhanced_cover_art_uploads/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/index.ts
@@ -8,12 +8,12 @@ import { App } from './App';
 import { seederFactory } from './seeding';
 
 import DEBUG_MODE from 'consts:debug-mode';
-import USERSCRIPT_NAME from 'consts:userscript-name';
+import USERSCRIPT_ID from 'consts:userscript-id';
 
 LOGGER.configure({
     logLevel: DEBUG_MODE ? LogLevel.DEBUG : LogLevel.INFO,
 });
-LOGGER.addSink(new ConsoleSink(USERSCRIPT_NAME));
+LOGGER.addSink(new ConsoleSink(USERSCRIPT_ID));
 
 const seeder = seederFactory(document.location);
 if (seeder) {

--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -5,7 +5,7 @@ import { qs } from '@lib/util/dom';
 import type { App } from '../App';
 import type { CoverArtProvider } from '../providers/base';
 
-import USERSCRIPT_NAME from 'consts:userscript-name';
+import USERSCRIPT_ID from 'consts:userscript-id';
 import css from './main.scss';
 
 export class InputForm {
@@ -15,7 +15,7 @@ export class InputForm {
 
     constructor(app: App) {
         // Inject our custom CSS
-        document.head.append(<style id={'ROpdebee_' + USERSCRIPT_NAME}>
+        document.head.append(<style id={'ROpdebee_' + USERSCRIPT_ID}>
             {css}
         </style>);
 

--- a/src/types/rollup-consts.d.ts
+++ b/src/types/rollup-consts.d.ts
@@ -1,11 +1,11 @@
 // https://github.com/NotWoods/rollup-plugin-consts/wiki/Usage-with-TypeScript
 
-declare module 'consts:userscript-name' {
-    const userscriptName: string;
-    export default userscriptName;
+declare module 'consts:userscript-id' {
+    const USERSCRIPT_ID: string;
+    export default USERSCRIPT_ID;
 }
 
 declare module 'consts:debug-mode' {
-    const debugMode: boolean;
-    export default debugMode;
+    const DEBUG_MODE: boolean;
+    export default DEBUG_MODE;
 }

--- a/src/types/rollup-consts.d.ts
+++ b/src/types/rollup-consts.d.ts
@@ -9,3 +9,12 @@ declare module 'consts:debug-mode' {
     const DEBUG_MODE: boolean;
     export default DEBUG_MODE;
 }
+
+declare module 'consts:userscript-feature-history' {
+    interface Feature {
+        versionAdded: string;
+        description: string;
+    }
+    const USERSCRIPT_FEATURE_HISTORY: Feature[];
+    export default USERSCRIPT_FEATURE_HISTORY;
+}

--- a/src/types/rollup-consts.d.ts
+++ b/src/types/rollup-consts.d.ts
@@ -18,3 +18,8 @@ declare module 'consts:userscript-feature-history' {
     const USERSCRIPT_FEATURE_HISTORY: Feature[];
     export default USERSCRIPT_FEATURE_HISTORY;
 }
+
+declare module 'consts:changelog-url' {
+    const CHANGELOG_URL: string;
+    export default CHANGELOG_URL;
+}

--- a/tests/unit/build/changelog.test.ts
+++ b/tests/unit/build/changelog.test.ts
@@ -137,6 +137,7 @@ describe('parsing changelog', () => {
             title: 'feat(ecau): add Jamendo provider',
             number: 123,
             labels: [],
+            url: 'testurl',
         });
         // @ts-expect-error: Mocking
         changelogReaderMock.mockResolvedValue(changelogWriterMock.mock.lastCall[1]);
@@ -144,6 +145,7 @@ describe('parsing changelog', () => {
             title: 'fix(ecau): fix a mistake!!',
             number: 124,
             labels: [],
+            url: 'testurl',
         });
         // @ts-expect-error: Mocking
         changelogReaderMock.mockResolvedValue(changelogWriterMock.mock.lastCall[1]);

--- a/tests/unit/build/plugin-userscript.test.ts
+++ b/tests/unit/build/plugin-userscript.test.ts
@@ -63,6 +63,15 @@ describe('git URLs', () => {
         });
     });
 
+    describe('blob URL', () => {
+        it('creates correct URLs', () => {
+            const gitUrls = new GitURLs('https://github.com/ROpdebee/mb-userscripts');
+
+            expect(gitUrls.constructBlobURL('dist', 'README.md'))
+                .toBe('https://github.com/ROpdebee/mb-userscripts/blob/dist/README.md');
+        });
+    });
+
     describe('creating from package.json', () => {
         it('should throw if no repository defined', () => {
             expect(() => GitURLs.fromPackageJson({}))

--- a/tests/unit/lib/util/versions.test.ts
+++ b/tests/unit/lib/util/versions.test.ts
@@ -1,0 +1,37 @@
+import { parseVersion, versionLessThan } from '@lib/util/versions';
+
+describe('parsing versions', () => {
+    it('parses versions', () => {
+        expect(parseVersion('1.2.3')).toStrictEqual([1, 2, 3]);
+    });
+
+    it('parses long versions', () => {
+        expect(parseVersion('1.2.3.4')).toStrictEqual([1, 2, 3, 4]);
+    });
+
+    it('parses multi-digit versions', () => {
+        expect(parseVersion('2022.6.7')).toStrictEqual([2022, 6, 7]);
+    });
+});
+
+describe('comparing versions', () => {
+    it('does not consider same version to be less-than', () => {
+        expect(versionLessThan([1, 2, 3], [1, 2, 3])).toBeFalse();
+    });
+
+    const cases = [
+        ['1.2.3', '1.2.4'],
+        ['1.2.3', '1.2.3.4'],
+        ['1.2.3', '1.3.0'],
+        ['1.2.3', '2.0.0'],
+        ['2022.2.1', '2022.6.7'],
+    ];
+
+    it.each(cases)('considers %s to be older than %s', (v1s, v2s) => {
+        const v1 = parseVersion(v1s);
+        const v2 = parseVersion(v2s);
+
+        expect(versionLessThan(v1, v2)).toBeTrue();
+        expect(versionLessThan(v2, v1)).toBeFalse();
+    });
+});


### PR DESCRIPTION
Fixes #455. Depends on #457.

This allows the scripts to automatically notify when its recent updates contain new features. Some changes to the build were necessary to inject the necessary information too. Unfortunately the script still needs to explicitly call a function to get these to be displayed, I did not manage to inject that during the build.

All new features since the last "acknowledged" (= closing the notification) will be grouped together per script.

Some caveats:
- The notifications can be dismissed, but that dismissal won't be shared between beta.MB and main MB because it's using local storage to track which version was last dismissed. Can't do much about that except for using `GM.getValue` and `GM.setValue`, but that would lead to issues with content vs page context scripts.
- The update notification won't be displayed on first installation, otherwise people will get spammed in a couple of years if we add 100 providers to ECAU.
- Feature list is extracted from the changelog generated in #457. It isn't pretty, but it works.
- Probably doesn't work when building locally since changelogs are only created in CI.

Preview:
<img width="1792" alt="Screenshot 2022-06-08 at 00 52 10" src="https://user-images.githubusercontent.com/15186467/172497506-f26fb598-54df-454b-8df5-fe75c537c878.png">

