### PR TITLE
ci: fix finding PR number in deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,7 @@ jobs:
                 number: prs[0].number,
                 title: prs[0].title,
                 labels: prs[0].labels.map((label) => label.name),
-                url: pr.html_url,
+                url: prs[0].html_url,
               };
             } catch (err) {
               console.error('Could not find PR number for commit!');


### PR DESCRIPTION
I broke CI in #457, copy-paste error 🙁 Oops.

Via PR because I've restricted direct pushes to main and it's faster to submit a PR and merge it than to disable that restriction, push, and re-enable it. (Although it might've been faster considering I had to write all of this.) (And now that I wrote that, it definitely would've been faster…)