### PR TITLE
test: update recordings for `fetch`

### DIFF
--- a/tests/test-data/__recordings__/getting-URLs-for-release_1054398333/can-omit-URLs-which-are-ended_3862782763.warc
+++ b/tests/test-data/__recordings__/getting-URLs-for-release_1054398333/can-omit-URLs-which-are-ended_3862782763.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: getting URLs for release/can omit URLs which are ended
-WARC-Date: 2021-12-11T20:26:40.115Z
+WARC-Date: 2022-06-08T13:06:56.018Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:e372a1f0-8303-4a33-970d-b50fc1370de7>
+WARC-Record-ID: <urn:uuid:93297b69-d25f-4a18-ad04-5755edb55af5>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,19 +12,19 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:09f7bf93-8566-47d2-8e37-54f1e086e1fe>
+WARC-Concurrent-To: <urn:uuid:9ff01f7f-e963-4aca-86b5-5893a9843b64>
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/7d0cf748-475e-4be6-b7f2-ef2d55f3f0f5?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.115Z
+WARC-Date: 2022-06-08T13:06:56.019Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:d027ab2a-4b96-4fbc-b22b-6bd97802bc5f>
+WARC-Record-ID: <urn:uuid:12e04270-57e9-4715-ab4b-0ccbac66d03d>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:68dbf049cdb7e2ebf0be8a79a67a01d76ea05ca437ded1c907098a284efc88e0
-Content-Length: 202
+WARC-Block-Digest: sha256:632b37fb5a4babb5abcb869f97b3c65fa04e73dff1845aecbde5da18d091ca59
+Content-Length: 204
 
 GET /ws/2/release/7d0cf748-475e-4be6-b7f2-ef2d55f3f0f5?inc=url-rels&fmt=json HTTP/1.1
 accept: */*
-accept-encoding: gzip,deflate,br
+accept-encoding: gzip, deflate, br
 connection: close
 user-agent: node-fetch
 host: musicbrainz.org
@@ -32,25 +32,25 @@ host: musicbrainz.org
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:09f7bf93-8566-47d2-8e37-54f1e086e1fe>
+WARC-Concurrent-To: <urn:uuid:9ff01f7f-e963-4aca-86b5-5893a9843b64>
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/7d0cf748-475e-4be6-b7f2-ef2d55f3f0f5?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.116Z
+WARC-Date: 2022-06-08T13:06:56.019Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:20e6b082-f9d7-4b38-8e40-c6a5b8027492>
+WARC-Record-ID: <urn:uuid:bf7f5d62-ff88-414c-941b-601ea8f023bb>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:6bd4a41589621399d45158bfaae531c6423da9a9695361f6cf5f7ff92db416bf
-WARC-Block-Digest: sha256:6bd4a41589621399d45158bfaae531c6423da9a9695361f6cf5f7ff92db416bf
-Content-Length: 388
+WARC-Payload-Digest: sha256:fbb10724ac92fda754cd85737280a40e19da644b8a338b778bf5597578e07abb
+WARC-Block-Digest: sha256:fbb10724ac92fda754cd85737280a40e19da644b8a338b778bf5597578e07abb
+Content-Length: 386
 
-harEntryId: 19f52f55acaf0262f6a28d0a9f17b7d2
+harEntryId: f18d12adae301f0614e449784b519988
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:39.075Z
-time: 1034
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":1034,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 225
+startedDateTime: 2022-06-08T13:06:55.893Z
+time: 119
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":119,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 227
 warcRequestCookies: []
-warcResponseHeadersSize: 396
+warcResponseHeadersSize: 397
 warcResponseCookies: []
 responseDecoded: false
 warcResponseContentEncoding: base64
@@ -58,28 +58,28 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/7d0cf748-475e-4be6-b7f2-ef2d55f3f0f5?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.115Z
+WARC-Date: 2022-06-08T13:06:56.018Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:09f7bf93-8566-47d2-8e37-54f1e086e1fe>
+WARC-Record-ID: <urn:uuid:9ff01f7f-e963-4aca-86b5-5893a9843b64>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:f1e218a80c7493981adf3862e8648be1fb667f1b61c92f2b3254be5481280b9b
-WARC-Block-Digest: sha256:35f645a50a8eb77449d30cebbcf82ce073bb3d03e00e724e8d313ed67f3258b1
-Content-Length: 1601
+WARC-Payload-Digest: sha256:87a9b6eb5053b372aa5032ce32be9501a4b1c393a5ec5d01a35f8b15a26f9ea4
+WARC-Block-Digest: sha256:a2ebb289677aec37dee4021402c6a01128189b0e18155010225d4d8cc19e3cb6
+Content-Length: 1590
 
 HTTP/1.1 200 OK
-date: Sat, 11 Dec 2021 20:26:40 GMT
+date: Wed, 08 Jun 2022 13:06:56 GMT
 content-type: application/json; charset=utf-8
 transfer-encoding: chunked
 connection: close
 vary: Accept-Encoding
 x-ratelimit-limit: 1200
-x-ratelimit-remaining: 936
-x-ratelimit-reset: 1639254401
+x-ratelimit-remaining: 1095
+x-ratelimit-reset: 1654693617
 server: Plack::Handler::Starlet
-etag: W/"06740707858f43c8a853afb286e2f34e"
+etag: W/"376266192a0c9011c70ae7b180914a74"
 access-control-allow-origin: *
 x-cache-status: STALE
 content-encoding: gzip
 
-["H4sIAAAAAAAAA6VVyXLbOBD9FRfOahsbSUC33KecU+aQqRywNGRWKFIBSWsSlf59GpJsWTZnqZqDqkQs3a/fe904sAn/nCDjLuOI/eSmdujZ+sDGkNvdxNbsNzf1bMU6129mt0FawX7Djiu2c+G727T9BtpIq0JY9K6pwSutQCGX4KSVkHjivNbae+spztROXQnyO/ZtQFoIwzNmcHmiX3hqn7Fk9xSbrZPrRiwn5p6QiBWjU/sh086UZ9pIeSgb54/o8nfsMV6uEcCM3amcka3/OLDp567kTRnxbpwyui1BL4Bc3uAEl+05d7Tmkepi637uuhWVG1/+umnKrZ8npJIp6oGSlAsEmNgb5hxKiKdp2o3rh4f9fn8fEX9hvg/D9sF1ft4+CK6s0rWUlOVMm5ZSO2OhEjKCtoqD18pBdF5Hr+sm1LKwfU397LoZL9ljmzGcJWNpyHuXIwU+Q4GQMbZFwmuVN0tU8Vk6brSuQkjQeGtBa2XAJusgeeuCMNxaLEoREa/0vgFU6P12XB2WclyunBW6JrQGuQmSg9FkEy1qBcY2HCpVcTJK7QRq9j7F/+bgPwl5wlcZG2VFKlTBG9CebOwq1FCrGEJUKUll2GpJ9O08tuHe7XYdnlSfxxfhdaMkpwLroubFbTu6/eRGvCPcd3HY993g4r97spB9Y9Gl85ePt1b/e6++h93/+gj7YlhDRvWcC9JOe9CuUWBr0s4IH0JtjbR1ujXsK8VvBFiQZ1nHZc3fO+NqLULrYpI1gUqOrGUIHtcViFQlJZNRKvgPXv7g3GNx23gl+HXW0ebj0Jdu8DSuhlhIFFZrKwSxpMXJFR2SpoDPNE/Psye6qRyUXFjgBkRVCiNdToYbB1CirkFAiVcusE9f2LcXBc8AYju6rW9pBF8Yogi925aon2bS2HWtex0pvEbuMYCvqZOVVw34RglIlYoVb2LgHE8dQjN3IcYrlyerFa/9E/yb07dBH3F/9xUdvRzxah6pQxMtJN1IUMZycLoykKQhaEZEG0rjL3Hy+LVwshh6iZwrecci5ukNyT9LqV9ewDSRh9RoavCmQupypLerSRIwyViRW+jlKpX+mImYqVzth7x1pbdGeidnQsU+p9SG9rS2RNL53NmYGhXXVBRVXUdQmltwSSI0xlQNYqhCwsVajn8B5MnsIaQHAAA="]
+["H4sIAAAAAAAAA42VTXPbOAyG/0qG5yDhlyTSt9532lP30J0c+AE6msqSS0nxth7/9wVlx3FSJ9ubaRIg3ucFqD3L2KEbEfAJ+2lkq3/2LLoJ2YpJLixwA6Jit8xldGy1Z22kHcFr5B4D+FoZUF414BslIFUqVryJgXOkmNiObuPb9eymdugpjv5rxwGUqGsQEIaI5UL26St7uGW925RbP83jlF3XOjo8DnmCK/9PP7cIpZJ+7rrj8vj7cLj9uPx3I8/3f8bdzTd0nevjmwpe71wT8vlbEbIgMpXUoYkWkm4kKGM5OF0ZSNIQIiOiDfoqosOBUoThCTM4utvl8Ng+Yamdlrshf2erKc94y1Ie+ul54V2gjeS6EUv0XHYEpXf5O/YYT1sHUoz/TpBxm3Ekv0+37hmJohrWRSb26yI85HZLSdhfbuoZBW7pBrduaZNIDH3xd6T4mYSzLym1oXVdAT22/ZluO3Ul49/Yt6EELGSayENqtAHdVAjaY03NkyRgkrGqkko8FccWEflncf7r+a7FOqZRcU3sCWsdQWluwSWJ0BhTNYihCmlpvyt9cFZxzCSERe8aqkBpBQq5BCetBKqB81pr761nhW4uHpcAq7UVgldKC9qg4VkQHufm2E1kDOINNSu6Tbuw9Lh+gYJ9PPtBiFxe4wSnyDkvCKcpt36eSqNS4v3hfCxkjO10HKSXU0+um/F0sGQgO8ndYc6h5Hycpu24ur/f7XZ3EfEX5rswbO5d5+fNveDKKl1L+WyO0FJqZyxUQkbQVnHwWjmIzuvodd2EWpZuOM8R40brKoQEjbcWtKYHwSbrIHnrgjDcWsTLcguqh9L4GcOp59OQdy4fx61U/Uon8TrNNo32+/I289iGO7fddrjom8dnibpRkvyq6meNlbFRViSqCp660JPfrkINtYohRJWSVKZovE74QyveGvbK19NiS5U/0ot7Q7Jv4rDru8FFdm6M0zxftsxHVN4j+Zb3i2HWIDdBcjCa2l2LWoGxDQdCxKnhaydQswvYp+dMSM+5oCDtQbtGga0pyAgfQm2NtHVa5uF/jel//W7Mu7D/bBQ+mq8j88tpvGbNBc4rsP+sd18IkywXk6wJUXJE2BAsrisQiZ43mYxSwbPDw/UP5I+ZPnJTeff6IW/oTT38B5bVNoekBwAA"]
 

--- a/tests/test-data/__recordings__/getting-URLs-for-release_1054398333/can-omit-duplicate-URLs_4045665903.warc
+++ b/tests/test-data/__recordings__/getting-URLs-for-release_1054398333/can-omit-duplicate-URLs_4045665903.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: getting URLs for release/can omit duplicate URLs
-WARC-Date: 2021-12-11T20:26:40.297Z
+WARC-Date: 2022-06-08T13:06:56.152Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:1dfa2025-b5ab-40ab-a121-db69239aa231>
+WARC-Record-ID: <urn:uuid:e9c1c595-9e1b-4118-9387-5eb265d16b2a>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,19 +12,19 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:a73cbb5d-1273-4547-a81f-771d61ae2bb4>
+WARC-Concurrent-To: <urn:uuid:9b14d665-f3a4-4b14-acd3-2a32490cc392>
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/6393da26-1c2a-491c-8149-3ddaf5cc0d89?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.297Z
+WARC-Date: 2022-06-08T13:06:56.152Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:a2d31638-78b7-486b-b040-62c1903848d3>
+WARC-Record-ID: <urn:uuid:676c13d1-3aa0-4a88-aec2-55d9a5df8ad4>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:dfcfa5c40b463996bc63776fb822518555a82284d7f4610e7045fb90fdf60451
-Content-Length: 202
+WARC-Block-Digest: sha256:420d19399c98f18686462590b5dd80680abffbb2e73f4a342775710b7f7d3f04
+Content-Length: 204
 
 GET /ws/2/release/6393da26-1c2a-491c-8149-3ddaf5cc0d89?inc=url-rels&fmt=json HTTP/1.1
 accept: */*
