### PR TITLE
fix(ecau): don't require dimensions to load before inserting seed links on a-tisket

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/atisket.tsx
@@ -56,8 +56,8 @@ function addSeedLinkToCovers(mbid: string, origin: string): void {
 }
 
 function tryExtractReleaseUrl(fig: HTMLElement): string | undefined {
-    const countryCode = fig.closest('div')?.dataset['matched-country'];
-    const vendorId = fig.dataset['vendor-id'];
+    const countryCode = fig.closest('div')?.dataset.matchedCountry;
+    const vendorId = fig.dataset.vendorId;
     const vendorCode = [...fig.classList]
         .find((klass) => ['spf', 'deez', 'itu'].includes(klass));
     // Vendor code and ID are required, but we only need a non-empty country code for Apple Music/iTunes releases


### PR DESCRIPTION
Fixes #438. Also fixes a new issue introduced by #464 (seeding still worked, but it was using image links instead of release links).

If we merge #451 before this one, I'll also do the refactoring to use the new implementation here so we get a retry loop.