### PR TITLE
fix(ecau): prevent accidental double pastes

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -8,6 +8,8 @@ import type { CoverArtProvider } from '../providers/base';
 
 import css from './main.scss';
 
+const INPUT_PLACEHOLDER_TEXT = 'or paste one or more URLs here';
+
 export class InputForm {
     private readonly urlInput: HTMLInputElement;
     private readonly buttonContainer: HTMLDivElement;
@@ -20,7 +22,7 @@ export class InputForm {
         // The input element into which URLs will be pasted.
         this.urlInput = <input
             type='url'
-            placeholder='or paste one or more URLs here'
+            placeholder={INPUT_PLACEHOLDER_TEXT}
             size={47}
             id='ROpdebee_paste_url'
             // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -28,6 +30,12 @@ export class InputForm {
                 // Early validation.
                 if (!evt.currentTarget.value) return;
                 const oldValue = evt.currentTarget.value;
+                // Prevent accidental double pasting, which could append to the
+                // existing URL.
+                evt.currentTarget.value = '';
+                // Set the URL we'll process as the input's placeholder text as
+                // an "acknowledgement".
+                evt.currentTarget.placeholder = oldValue;
 
                 for (const inputUrl of oldValue.trim().split(/\s+/)) {
                     let url: URL;
@@ -44,8 +52,8 @@ export class InputForm {
                 }
                 app.clearLogLater();
 
-                if (this.urlInput.value === oldValue) {
-                    this.urlInput.value = '';
+                if (this.urlInput.placeholder === oldValue) {
+                    this.urlInput.placeholder = INPUT_PLACEHOLDER_TEXT;
                 }
             }}
         /> as HTMLInputElement;


### PR DESCRIPTION
Fixes issue reported by [chaban in the forums](https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/84?u=ropdebee).

~It's a bit of a hack, but it should prevent double pasting from causing dupes. I've described some possible alternatives in the comments, but they would probably either be quite complex, not user-friendly, or both.~ ~I should really test stuff before I push. This doesn't work :facepalm: Something is removing the space we're appending (I think an MB event handler?), so I'm working on another solution.~

We'll now clear the input as soon as we're handling it, and set the URL we're processing as the input's placeholder as an "acknowledgement".