-accept-encoding: gzip,deflate,br
+accept-encoding: gzip, deflate, br
 connection: close
 user-agent: node-fetch
 host: musicbrainz.org
@@ -32,25 +32,25 @@ host: musicbrainz.org
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:a73cbb5d-1273-4547-a81f-771d61ae2bb4>
+WARC-Concurrent-To: <urn:uuid:9b14d665-f3a4-4b14-acd3-2a32490cc392>
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/6393da26-1c2a-491c-8149-3ddaf5cc0d89?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.297Z
+WARC-Date: 2022-06-08T13:06:56.153Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:c555af0a-90be-4c50-989f-cfce86f3cb92>
+WARC-Record-ID: <urn:uuid:e134b0fe-bd16-487d-8694-85b63cad1073>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:f112f00f765ba2051c1bc01cec7be96ad77d432f4d0c49c5e4ee27c61e9b23a5
-WARC-Block-Digest: sha256:f112f00f765ba2051c1bc01cec7be96ad77d432f4d0c49c5e4ee27c61e9b23a5
+WARC-Payload-Digest: sha256:e48d43a0484a192163c7ac4d65b6675138aaab92769b1d904612afd3b2f88e8c
+WARC-Block-Digest: sha256:e48d43a0484a192163c7ac4d65b6675138aaab92769b1d904612afd3b2f88e8c
 Content-Length: 386
 
