### PR TITLE
test(ecau): test for missing providers in docs

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/docs/supported_providers.md
+++ b/src/mb_enhanced_cover_art_uploads/docs/supported_providers.md
@@ -18,12 +18,12 @@ The following table describes the types of links supported by MB: Upload to CAA 
 | Discogs | Partial | ❌ | Images are limited to 600x600, see [qsniyg/maxurl#689](https://github.com/qsniyg/maxurl/issues/689) |
 | Jamendo | ✔️ | ✔️ |
 | Melon | ✔️ | ✔️ |
-| MusicBrainz/CAA | ✔️ | ✔️ | To copy images from one release to another. |
+| MusicBrainz/Cover Art Archive | ✔️ | ✔️ | To copy images from one release to another. |
 | Musik-Sammler | ✔️ | ❌ |
 | Qobuz | ✔️ | ✔️ | Goodies are grabbed whenever possible. Back covers might not be supported at this time, if you have a release with a back cover, please let me know. Maximised to original source image. |
 | QUB Musique | ✔️ | ✔️ | Dispatched to Qobuz provider. |
 | RateYourMusic | ✔️ | ✔️ | Requires being logged in to RYM. |
-| Rockipedia.no | ✔️ | ❌ |
+| Rockipedia | ✔️ | ❌ |
 | Soundcloud | ✔️ | ✔️ | Grabs custom track images. |
 | Spotify | ✔️ | ✔️ |
 | Tidal | ✔️ | ✔️ | listen.tidal.com/store.tidal.com are converted to tidal.com prior to fetching |

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/docs.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/docs.test.ts
@@ -1,0 +1,41 @@
+import '@src/mb_enhanced_cover_art_uploads/providers';
+
+import fs from 'node:fs/promises';
+
+import type { CoverArtProvider } from '@src/mb_enhanced_cover_art_uploads/providers/base';
+import { DispatchMap } from '@lib/util/domain_dispatch';
+
+jest.mock('@lib/util/domain_dispatch');
+
+// eslint-disable-next-line jest/unbound-method
+const spyDispatchMapSet = DispatchMap.prototype.set as jest.MockedFunction<DispatchMap<CoverArtProvider>['set']>;
+
+function getAllProviderNamesInSource(): Set<string> {
+    const providerNames = new Set<string>();
+
+    for (const [, provider] of spyDispatchMapSet.mock.calls) {
+        providerNames.add(provider.name);
+    }
+
+    return providerNames;
+}
+
+describe('cover art provider documentation', () => {
+    const providerNamesInDocs = new Set<string>();
+
+    beforeAll(async () => {
+        const docsContent = await fs.readFile('./src/mb_enhanced_cover_art_uploads/docs/supported_providers.md', {
+            encoding: 'utf8',
+        });
+
+        for (const providerNameMatch of docsContent.matchAll(/^\|([^|]+)\|/gm)) {
+            for (const providerName of providerNameMatch[1].split('/')) {
+                providerNamesInDocs.add(providerName.trim());
+            }
+        }
+    });
+
+    it.each([...getAllProviderNamesInSource()])('has an entry for %s', (providerName) => {
+        expect(providerNamesInDocs.has(providerName)).toBeTrue();
+    });
+});


### PR DESCRIPTION
While adding new providers yesterday, I kept on forgetting to add them to the `supported_providers.md` file. This adds a test to verify that the new provider has an entry in that file.