### PR TITLE
fix(seed disamb): update release title extraction for new MBS version

### DIFF
--- a/mb_qol_seed_recording_disambiguation.user.js
+++ b/mb_qol_seed_recording_disambiguation.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: QoL: Seed the batch recording comments script
-// @version      2021.12.23
+// @version      2022.6.13
 // @description  Seed the recording comments for the batch recording comments userscripts with live and DJ-mix data.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -29,7 +29,9 @@ function unicodeToAscii(s) {
 }
 
 function getReleaseTitle() {
-    return $('.releaseheader > h1:first-child bdi').text();
+    // Make sure we're only taking the first <bdi> element. There could be a
+    // second if the release has a disambiguation comment itself.
+    return document.querySelector('.releaseheader > h1 bdi').textContent;
 }
 
 function getDJMixComment() {


### PR DESCRIPTION
Partial fix for #480.

Ideally we should extract it from the JSON-LD embedded on the page, or some other source that doesn't rely as much on the DOM structure. However, we'll do that after the script is rewritten to TypeScript. I'm going to leave the issue open until then though.