-harEntryId: 760fcf728263066e0cd01623c3318455
+harEntryId: 3457756a84fe96ee04fe743daceb1c96
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:40.121Z
-time: 169
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":169,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 225
+startedDateTime: 2022-06-08T13:06:56.025Z
+time: 121
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":121,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 227
 warcRequestCookies: []
-warcResponseHeadersSize: 396
+warcResponseHeadersSize: 397
 warcResponseCookies: []
 responseDecoded: false
 warcResponseContentEncoding: base64
@@ -58,28 +58,28 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/6393da26-1c2a-491c-8149-3ddaf5cc0d89?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.297Z
+WARC-Date: 2022-06-08T13:06:56.152Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:a73cbb5d-1273-4547-a81f-771d61ae2bb4>
+WARC-Record-ID: <urn:uuid:9b14d665-f3a4-4b14-acd3-2a32490cc392>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:2c56e0a4f6f198f592f8ab871aa5b740bf51cea5c2baa1c404d9c8d94bf436b3
-WARC-Block-Digest: sha256:ad38834a2559947b355352eafa5b47a1d251dcb44b41b4fc04e74f90a5ace8a3
-Content-Length: 1345
+WARC-Payload-Digest: sha256:95063feab05a2bdd79428284617709315238f9e309fd9332f5ff3d8552634e8c
+WARC-Block-Digest: sha256:4fdee8cedda7ce0ccc420f019057b511271cc081349d9910bbeb45be1ecbdb68
+Content-Length: 1354
 
 HTTP/1.1 200 OK
-date: Sat, 11 Dec 2021 20:26:40 GMT
+date: Wed, 08 Jun 2022 13:06:56 GMT
 content-type: application/json; charset=utf-8
 transfer-encoding: chunked
 connection: close
 vary: Accept-Encoding
 x-ratelimit-limit: 1200
-x-ratelimit-remaining: 876
-x-ratelimit-reset: 1639254401
+x-ratelimit-remaining: 1051
+x-ratelimit-reset: 1654693617
 server: Plack::Handler::Starlet
-etag: W/"7e863f220e1eae361fa83ecaa79b0cea"
+etag: W/"ec8572602b9c9528c7b237ff8161034d"
 access-control-allow-origin: *
 x-cache-status: STALE
 content-encoding: gzip
 
-["H4sIAAAAAAAAA62Uy27bMBBFfyXQ2pOQEiWT+YaiBbpJgSCLITlyiMiiS1FxA8P/3qFfTVoX6KILAeJr7p0zQ+6qDboXXIVxVd1Xn+NI1aKaMuZ5guB5SlEjVCM7aHTnoVHCAPY1wVLrdknkWteXI4kGzCGOU3X/uKt8SOTKkAP0MW0xed5jiWWq+3EeBtaIc3IELpEPmbfxOo2eWLLHYaJFld82VI4nopspJ8J18bioMOcU7JypSD29G8MrDnOZ3e0Psc5Kcxp4jh0eJTnmc86b6f7uzvI65U2KsV/TNNG4onRrcfQO15tbF9d3OTGduxTn0UPN4gckBtveatOB8K4DpbEB3Tf8hx6F7nQjpa/2750Ff7JVkjpyFVqp1rkeltYYUKrRYHqD0FuDTmphDBWuGdOK8gdMp6kTn5LdfvE35Fcof6jCR+TXUf4O/CS84cjPONENq934uB2HiEXyhPvfSS3+R2k+lvwa+T+oXYd7KZDRJLSrBWglalCyY+9mKaBtWqGs7VCSqvbM43KBjuekNGRx2YFtVAMN8WGsTQ296IXoFB81tgjRjwyJNpw7jRmPldtVA46rGVfFIx3afXIpbIq5T5jHkqbF5KKnc6ouvlICTJk/9xxeqUSxbOlSVceIOIBc8F2K5S+nuRQ75W1ML+ehx/RC46UZCrGQh+Lja0F8c+n+rjGNx7oD6WoEZaQDLZWBxnvsuaOF1+b4IBB3B9Arp3d6FTCXeLWoJYglyLbcZr7YxfGI67L2+BDT4LfB0xMv+jDh2gYGcmrs9wU6ph+mCPw6sRsoVIpQ9e2hurTp+bFhPlclDim1desVSc05CMHhLL9xrbaAUnVoZOdJ99W+1PqaI5x+3adrKX6fcQj5jafHmNZYGu9QklSm2Ov5veXRl74PLvCW/U+/YdlymAUAAA=="]
+["H4sIAAAAAAAAA61UwY7jKBD9lRbn1DTY2IF8w2pH2sus1OpDAeU0asdkMO7eVpR/3yJJZzKazGGlvRlTr+rx3oOD8GmZSv4QG/H3N7EShf4pkGmfaaapYIlpEpuDGHHaLrglLqNpy3Wzz3FfePkHlkkcVyLTSDgT0BvjZrF5OoiApQIa2SiQa1Ad4zAT1oZxTtCqvgcFPgWqgErgeSViYEzXdEGTMtAGKbnQWcDOOECle7SqD2QG7hbijDsXmdqZqKgn+Njz1GkZR2aZcoEJd5XG07eUx/AeAz1fqqCOOhfeqTkemUyJZawbf7FK4aFh4PcFx1iqXlPKOxx/w8KnN8qAPB6zf4lvVA/t0L+KzYDjTKuz8GKjGI/5lSYK1y2GvafMpSUvvBxyqpV1wULvuQluI7uwEX+miSqBO0Jfy06nFEpZcrjuwbW6hZZkA9jYBgY5SNlr7Zx1jHLMlu246scJWOZzB02t1GwZtKYP0GrJlgwNwdqYbk3kOz9ULjjH6RPOmThJco7DVXIhjdad9wOsnbWgdWvADhZhcBa9MtJaoquTfHyih7lwcHbxlL0lj6cI1VYWu8EZ24MMvgdtsAUztPyFAaXpTatUEJXJnJbsa7uXUvbz5vHRMUUq+5zSsKOZ076l/MXhFDzu9l982j2WzBo+5mo9NDXjWEqObimnuD7XeNWe4DOFWC7pw7ylAhfqlekNDN5wXCr4cNuMNbn8oukaSP68CYSj7Q9VLyNup4aYyV/CN6T8jjkw38OnUv/D6Vf/Qe7j1bo9T33hV+GBST2E9D6NCcPt7RPWkDS+kWA0R1KrnhvatYSu7SSHskdFWvyq/D2Z77hxX/mf1PxZ6BsH7vhzT+Y7fhw/X7G+tW3Ahh853yBoqzwYpS0/agEHvgAyGCs+bxnXfx2G6CO/Kcd/Abh62uaYBQAA"]
 

