### PR TITLE
fix(inline recs): use MBS custom events to prevent hydration errors

### DIFF
--- a/mb_qol_inline_recording_tracks.user.js
+++ b/mb_qol_inline_recording_tracks.user.js
@@ -108,7 +108,7 @@ function loadAndInsert() {
 // listening for the correct one.
 function onReactHydrated(element, callback) {
     var alreadyHydrated = Object.keys(element).some(function (propertyName) {
-        return propertyName.indexOf('_reactListening') === 0 && element[propertyName];
+        return propertyName.startsWith('_reactListening') && element[propertyName];
     });
 
     if (alreadyHydrated) {


### PR DESCRIPTION
Followup for #484. The previous fix in #489 works, but isn't ideal. Instead, we'll use the new custom events dispatched by MBS when hydration on an element finishes, introduced in https://github.com/metabrainz/musicbrainz-server/pull/2566.

Blocked until https://github.com/metabrainz/musicbrainz-server/pull/2566 gets released into production, but can currently be tested on test.musicbrainz.org.