### PR TITLE
refactor(lib): allow tree-shaking the prototype input setter

### DIFF
--- a/src/lib/util/async.ts
+++ b/src/lib/util/async.ts
@@ -33,8 +33,8 @@ export function retryTimes<T>(fn: () => T | Promise<T>, times: number, retryWait
 }
 
 // istanbul ignore next: Fine.
-export function logFailure(promise: Promise<unknown>, message?: string): void {
+export function logFailure(promise: Promise<unknown>, message = 'An error occurred'): void {
     promise.catch((err) => {
-        LOGGER.error(message ?? 'An error occurred', err);
+        LOGGER.error(message, err);
     });
 }

--- a/src/lib/util/dom.ts
+++ b/src/lib/util/dom.ts
@@ -2,7 +2,7 @@
  * DOM utilities.
  */
 
-import { assertDefined, assertNonNull } from './assert';
+import { assertNonNull } from './assert';
 
 /**
  * Element.querySelector shorthand, query result required to exist.
@@ -70,14 +70,12 @@ export function parseDOM(html: string, baseUrl: string): Document {
     return doc;
 }
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const nativeInputValueSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
-assertDefined(nativeInputValueSetter);
+const inputValueSetterDescriptor = /*#__PURE__*/ Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
 
 // https://stackoverflow.com/a/46012210
 // Via kellnerd, https://github.com/kellnerd/musicbrainz-bookmarklets/blob/730ed0f96a81ef9bb239ed564f247bd68f84bee3/utils/dom/react.js
 export function setInputValue(input: HTMLInputElement, value: string, dispatchEvent = true): void {
-    nativeInputValueSetter!.call(input, value);
+    inputValueSetterDescriptor!.set!.call(input, value);
     if (dispatchEvent) {
         input.dispatchEvent(new Event('input', { bubbles: true }));
     }

--- a/src/lib/util/dom.ts
+++ b/src/lib/util/dom.ts
@@ -70,12 +70,12 @@ export function parseDOM(html: string, baseUrl: string): Document {
     return doc;
 }
 
-const inputValueSetterDescriptor = /*#__PURE__*/ Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
+const inputValueDescriptor = /*#__PURE__*/ Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value');
 
 // https://stackoverflow.com/a/46012210
 // Via kellnerd, https://github.com/kellnerd/musicbrainz-bookmarklets/blob/730ed0f96a81ef9bb239ed564f247bd68f84bee3/utils/dom/react.js
 export function setInputValue(input: HTMLInputElement, value: string, dispatchEvent = true): void {
-    inputValueSetterDescriptor!.set!.call(input, value);
+    inputValueDescriptor!.set!.call(input, value);
     if (dispatchEvent) {
         input.dispatchEvent(new Event('input', { bubbles: true }));
     }

--- a/src/mb_multi_external_links/index.ts
+++ b/src/mb_multi_external_links/index.ts
@@ -34,7 +34,6 @@ function submitUrls(editor: ExternalLinks, urls: string[]): void {
 
     LOGGER.debug(`Submitting URL ${urls[0]}`);
     setInputValue(lastInput, urls[0]);
-    lastInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
     // Need to wait a while before the input event is processed before we can
     // fire the blur event, otherwise things get messy.
     setTimeout(() => {


### PR DESCRIPTION
https://github.com/ROpdebee/mb-userscripts/pull/473#issuecomment-1153312621

Probably not worth a new version, but `skip cd` will cause useless updates to be made to 2 of the 3 TS scripts on the next PR anway, and it'll bother me otherwise.

\+ A small fix for `split links` and refactoring to use `logFailure`, not worth separate PRs and deployments IMO.