--- a/tests/test-data/__recordings__/getting-URLs-for-release_1054398333/retrieves-all-URLs_515713061.warc
+++ b/tests/test-data/__recordings__/getting-URLs-for-release_1054398333/retrieves-all-URLs_515713061.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: getting URLs for release/retrieves all URLs
-WARC-Date: 2021-12-11T20:26:39.061Z
+WARC-Date: 2022-06-08T13:06:55.866Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:76f4f2ae-e238-46ce-a60f-ca613a137ad4>
+WARC-Record-ID: <urn:uuid:48bb3d88-adcc-415b-a619-c26c29b8cc8b>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,19 +12,19 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:191c59c6-2b32-47ad-b35a-b7becca960a4>
+WARC-Concurrent-To: <urn:uuid:a69ff554-1d06-4c84-8c75-5c053fe2574c>
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/83a3f2c0-3ca7-4e6e-9de8-f740a1eb8990?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:39.063Z
+WARC-Date: 2022-06-08T13:06:55.871Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:b238f1af-3e58-4065-a4eb-582733d6e5eb>
+WARC-Record-ID: <urn:uuid:62980529-cda2-4541-985c-5c1903f98abb>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:c6bf16baa3797189ad8c89c220eea88e3e686ba4fe1fae7f93592c22e608fbdf
-Content-Length: 202
+WARC-Block-Digest: sha256:3f8852bd3f4121f9a3bc1fed82231f6e1b66d2c89f4b05896c79b580c3e78291
+Content-Length: 204
 
 GET /ws/2/release/83a3f2c0-3ca7-4e6e-9de8-f740a1eb8990?inc=url-rels&fmt=json HTTP/1.1
 accept: */*
-accept-encoding: gzip,deflate,br
+accept-encoding: gzip, deflate, br
 connection: close
 user-agent: node-fetch
 host: musicbrainz.org
@@ -32,25 +32,25 @@ host: musicbrainz.org
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:191c59c6-2b32-47ad-b35a-b7becca960a4>
+WARC-Concurrent-To: <urn:uuid:a69ff554-1d06-4c84-8c75-5c053fe2574c>
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/83a3f2c0-3ca7-4e6e-9de8-f740a1eb8990?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:39.063Z
+WARC-Date: 2022-06-08T13:06:55.872Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:30267af4-d427-4647-ab84-d6e9142382a7>
+WARC-Record-ID: <urn:uuid:344548be-872a-4a8c-afa3-b10440d187da>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:bdc1d5e1ca58ce11c4fa0cf4bb7d78a972230cd37abd74a7bc68d5a4f9e207e5
-WARC-Block-Digest: sha256:bdc1d5e1ca58ce11c4fa0cf4bb7d78a972230cd37abd74a7bc68d5a4f9e207e5
+WARC-Payload-Digest: sha256:e03009078509c474798155898634e1ed1556d6bd60aa8496a7a06c83ac3e38f2
+WARC-Block-Digest: sha256:e03009078509c474798155898634e1ed1556d6bd60aa8496a7a06c83ac3e38f2
 Content-Length: 386
 
-harEntryId: a5a01867bdce64a1d440e98c7637da11
+harEntryId: 9dd2248a812e8a01324765bfad002845
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:38.558Z
-time: 488
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":488,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 225
+startedDateTime: 2022-06-08T13:06:55.578Z
+time: 259
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":259,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 227
 warcRequestCookies: []
-warcResponseHeadersSize: 396
+warcResponseHeadersSize: 397
 warcResponseCookies: []
 responseDecoded: false
 warcResponseContentEncoding: base64
@@ -58,28 +58,28 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://musicbrainz.org/ws/2/release/83a3f2c0-3ca7-4e6e-9de8-f740a1eb8990?inc=url-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:39.062Z
+WARC-Date: 2022-06-08T13:06:55.867Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:191c59c6-2b32-47ad-b35a-b7becca960a4>
+WARC-Record-ID: <urn:uuid:a69ff554-1d06-4c84-8c75-5c053fe2574c>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:80e295cfc9863fa5d58c750a6efdb6feef27813a0ad453763863d9a07f1463a9
-WARC-Block-Digest: sha256:257694ba0926ab755d4aebc380d913450e602636fa0f1228331eecf247aef8a2
-Content-Length: 1513
+WARC-Payload-Digest: sha256:548d93289bfb6a01e888871d277e056b02e33acd06ff82bb81c67612f0282e42
+WARC-Block-Digest: sha256:9b334810790cb62112f1e9f45240608262bbaf8e64ea97b08fe1bcb1fb03aba4
+Content-Length: 1514
 
 HTTP/1.1 200 OK
-date: Sat, 11 Dec 2021 20:26:39 GMT
+date: Wed, 08 Jun 2022 13:06:55 GMT
 content-type: application/json; charset=utf-8
 transfer-encoding: chunked
 connection: close
 vary: Accept-Encoding
 x-ratelimit-limit: 1200
-x-ratelimit-remaining: 626
-x-ratelimit-reset: 1639254399
+x-ratelimit-remaining: 1152
+x-ratelimit-reset: 1654693617
 server: Plack::Handler::Starlet
-etag: W/"81777fd0460a293e88c590c2927072d8"
+etag: W/"07b3dcaa14f2a1bcbece473c3caa7652"
 access-control-allow-origin: *
 x-cache-status: STALE
 content-encoding: gzip
 
-["H4sIAAAAAAAAA71VTW/jNhD9KwHPmYQUKYnMre1ht8Ci7aFAii72MKSGXiGy5KWouKkRoH+jf6+/ZIe2k3VQBwtsgR41nI/33jyPd8JjClNH4kZYa2qprLK61uJS9F2JadSxChJ0wBYMNQSuIwuxNRIVeeuc5NwwLWNOD1zw2y1/JhoIZwK6pzHP4ub9TnSYy4xKqgqUAlUmYCIUNzvRzxNo1TSgoEApBaXPh0vR9TOufb9aMPfTyPVcNeK6dHp/O6Wh2/YdfeBgfthwcFyG4Qi8rurOkLKgO8nolXeAtfWAyjToVMMkItfNU8rwakcorUrTx0cG82nBoc+F5DilNQ6lPGNeGK/4OcY+9PvYOaaHvH07YUhLw3RB26YDbSQjixVBa23dEoU6RBLnqWf6I0OiTaKZhT0+7MQcUr/JnPIO88hpA45ctiooaFyJx0uxwXCHq35cHSAo5chj24DXRoMmWQFWroIoo5SNMd47v9/qPSVAVog98rG/pzKsw3RHI3GbiMNMlyKmaeThOS1UVpq3U7p7+vQ89zlxbxJxoxhP7vNQ4L2lf/76e774bhgufrx4M+WDd/bEDraZpyUFgpCo6/NBhK5PFI6axCltMXXFSzmn3i+Z4B6HpXho93gSLd14hTR2J8ifVyykNaYOIULrnQNjtAUXHUL0DoOy0jkqO8mYVpRfoPHEsj457/h+MKNY0vDsTFaJ6GLO7Pg1r4Hj5bV4v4x3PvjYIptVUgXGqhqcCxratm6C5aVUst1Lc5CDKz7mvJlvrq+nDY1X82bKfXy4CtP6Gge/rK8VPdz+os3d99Wn39UP6W397s2v6404VYSJH0ViUY4uv9z9D4r9x5UedTujxXa7veqI/qR0okQjXSsb9XTPqqaysZMEqg4eTBsMWN8i1DI2usLQKb5nX5Hpm5f+Qt8vjV9ntF7mPlzhZjPQntIyH1nVrVWNdVY+8VJYu3KrAZEMOyjUYCsvgc+JVzXZmqmJlyTO4X5J7PByatrX3KAriV2sGnBNRDD8FwJOmhpUrKOuotU6ePHvn+MZd5y3whnPnHNHudI4f2HwfPa45KdpJPH4GQsbVH/wBgAA"]
+["H4sIAAAAAAAAA71VwY7bNhD9lYXOO7ukSEqkb20PSYGg7aHAFg32MCSHjrCy5FDUulvDQH+jv9cvKSmvnW3iBmgR5CYOh5z33jyO9tX7GfsuPVWrahjjBvvqukr0W4JI20gTDQlTNw7Val/1OKxnXFNOpWGd8yYXu23KyzeYhuqQAzl5nqDzOSZJMCl4A0I3HoRkBjDUBK3WqiVyygXKd0TqCScCesylpmr1dl95TKVGzXgNnAMXOQ0jYcHguwk3tss4jqiqvDfgpuS/vRtj73edp/scXDCoWnlJXIPwjIHgNmNQ2gJy2aDhjScdCo8xJrh4S3ra0kJnmPv+uDx9d9OYb2wa4OBGTwV69ctddX843F9fpJC61Jfga/rrjz+nq2/6/ur7q1djylsWY7kjb2otFeOaa6HKGTc+UgTM8HLGu+6RigYW3UO1CthPVCrFBxrInwNunIfcE35dhTiWrxRnKgKm3Rgfjstzq3LFH0PoXLf0HaduONHLfVkkPrYEU4qdndNC8/4kRK5AdDWl3JtNtzjirFfFtJTKuQCtNQakFBpMMAjBGnRcM2OotN/S+kPNaZyjI3CRfJeOvaXBv+A2x74IkH25ZOaUdyltp9Xt7bil4WbajqkLTzdu3Nxib+fNLaenu5+EfPi2fv8r/y6+Vm9e/bzZnuxhrLOhxWwPRjVIzRUY4wS0rWqcZoHVrC229l0k9+y3MMYdRl/UOmkCj9jPRZn94WW088+hhHFN6WNaZ08dd58VLQwP1/tLZy7c/Nlr/hvuf5d2t9vdeKLfKb4QtmGmZQ0/KVk3tQ6eEXDlLMjWSdC2RVAsNKJG57lhRckv5puPDflPn3zeVUXfr9zSTwF/YCxqhj7UDZgmIMj89MEwqYAHFUQdtBDOVmfpXqr2vx7PUpOjMlqgAESS2flOga4tgzyWLVekVW7ZMpw/ccNmnjp3g9ttT4sd5unZEarVvNFG5z6XCbjNQwozvPWRJOeGLLYNWCEFCGI1YG1qCPmVsUZKa00heT6Vj/wwDnTyV8EaapdnuMMWJDUEJg9vCK1kyMlqk/11ffHvsMzDWP5veTof/gb7tH4s8AYAAA=="]
 

--- a/tests/test-data/__recordings__/getting-releases-for-URLs_3409569510/returns-empty-list-when-URL-does-not-exist_2275831759.warc
+++ b/tests/test-data/__recordings__/getting-releases-for-URLs_3409569510/returns-empty-list-when-URL-does-not-exist_2275831759.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: getting releases for URLs/returns empty list when URL does not exist
-WARC-Date: 2021-12-11T20:26:40.488Z
+WARC-Date: 2022-06-08T13:06:56.282Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:a3a98153-4b0f-44e7-a9dc-473b69edbe32>
+WARC-Record-ID: <urn:uuid:8d65e40c-d76f-4fdf-989c-c58e1271a33d>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,19 +12,19 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:51220b5b-6932-4af2-bd8c-56f9e84e1037>
+WARC-Concurrent-To: <urn:uuid:39cc83a1-7649-4051-9068-7ab0275e9f08>
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fexample.com&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.488Z
+WARC-Date: 2022-06-08T13:06:56.282Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:48ade9e8-959d-4614-9076-12c7b2ca15c1>
+WARC-Record-ID: <urn:uuid:1aaf0f08-4e73-4e73-807e-9ee5829a396d>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:da1d991914b6ed46cf2df603542030a7160fcebb723026f25a7fa307a2c2e383
-Content-Length: 200
+WARC-Block-Digest: sha256:239a85bd5b31fdb2c4d71c5c223e89f957e920f249e9dac630837726973027e2
+Content-Length: 202
 
 GET /ws/2/url?resource=https%3A%2F%2Fexample.com&inc=release-rels&fmt=json HTTP/1.1
 accept: */*
