### PR TITLE
fix(split links): adjust links editor properties for new MBS version

### DIFF
--- a/src/lib/MB/types.ts
+++ b/src/lib/MB/types.ts
@@ -20,7 +20,9 @@ export interface ExternalLinks {
 
 export interface ReleaseEditor {
     externalLinks: {
-        current: ExternalLinks;
+        externalLinksEditorRef: {
+            current: ExternalLinks;
+        };
     };
 }
 
@@ -29,7 +31,9 @@ declare global {
         MB: {
             releaseEditor?: ReleaseEditor;
             sourceExternalLinksEditor?: {
-                current: ExternalLinks;
+                externalLinksEditorRef: {
+                    current: ExternalLinks;
+                };
             };
         };
     }

--- a/src/mb_multi_external_links/index.ts
+++ b/src/mb_multi_external_links/index.ts
@@ -4,7 +4,7 @@ import type { ExternalLinks } from '@lib/MB/types';
 import { ConsoleSink } from '@lib/logging/consoleSink';
 import { LogLevel } from '@lib/logging/levels';
 import { LOGGER } from '@lib/logging/logger';
-import { assertDefined } from '@lib/util/assert';
+import { assertHasValue } from '@lib/util/assert';
 import { logFailure, retryTimes } from '@lib/util/async';
 import { createPersistentCheckbox } from '@lib/util/checkboxes';
 import { onAddEntityDialogLoaded, qsa, qsMaybe, setInputValue } from '@lib/util/dom';
@@ -14,8 +14,8 @@ import USERSCRIPT_ID from 'consts:userscript-id';
 
 function getExternalLinksEditor(mbInstance: typeof window.MB): ExternalLinks {
     // Can be found in the MB object, but exact property depends on actual page.
-    const editor = (mbInstance.releaseEditor?.externalLinks ?? mbInstance.sourceExternalLinksEditor)?.current;
-    assertDefined(editor, 'Cannot find external links editor object');
+    const editor = (mbInstance.releaseEditor?.externalLinks ?? mbInstance.sourceExternalLinksEditor)?.externalLinksEditorRef.current;
+    assertHasValue(editor, 'Cannot find external links editor object');
     return editor;
 }
 


### PR DESCRIPTION
https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/91

https://github.com/metabrainz/musicbrainz-server/pull/2497 changed some internals that we were using to get the external links editor object (specifically, https://github.com/metabrainz/musicbrainz-server/pull/2497/files#diff-20a3affccc96c36d0a67c0ca98ebc7010590a1adc067eeea57147b0302bf1add).

This is only in beta for now, so for now we'll try both the fixed and old implementation and use the one that worked, but once this goes into prod we should remove the old implementation.