### PR TITLE
build: automatically insert logger boilerplate config

### DIFF
--- a/build/plugin-logger.ts
+++ b/build/plugin-logger.ts
@@ -1,0 +1,75 @@
+import type { FilterPattern } from '@rollup/pluginutils';
+import type { Plugin } from 'rollup';
+import { createFilter } from '@rollup/pluginutils';
+
+interface PluginOptions {
+    include?: FilterPattern;
+    exclude?: FilterPattern;
+}
+
+const LOGGER_CODE = `
+import { ConsoleSink } from '@lib/logging/consoleSink';
+import { LogLevel } from '@lib/logging/levels';
+import { LOGGER } from '@lib/logging/logger';
+
+import DEBUG_MODE from 'consts:debug-mode';
+import USERSCRIPT_ID from 'consts:userscript-id';
+
+LOGGER.configure({
+    logLevel: DEBUG_MODE ? LogLevel.DEBUG : LogLevel.INFO,
+});
+LOGGER.addSink(new ConsoleSink(USERSCRIPT_ID));
+`;
+
+export const LOGGER_SOURCE_ID = '_LOGGER_virtualSource_';
+
+/**
+ * Transformer plugin to automatically inject the logger boilerplate setup.
+ *
+ * @param      {Readonly<PluginOptions>}  options  The options
+ * @return     {Plugin}  The plugin.
+ */
+export function logger(options?: Readonly<PluginOptions>): Plugin {
+    // Another option would've been to put the boilerplate configuration into
+    // `@lib/util/logger.ts`, so the logger gets its default configuration when
+    // it's imported anywhere. However, this will also enable the logger and its
+    // console sink in the tests, which would lead to noisy test output.
+    const { include, exclude } = options ?? {};
+    const filter = createFilter(include, exclude);
+
+    return {
+        name: 'LoggerPlugin',
+
+        resolveId(id): { id: string; moduleSideEffects: boolean } | null {
+            if (id === LOGGER_SOURCE_ID) {
+                return {
+                    id: LOGGER_SOURCE_ID,
+                    moduleSideEffects: true,
+                };
+            }
+            return null;
+        },
+
+        load(id): string | undefined {
+            if (id === LOGGER_SOURCE_ID) return LOGGER_CODE;
+            return undefined;
+        },
+
+        /**
+         * Transform hook for the plugin.
+         *
+         * Injects the logger boilerplate setup.
+         *
+         * @param      {string}                       code    The code
+         * @param      {string}                       id      The identifier
+         * @return     {Promise<undefined | string>}  The transformed result.
+         */
+        async transform(code: string, id: string): Promise<undefined | string> {
+            if (!filter(id)) return;
+
+            // Insert logger code first, so it gets configured before anything
+            // else runs.
+            return [`import "${LOGGER_SOURCE_ID}";`, code].join('\n\n');
+        },
+    };
+}

--- a/src/mb_caa_dimensions/index.ts
+++ b/src/mb_caa_dimensions/index.ts
@@ -1,8 +1,5 @@
 // istanbul ignore file: Covered by E2E
 
-import { ConsoleSink } from '@lib/logging/consoleSink';
-import { LogLevel } from '@lib/logging/levels';
-import { LOGGER } from '@lib/logging/logger';
 import { logFailure } from '@lib/util/async';
 import { insertStylesheet } from '@lib/util/css';
 import { onDocumentLoaded, qs, qsa, qsMaybe } from '@lib/util/dom';
@@ -12,14 +9,7 @@ import { displayedCoverArtFactory, DisplayedQueuedUploadImage, displayInfoWhenIn
 import { setupExports } from './exports';
 import { createCache } from './InfoCache';
 
-import DEBUG_MODE from 'consts:debug-mode';
-import USERSCRIPT_ID from 'consts:userscript-id';
 import css from './style.scss';
-
-LOGGER.configure({
-    logLevel: DEBUG_MODE ? LogLevel.DEBUG : LogLevel.INFO,
-});
-LOGGER.addSink(new ConsoleSink(USERSCRIPT_ID));
 
 async function processPageChange(mutations: MutationRecord[], cache: InfoCache): Promise<void> {
     mutations.flatMap((mutation) => [...mutation.addedNodes])

--- a/src/mb_enhanced_cover_art_uploads/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/index.ts
@@ -1,19 +1,9 @@
 /* istanbul ignore file: Covered by E2E */
 
-import { ConsoleSink } from '@lib/logging/consoleSink';
-import { LogLevel } from '@lib/logging/levels';
 import { LOGGER } from '@lib/logging/logger';
 
 import { App } from './App';
 import { seederFactory } from './seeding';
-
-import DEBUG_MODE from 'consts:debug-mode';
-import USERSCRIPT_ID from 'consts:userscript-id';
-
-LOGGER.configure({
-    logLevel: DEBUG_MODE ? LogLevel.DEBUG : LogLevel.INFO,
-});
-LOGGER.addSink(new ConsoleSink(USERSCRIPT_ID));
 
 const seeder = seederFactory(document.location);
 if (seeder) {

--- a/src/mb_multi_external_links/index.ts
+++ b/src/mb_multi_external_links/index.ts
@@ -1,16 +1,12 @@
 // istanbul ignore file: Better suited for E2E test.
 
 import type { ExternalLinks } from '@lib/MB/types';
-import { ConsoleSink } from '@lib/logging/consoleSink';
-import { LogLevel } from '@lib/logging/levels';
 import { LOGGER } from '@lib/logging/logger';
 import { assertDefined } from '@lib/util/assert';
 import { logFailure, retryTimes } from '@lib/util/async';
 import { createPersistentCheckbox } from '@lib/util/checkboxes';
 import { onAddEntityDialogLoaded, qsa, qsMaybe, setInputValue } from '@lib/util/dom';
 
-import DEBUG_MODE from 'consts:debug-mode';
-import USERSCRIPT_ID from 'consts:userscript-id';
 
 function getExternalLinksEditor(mbInstance: typeof window.MB): ExternalLinks {
     // Can be found in the MB object, but exact property depends on actual page.
@@ -187,11 +183,6 @@ function listenForIframes(): void {
         childList: true,
     });
 }
-
-LOGGER.configure({
-    logLevel: DEBUG_MODE ? LogLevel.DEBUG : LogLevel.INFO,
-});
-LOGGER.addSink(new ConsoleSink(USERSCRIPT_ID));
 
 logFailure(run(window));
 


### PR DESCRIPTION
I keep forgetting to enable the logger in new or migrated scripts, all of them need it, and the code is mostly identical anyway. Let's automatically inject it when building it so it'll always be present.

Cherry-picked from #499.