-accept-encoding: gzip,deflate,br
+accept-encoding: gzip, deflate, br
 connection: close
 user-agent: node-fetch
 host: musicbrainz.org
@@ -32,47 +32,47 @@ host: musicbrainz.org
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:51220b5b-6932-4af2-bd8c-56f9e84e1037>
+WARC-Concurrent-To: <urn:uuid:39cc83a1-7649-4051-9068-7ab0275e9f08>
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fexample.com&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.488Z
+WARC-Date: 2022-06-08T13:06:56.282Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:c3036c15-a8f4-43cf-a3a4-bf73e6232f5c>
+WARC-Record-ID: <urn:uuid:e0cd9899-7c53-4395-9764-1d7ddf527d05>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:19aceab5e54488bd71a48d33803eedbbe13b5368b12222d99fdff1ea67dc37c0
-WARC-Block-Digest: sha256:19aceab5e54488bd71a48d33803eedbbe13b5368b12222d99fdff1ea67dc37c0
+WARC-Payload-Digest: sha256:5fb6b02229f1a45be231fab6f76685fa25a1a1ae50e54c228e7694b6c7751fd6
+WARC-Block-Digest: sha256:5fb6b02229f1a45be231fab6f76685fa25a1a1ae50e54c228e7694b6c7751fd6
 Content-Length: 349
 
