### PR TITLE
fix(caa dims): fix order of dimensions on queued upload thumbnails

### DIFF
--- a/src/mb_caa_dimensions/DisplayedImage.tsx
+++ b/src/mb_caa_dimensions/DisplayedImage.tsx
@@ -178,7 +178,7 @@ export class DisplayedQueuedUploadImage extends BaseDisplayedImage {
         if (this.imgElement.src.endsWith('/static/images/icons/pdf-icon.png')) return;
 
         const dimensions = await this.image.getDimensions();
-        const infoString = `${dimensions.height}x${dimensions.width}`;
+        const infoString = `${dimensions.width}x${dimensions.height}`;
         this.dimensionsSpan.textContent = infoString;
     }
 }


### PR DESCRIPTION
Fixed this previously for other images, but missed the same mistake in queued upload thumbnails.

Follow up for #495.