### PR TITLE
fix(ecau): drop images without jQuery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "MIT; https://opensource.org/licenses/MIT",
       "dependencies": {
-        "jquery": "3.6.0",
         "p-throttle": "5.0.0",
         "ts-custom-error": "3.2.0"
       },
@@ -37,7 +36,6 @@
         "@types/greasemonkey": "4.0.3",
         "@types/jest": "28.1.1",
         "@types/jest-when": "3.5.0",
-        "@types/jquery": "3.5.14",
         "@types/postcss-preset-env": "6.7.3",
         "@types/rollup__plugin-virtual": "2.0.1",
         "@types/rollup-plugin-progress": "1.1.1",
@@ -3514,15 +3512,6 @@
         "@types/jest": "*"
       }
     },
-    "node_modules/@types/jquery": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
-      "dev": true,
-      "dependencies": {
-        "@types/sizzle": "*"
-      }
-    },
     "node_modules/@types/jsdom": {
       "version": "16.2.14",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.14.tgz",
@@ -3734,12 +3723,6 @@
       "dependencies": {
         "@types/pollyjs__core": "*"
       }
-    },
-    "node_modules/@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -9753,11 +9736,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -16837,15 +16815,6 @@
         "@types/jest": "*"
       }
     },
-    "@types/jquery": {
-      "version": "3.5.14",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.14.tgz",
-      "integrity": "sha512-X1gtMRMbziVQkErhTQmSe2jFwwENA/Zr+PprCkF63vFq+Yt5PZ4AlKqgmeNlwgn7dhsXEK888eIW2520EpC+xg==",
-      "dev": true,
-      "requires": {
-        "@types/sizzle": "*"
-      }
-    },
     "@types/jsdom": {
       "version": "16.2.14",
       "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-16.2.14.tgz",
@@ -17044,12 +17013,6 @@
       "requires": {
         "@types/pollyjs__core": "*"
       }
-    },
-    "@types/sizzle": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.3.tgz",
-      "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ==",
-      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",
@@ -21437,11 +21400,6 @@
           }
         }
       }
-    },
-    "jquery": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.0.tgz",
-      "integrity": "sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@types/greasemonkey": "4.0.3",
     "@types/jest": "28.1.1",
     "@types/jest-when": "3.5.0",
-    "@types/jquery": "3.5.14",
     "@types/postcss-preset-env": "6.7.3",
     "@types/rollup__plugin-virtual": "2.0.1",
     "@types/rollup-plugin-progress": "1.1.1",
@@ -106,7 +105,6 @@
     "warcio": "1.5.1"
   },
   "dependencies": {
-    "jquery": "3.6.0",
     "p-throttle": "5.0.0",
     "ts-custom-error": "3.2.0"
   }

--- a/src/mb_enhanced_cover_art_uploads/tsconfig.json
+++ b/src/mb_enhanced_cover_art_uploads/tsconfig.json
@@ -5,6 +5,6 @@
         { "path": "../lib/" }
     ],
     "compilerOptions": {
-        "types": ["jquery", "nativejsx/types/jsx", "greasemonkey"]
+        "types": ["nativejsx/types/jsx", "greasemonkey"]
     }
 }


### PR DESCRIPTION
So apparently my previous experimentation didn't go far enough and it turns out we don't actually need jQuery to get MB to handle the drop event. The reason we were using jQuery was that we can't "officially" instantiate our own `DropEvent`s with a `FileList` with our own files in the `dataTransfer` property (either because of read-only properties, private constructors, or some other security precaution). However, I never tried just defining the necessary properties using `Object.defineProperty`, which can circumvent the readonly status. Turns out, that just works. :tada:

Fixes #440.

Tested successfully on:
- [x] Firefox/Violentmonkey
- [x] Firefox/Violentmonkey BETA
- [x] Firefox/Tampermonkey
- [x] Firefox/Greasemonkey 4
- [x] Chromium/Violentmonkey
- [x] Chromium/Violentmonkey BETA
- [x] Chromium/Tampermonkey
- [x] Waterfox/Greasemonkey 3