-harEntryId: 1da35b6695a66421e008745ab8704fb2
+harEntryId: aaf2a340680360fcdad896a506075aa1
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:40.304Z
-time: 180
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":180,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 223
+startedDateTime: 2022-06-08T13:06:56.159Z
+time: 120
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":120,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 225
 warcRequestCookies: []
-warcResponseHeadersSize: 316
+warcResponseHeadersSize: 317
 warcResponseCookies: []
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fexample.com&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.488Z
+WARC-Date: 2022-06-08T13:06:56.282Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:51220b5b-6932-4af2-bd8c-56f9e84e1037>
+WARC-Record-ID: <urn:uuid:39cc83a1-7649-4051-9068-7ab0275e9f08>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:a00943cd14c32cab2a0e3891907a7bf079ed608627ab75cff6dfd049ecd1c2fe
-WARC-Block-Digest: sha256:4228491faee9c271392c4ff993e2637537c7aa46a881f1dfba54391a7f830675
-Content-Length: 433
+WARC-Block-Digest: sha256:384bbd5ed5f1e9d14c586aa3c59f073fac2d8008909173f8bf47da6f6b5ee407
+Content-Length: 434
 
 HTTP/1.1 404 Not Found
-date: Sat, 11 Dec 2021 20:26:40 GMT
+date: Wed, 08 Jun 2022 13:06:56 GMT
 content-type: application/json; charset=utf-8
 content-length: 93
 connection: close
 x-ratelimit-limit: 1200
-x-ratelimit-remaining: 808
-x-ratelimit-reset: 1639254401
+x-ratelimit-remaining: 1013
+x-ratelimit-reset: 1654693617
 server: Plack::Handler::Starlet
 etag: "8b5a62e76b15ec04b7cbc0eb576f7f62"
 access-control-allow-origin: *

--- a/tests/test-data/__recordings__/getting-releases-for-URLs_3409569510/returns-empty-list-when-no-release-is-attached-to-URL_3987713515.warc
+++ b/tests/test-data/__recordings__/getting-releases-for-URLs_3409569510/returns-empty-list-when-no-release-is-attached-to-URL_3987713515.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: getting releases for URLs/returns empty list when no release is attached to URL
-WARC-Date: 2021-12-11T20:26:40.687Z
+WARC-Date: 2022-06-08T13:06:56.406Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:931c1c60-d2c3-40b1-bdd3-fc9c15fcbdb6>
+WARC-Record-ID: <urn:uuid:d8b2fb6b-0266-4ea1-906f-4884e708b336>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,19 +12,19 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:a73262c1-3a31-4b44-8531-632c88f67d4f>
+WARC-Concurrent-To: <urn:uuid:bcd5009a-8a33-433e-b873-64c8cf178674>
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fwww.discogs.com%2Fartist%2F5788865&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.687Z
+WARC-Date: 2022-06-08T13:06:56.407Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:57463c40-9aa5-4aac-8906-59738f33cbb7>
+WARC-Record-ID: <urn:uuid:5d3720dc-facb-4aaa-927e-37f1a768afb8>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:3aae3f7f68506966cbb86f65f168a15b38864f75106a03d132249a8f5436368c
-Content-Length: 223
+WARC-Block-Digest: sha256:8df36a9a72165f15e5e337770ce11c92a4ffa1ac97ce7d101118fb28b50d8e6b
+Content-Length: 225
 
 GET /ws/2/url?resource=https%3A%2F%2Fwww.discogs.com%2Fartist%2F5788865&inc=release-rels&fmt=json HTTP/1.1
 accept: */*
-accept-encoding: gzip,deflate,br
+accept-encoding: gzip, deflate, br
 connection: close
 user-agent: node-fetch
 host: musicbrainz.org
@@ -32,51 +32,51 @@ host: musicbrainz.org
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:a73262c1-3a31-4b44-8531-632c88f67d4f>
+WARC-Concurrent-To: <urn:uuid:bcd5009a-8a33-433e-b873-64c8cf178674>
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fwww.discogs.com%2Fartist%2F5788865&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.687Z
+WARC-Date: 2022-06-08T13:06:56.407Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:440ea2d7-ac42-4a81-a300-566ef78afcbb>
+WARC-Record-ID: <urn:uuid:8514b7f7-8bf1-469f-8314-f5b758ebb295>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:d90939bc2aeafaac83ad13dd727a24047f5245dd72f83a913a0eefae3f01cd10
-WARC-Block-Digest: sha256:d90939bc2aeafaac83ad13dd727a24047f5245dd72f83a913a0eefae3f01cd10
+WARC-Payload-Digest: sha256:dcdbb2faf6ace1b9f1dbbeeb17194ab127c06f0eabe0ff7abaaea557753aea40
+WARC-Block-Digest: sha256:dcdbb2faf6ace1b9f1dbbeeb17194ab127c06f0eabe0ff7abaaea557753aea40
 Content-Length: 349
 
-harEntryId: 303e1b8705b5a2e6ab0833e45a1d05cc
+harEntryId: c475eaa14b27831b659c01b29734405c
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:40.494Z
-time: 188
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":188,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 246
+startedDateTime: 2022-06-08T13:06:56.288Z
+time: 115
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":115,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 248
 warcRequestCookies: []
-warcResponseHeadersSize: 339
+warcResponseHeadersSize: 340
 warcResponseCookies: []
 responseDecoded: false
 
 
 WARC/1.1
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fwww.discogs.com%2Fartist%2F5788865&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.687Z
+WARC-Date: 2022-06-08T13:06:56.406Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:a73262c1-3a31-4b44-8531-632c88f67d4f>
+WARC-Record-ID: <urn:uuid:bcd5009a-8a33-433e-b873-64c8cf178674>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:38285b0b31d4660150ea146a41ea6b0c59a2d4cd3a020197231fadb7b0ad8751
-WARC-Block-Digest: sha256:42fccd1e2d85c3657e674343844761105e24d6fa64015b083ace916fc633201f
-Content-Length: 468
+WARC-Block-Digest: sha256:d17c019e03b9fa130dedea72dd37612ee7e88e935d110b33b3cd9f9e798e4f66
+Content-Length: 469
 
 HTTP/1.1 200 OK
-date: Sat, 11 Dec 2021 20:26:40 GMT
+date: Wed, 08 Jun 2022 13:06:56 GMT
 content-type: application/json; charset=utf-8
 content-length: 112
 connection: close
 x-ratelimit-limit: 1200
-x-ratelimit-remaining: 741
-x-ratelimit-reset: 1639254401
+x-ratelimit-remaining: 976
+x-ratelimit-reset: 1654693617
 server: Plack::Handler::Starlet
 etag: "23ee07cc3319d41aa18f97e7683d5b97"
 access-control-allow-origin: *
-x-cache-status: MISS
+x-cache-status: STALE
 
 {"relations":[],"id":"b3853e43-d80f-48af-80a7-117021f04e30","resource":"https://www.discogs.com/artist/5788865"}
 

--- a/tests/test-data/__recordings__/getting-releases-for-URLs_3409569510/returns-release-ID-for-URL_2258567196.warc
+++ b/tests/test-data/__recordings__/getting-releases-for-URLs_3409569510/returns-release-ID-for-URL_2258567196.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: getting releases for URLs/returns release ID for URL
-WARC-Date: 2021-12-11T20:26:40.893Z
+WARC-Date: 2022-06-08T13:06:56.526Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:f8860c28-de33-4c30-bbda-9ac114afa6f3>
+WARC-Record-ID: <urn:uuid:e9eb1cd7-dd1d-41e8-87e3-fabbbc9ad095>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,19 +12,19 @@ harCreator: {"name":"Polly.JS","version":"6.0.4","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:c569b266-7b23-463d-ad0e-39a757aba014>
+WARC-Concurrent-To: <urn:uuid:04573344-b874-47d5-89e2-dd06746e3d4c>
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fwww.discogs.com%2Frelease%2F12620800&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.893Z
+WARC-Date: 2022-06-08T13:06:56.527Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:92fede02-a3ff-4680-8058-2d9b69e5d615>
+WARC-Record-ID: <urn:uuid:25eb3d24-e649-4762-a7f5-7fa9fdbb7def>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:95619141c6673b6e05690ecfac34c3702fab8330b8aa4097a27b8abab284f7eb
-Content-Length: 225
+WARC-Block-Digest: sha256:0e725b8c47394ebb74004f0d9446518ad3ce1e1b6eae2693dd2b8c92fd080c9d
+Content-Length: 227
 
 GET /ws/2/url?resource=https%3A%2F%2Fwww.discogs.com%2Frelease%2F12620800&inc=release-rels&fmt=json HTTP/1.1
 accept: */*
-accept-encoding: gzip,deflate,br
+accept-encoding: gzip, deflate, br
 connection: close
 user-agent: node-fetch
 host: musicbrainz.org
@@ -32,25 +32,25 @@ host: musicbrainz.org
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:c569b266-7b23-463d-ad0e-39a757aba014>
+WARC-Concurrent-To: <urn:uuid:04573344-b874-47d5-89e2-dd06746e3d4c>
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fwww.discogs.com%2Frelease%2F12620800&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.893Z
+WARC-Date: 2022-06-08T13:06:56.527Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:2726af74-ae15-43a3-aa7a-71a6dc6680aa>
+WARC-Record-ID: <urn:uuid:2d0499a4-e601-4a3a-8438-ba369cfc93f4>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:6db1de4a3f8b1272da7c222fddf4974c183fab550428991ac843bdd64359af33
-WARC-Block-Digest: sha256:6db1de4a3f8b1272da7c222fddf4974c183fab550428991ac843bdd64359af33
+WARC-Payload-Digest: sha256:ccc600e645c6aad28489c3cb234cc8d58b90e4134598d1ad17fc7945c6762818
+WARC-Block-Digest: sha256:ccc600e645c6aad28489c3cb234cc8d58b90e4134598d1ad17fc7945c6762818
 Content-Length: 386
 
-harEntryId: 1e1af7b19fd74d3c614196e6da0c12da
+harEntryId: ac5a6afc90467cc508868e86c9f86fe2
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2021-12-11T20:26:40.691Z
-time: 197
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":197,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 248
+startedDateTime: 2022-06-08T13:06:56.412Z
+time: 111
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":111,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 250
 warcRequestCookies: []
-warcResponseHeadersSize: 395
+warcResponseHeadersSize: 396
 warcResponseCookies: []
 responseDecoded: false
 warcResponseContentEncoding: base64
@@ -58,28 +58,28 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://musicbrainz.org/ws/2/url?resource=https%3A%2F%2Fwww.discogs.com%2Frelease%2F12620800&inc=release-rels&fmt=json
-WARC-Date: 2021-12-11T20:26:40.893Z
+WARC-Date: 2022-06-08T13:06:56.526Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:c569b266-7b23-463d-ad0e-39a757aba014>
+WARC-Record-ID: <urn:uuid:04573344-b874-47d5-89e2-dd06746e3d4c>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:14e4b22ebc6e1aad1b7419341fee558d1ab0804c28dd4a960a5d8094688ec0dd
-WARC-Block-Digest: sha256:a1c732b3f59a8c1d340cfd2d38a97ceb406947ad0576388b1223f6be13d126fa
-Content-Length: 1092
+WARC-Payload-Digest: sha256:b8f75beb56f34f01aa3a775958ff86944dd047492f54e3b57dbfc2527c1ca76b
+WARC-Block-Digest: sha256:7c4fc3447cc23ad238040315b1a8264203c9a915d7c994432f64a089b11ff96e
+Content-Length: 1101
 
 HTTP/1.1 200 OK
-date: Sat, 11 Dec 2021 20:26:40 GMT
+date: Wed, 08 Jun 2022 13:06:56 GMT
 content-type: application/json; charset=utf-8
 transfer-encoding: chunked
 connection: close
 vary: Accept-Encoding
 x-ratelimit-limit: 1200
-x-ratelimit-remaining: 676
-x-ratelimit-reset: 1639254401
+x-ratelimit-remaining: 947
+x-ratelimit-reset: 1654693617
 server: Plack::Handler::Starlet
-etag: W/"d14e4f8fb406fd38e19544d327282c99"
+etag: W/"d6365382a1b6959b531767b56ffd2a2c"
 access-control-allow-origin: *
-x-cache-status: MISS
+x-cache-status: STALE
 content-encoding: gzip
 
-["H4sIAAAAAAAAA21Ty27bMBD8lYBnbyyJD8m+51CgH1CgyGFJrRUiepWk4gaG/71LW0lUtNfl7szszPIifCuOQpMlq8oSUDkF6kASUFIFrXTyVCutXNOInQjUY/LTGMXx50Wk95l4tvXRTV3k5zgtwRG4QK1P/MIlTCl4uySCN+wX4sHLdSdoZNJx6fudSBg6SrBiMQFhJHFrIW46YR9pJyx1fvwY+cTMMp63HL5dCVbUrZIP6ONF/Fqw9+md6+MUBuz5tcWU+auibKAsoNBcsxjc1OayKSptalOXlck2zOhekQV14L/2oN8JAs2BIo3p5lKmii74OSv4jmnk0R7HbsEug9LYCZYauXmJG6R74RPXpz53fxsyI30tAvTGRPckMBBmtruL98Fbrs0BTa1dBZJkDVLzdraRDlTZWGz1ARuNDDnikDmeljDNmSLjbBT5OIEsjYESsiGZU/x4Emw9Z4+D9bzSfWFxu4KQ4G/E6/8Mvj6vIguDjvUdQKuTBWXIglWFhYNU2tZthZVsGddNy5hCTo25NyF8qPxHS3qhh6VPfmDqh3wIuXzdbCcU1k1TsR+l05JNqQ2gPknQTVEZV5tTZV0+Dh/IraCWac8Y2pt8Dvt28lx/SWmOx/3+fD4/rj/i0U3Dfk1rz6dTFU1RiOsfoydaw3MDAAA="]
+["H4sIAAAAAAAAA21Sy27bMBD8lYBnbyyJpCT7nkOBfkCBIocluXaI6OGSVNzA0L93KSmG0fYmjji7M8O5Ce/EUWgyZFRZAiqrQB1IAkqqwEkrT43Syrat2IlAHSY/DlEcf94EDY6YfMIu0k4YOvtBHIep63YijlOwBDaQ84nnMzd9Xoi/nI92PMcNgGW7wqZtK2mhtFqCKpsaUJ8k6LaoatvUp8pYJmBKwZspUV7/uqghjDz0Ji5o35H3n5eBq4Y79gUsu4oarSR5AK1OBlRNBowqDByk0qZxFVbS8S6Wib3x52nxy7z0Rk9Tl3yPiZ6yqwzvhB2nIYVPvvDjhY8xYZriPYXl9CBpUwz0QUNaQ3Q8j9lVUbZQFlDobDQQZldxDAkG7POFlymMHODmoj1g3WhbAVtpQGomm5YDVGVr0OkDthr57t/cf1zleXEEWdY1lGBHt2Sbvbw+PNAqfn3A/D3P/Pd/wpNPXQa/9Tn4vNFgyFMZq4tK103dlFWdq/Rrws6nHNwwhh67zKbfCQJdAkWOZ5N4Ex0OLPicZxA/Jsdqg7/kVn3HNIh5ZiaGMyXYKvbVi11u6F39euWxkfc+sUm2fZsfoQ/sJtpQ5wPZLTHDrbpicGJeGrgWnfG3lC7xuN9fr9fnrePPduz3m5g9266KtijE/AfMS6NncwMAAA=="]
 


### PR DESCRIPTION
Every time I run the tests, these recordings are getting regenerated. I'm not sure why it's happening, probably some dependency update, but I'm too lazy to figure that out. Let's just update the recordings so it stops regenerating them.