### PR TITLE
fix(caa dims): separate cache key from full-size URL

### DIFF
--- a/tests/unit/mb_caa_dimensions/Image.test.ts
+++ b/tests/unit/mb_caa_dimensions/Image.test.ts
@@ -2,7 +2,7 @@ import { getCAAInfo } from '@src/mb_caa_dimensions/caa_info';
 import { getImageDimensions } from '@src/mb_caa_dimensions/dimensions';
 import { CAAImage, QueuedUploadImage } from '@src/mb_caa_dimensions/Image';
 
-import { dummyCAAItemID, dummyCAAReleaseFullSizeURL, dummyCAAReleaseThumbnailURL, dummyDimensions, dummyFileInfo, dummyFullSizeURL, dummyImageID, dummyImageInfo, dummyPDFJP2URL, dummyPDFURL, dummyReleaseGroupURL, dummyThumbnail, mockCache } from './test-utils/mock-data';
+import { dummyCAAItemID, dummyCAAReleaseFullSizeURL, dummyCAAReleaseGroupURL, dummyCAAReleasePDFURL, dummyCAAReleaseThumbnailURL, dummyDimensions, dummyDirectFullSizeURL, dummyDirectPDFURL, dummyDirectThumbnailURL, dummyFileInfo, dummyImageID, dummyImageInfo, dummyPDFJP2URL, dummyReleaseID, mockCache } from './test-utils/mock-data';
 
 jest.mock('@src/mb_caa_dimensions/InfoCache');
 jest.mock('@src/mb_caa_dimensions/caa_info');
@@ -26,7 +26,7 @@ describe('caa image', () => {
     describe('getting dimensions', () => {
         it('retrieves from cache if available', async () => {
             mockCache.getDimensions.mockResolvedValue(dummyDimensions);
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getDimensions()).resolves.toStrictEqual(dummyDimensions);
             expect(mockGetImageDimensions).not.toHaveBeenCalled();
@@ -35,41 +35,41 @@ describe('caa image', () => {
         it('loads on cache miss', async () => {
             mockCache.getDimensions.mockResolvedValue(undefined);
             mockGetImageDimensions.mockResolvedValue(dummyDimensions);
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getDimensions()).resolves.toStrictEqual(dummyDimensions);
             expect(mockGetImageDimensions).toHaveBeenCalledOnce();
-            expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyFullSizeURL);
+            expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyDirectFullSizeURL);
             expect(mockCache.putDimensions).toHaveBeenCalledOnce();
-            expect(mockCache.putDimensions).toHaveBeenCalledWith(dummyFullSizeURL, dummyDimensions);
+            expect(mockCache.putDimensions).toHaveBeenCalledWith(dummyDirectFullSizeURL, dummyDimensions);
         });
 
         it('loads on cache error', async () => {
             mockCache.getDimensions.mockRejectedValue(new Error('test'));
             mockGetImageDimensions.mockResolvedValue(dummyDimensions);
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getDimensions()).resolves.toStrictEqual(dummyDimensions);
             expect(mockGetImageDimensions).toHaveBeenCalledOnce();
-            expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyFullSizeURL);
+            expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyDirectFullSizeURL);
             expect(mockCache.putDimensions).toHaveBeenCalledOnce();
-            expect(mockCache.putDimensions).toHaveBeenCalledWith(dummyFullSizeURL, dummyDimensions);
+            expect(mockCache.putDimensions).toHaveBeenCalledWith(dummyDirectFullSizeURL, dummyDimensions);
         });
 
         it('returns undefined when live loading fails', async () => {
             mockCache.getDimensions.mockRejectedValue(new Error('test'));
             mockGetImageDimensions.mockRejectedValue(new Error('test'));
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getDimensions()).resolves.toBeUndefined();
             expect(mockGetImageDimensions).toHaveBeenCalledOnce();
-            expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyFullSizeURL);
+            expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyDirectFullSizeURL);
             expect(mockCache.putDimensions).not.toHaveBeenCalled();
         });
 
         it('loads PDF dimensions from first page', async () => {
             mockGetImageDimensions.mockResolvedValue(dummyDimensions);
-            const image = new CAAImage(dummyPDFURL, mockCache);
+            const image = new CAAImage(dummyDirectPDFURL, mockCache);
 
             await expect(image.getDimensions()).resolves.toStrictEqual(dummyDimensions);
             expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyPDFJP2URL);
@@ -79,7 +79,7 @@ describe('caa image', () => {
     describe('getting file info', () => {
         it('retrieves from cache if available', async () => {
             mockCache.getFileInfo.mockResolvedValue(dummyFileInfo);
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getFileInfo()).resolves.toStrictEqual(dummyFileInfo);
             expect(mockGetCAAInfo).not.toHaveBeenCalled();
@@ -88,29 +88,29 @@ describe('caa image', () => {
         it('loads on cache miss', async () => {
             mockCache.getFileInfo.mockResolvedValue(undefined);
             mockGetCAAInfo.mockResolvedValue(dummyFileInfo);
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getFileInfo()).resolves.toStrictEqual(dummyFileInfo);
             expect(mockGetCAAInfo).toHaveBeenCalledOnce();
             expect(mockGetCAAInfo).toHaveBeenCalledWith(dummyCAAItemID, dummyImageID);
-            expect(mockCache.putFileInfo).toHaveBeenCalledWith(dummyFullSizeURL, dummyFileInfo);
+            expect(mockCache.putFileInfo).toHaveBeenCalledWith(dummyDirectFullSizeURL, dummyFileInfo);
         });
 
         it('loads on cache error', async () => {
             mockCache.getFileInfo.mockRejectedValue(new Error('test'));
             mockGetCAAInfo.mockResolvedValue(dummyFileInfo);
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getFileInfo()).resolves.toStrictEqual(dummyFileInfo);
             expect(mockGetCAAInfo).toHaveBeenCalledOnce();
             expect(mockGetCAAInfo).toHaveBeenCalledWith(dummyCAAItemID, dummyImageID);
-            expect(mockCache.putFileInfo).toHaveBeenCalledWith(dummyFullSizeURL, dummyFileInfo);
+            expect(mockCache.putFileInfo).toHaveBeenCalledWith(dummyDirectFullSizeURL, dummyFileInfo);
         });
 
         it('returns undefined when live loading fails', async () => {
             mockCache.getFileInfo.mockRejectedValue(new Error('test'));
             mockGetCAAInfo.mockRejectedValue(new Error('test'));
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getFileInfo()).resolves.toBeUndefined();
             expect(mockGetCAAInfo).toHaveBeenCalledOnce();
@@ -123,7 +123,7 @@ describe('caa image', () => {
         it('loads dimensions and file info', async () => {
             mockGetImageDimensions.mockResolvedValue(dummyDimensions);
             mockGetCAAInfo.mockResolvedValue(dummyFileInfo);
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getImageInfo()).resolves.toStrictEqual(dummyImageInfo);
         });
@@ -131,7 +131,7 @@ describe('caa image', () => {
         it('loads dimensions when file info fails', async () => {
             mockGetImageDimensions.mockResolvedValue(dummyDimensions);
             mockGetCAAInfo.mockRejectedValue(new Error('test'));
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getImageInfo()).resolves.toStrictEqual({
                 dimensions: dummyDimensions,
@@ -143,7 +143,7 @@ describe('caa image', () => {
         it('loads file info when dimensions fail', async () => {
             mockGetImageDimensions.mockRejectedValue(new Error('test'));
             mockGetCAAInfo.mockResolvedValue(dummyFileInfo);
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getImageInfo()).resolves.toStrictEqual({
                 dimensions: undefined,
@@ -154,7 +154,7 @@ describe('caa image', () => {
         it('loads nothing when both fail', async () => {
             mockGetImageDimensions.mockRejectedValue(new Error('test'));
             mockGetCAAInfo.mockRejectedValue(new Error('test'));
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
+            const image = new CAAImage(dummyDirectFullSizeURL, mockCache);
 
             await expect(image.getImageInfo()).resolves.toStrictEqual({
                 dimensions: undefined,
@@ -164,70 +164,117 @@ describe('caa image', () => {
         });
     });
 
-    describe('parsing CAA URLs', () => {
-        it('extracts correct item ID and image ID', async () => {
-            const image = new CAAImage(dummyFullSizeURL, mockCache);
-            await image.getFileInfo(); // Needed so we can inspect the mocked function call to see whether URL was parsed correctly.
+    describe('transforming URLs', () => {
+        const cacheKeyCases: Array<[string, string, string | undefined, string]> = [
+            // description, full-size URL, thumbnail URL, expected cache key
+            ['direct full-size URLs', dummyDirectFullSizeURL, undefined, dummyDirectFullSizeURL],
+            ['direct PDF URLs', dummyDirectPDFURL, undefined, dummyDirectPDFURL],
+            ['CAA-redirected release URLs', dummyCAAReleaseFullSizeURL, undefined, dummyDirectFullSizeURL],
+            ['CAA-redirected release group URLs', dummyCAAReleaseGroupURL, dummyDirectThumbnailURL, dummyDirectThumbnailURL],
+            ['CAA-redirected PDF URLs', dummyCAAReleasePDFURL, undefined, dummyDirectPDFURL],
+        ];
 
-            expect(mockGetCAAInfo).toHaveBeenCalledWith(dummyCAAItemID, dummyImageID);
+        it.each(cacheKeyCases)('extracts cache key from %s', async (_1, fullSizeURL, thumbnailURL, expectedCacheKey) => {
+            const image = new CAAImage(fullSizeURL, mockCache, thumbnailURL);
+            await image.getFileInfo(); // Needed so we can inspect the mocked function call to see whether the cache key was extracted correctly.
+
+            expect(mockCache.getFileInfo).toHaveBeenCalledWith(expectedCacheKey);
         });
 
-        it('extracts correct item ID and image ID from coverartarchive.org release URLs', async () => {
-            const image = new CAAImage(dummyCAAReleaseThumbnailURL, mockCache, dummyCAAReleaseThumbnailURL);
+        const imageURLCases: Array<[string, string, string | undefined, string]> = [
+            // description, input URL, thumbnail URL, expected image URL
+            ['direct full-size URLs', dummyDirectFullSizeURL, undefined, dummyDirectFullSizeURL],
+            ['direct PDF URLs', dummyDirectPDFURL, undefined, dummyPDFJP2URL],
+            ['CAA-redirected release URLs', dummyCAAReleaseFullSizeURL, undefined, dummyDirectFullSizeURL],
+            ['CAA-redirected release group URLs', dummyCAAReleaseGroupURL, dummyDirectThumbnailURL, dummyCAAReleaseGroupURL],
+            ['CAA-redirected PDF URLs', dummyCAAReleasePDFURL, undefined, dummyPDFJP2URL],
+        ];
+
+        it.each(imageURLCases)('transforms URL for %s', async (_1, fullSizeURL, thumbnailURL, expectedImageURL) => {
+            const image = new CAAImage(fullSizeURL, mockCache, thumbnailURL);
+            await image.getDimensions();
+
+            expect(mockGetImageDimensions).toHaveBeenCalledWith(expectedImageURL);
+        });
+
+        const caaIDCases: Array<[string, string, string | undefined]> = [
+            // description, input URL, thumbnail URL. Expected release and image IDs are always the same.
+            ['direct full-size URLs', dummyDirectFullSizeURL, undefined],
+            ['direct full-size URLs with thumbnail', dummyDirectFullSizeURL, dummyDirectThumbnailURL],
+            ['direct full-size URLs with redirected thumbnail', dummyDirectFullSizeURL, dummyCAAReleaseThumbnailURL],
+            ['direct PDF URLs', dummyDirectPDFURL, undefined],
+            ['direct PDF URLs with thumbnail', dummyDirectPDFURL, dummyDirectThumbnailURL],
+            ['direct PDF URLs with redirected thumbnail', dummyDirectPDFURL, dummyCAAReleaseThumbnailURL],
+            ['CAA-redirected release URLs', dummyCAAReleaseFullSizeURL, undefined],
+            ['CAA-redirected release URLs with thumbnail', dummyCAAReleaseFullSizeURL, dummyDirectThumbnailURL],
+            ['CAA-redirected release URLs with redirected thumbnail', dummyCAAReleaseFullSizeURL, dummyCAAReleaseThumbnailURL],
+            ['CAA-redirected PDF URLs', dummyCAAReleasePDFURL, undefined],
+            ['CAA-redirected PDF URLs with thumbnail', dummyCAAReleasePDFURL, dummyDirectThumbnailURL],
+            ['CAA-redirected PDF URLs with redirected thumbnail', dummyCAAReleasePDFURL, dummyCAAReleaseThumbnailURL],
+            // CAA-redirected RG URL without thumbnail should throw.
+            ['CAA-redirected release group URLs with thumbnail', dummyCAAReleaseGroupURL, dummyDirectThumbnailURL],
+            ['CAA-redirected release group URLs with redirected thumbnail', dummyCAAReleaseGroupURL, dummyCAAReleaseThumbnailURL],
+        ];
+
+        it.each(caaIDCases)('extracts correct item ID and image ID for %s', async (_1, fullSizeURL, thumbnailURL) => {
+            const image = new CAAImage(fullSizeURL, mockCache, thumbnailURL);
             await image.getFileInfo();
 
             expect(mockGetCAAInfo).toHaveBeenCalledWith(dummyCAAItemID, dummyImageID);
         });
 
-        it('does not parse CAA RG URLs', async () => {
-            // These don't have the image ID.
-            expect(() => new CAAImage(dummyReleaseGroupURL, mockCache)).toThrowWithMessage(Error, 'Unsupported URL');
+        it('throws on CAA-redirected release group URLs without thumbnails', () => {
+            expect(() => new CAAImage(dummyCAAReleaseGroupURL, mockCache))
+                .toThrowWithMessage(Error, 'Release group image requires a thumbnail URL');
         });
 
-        it('throws if URL is not supported', async () => {
-            expect(() => new CAAImage('https://archive.org/download/mbid-e276296d-0e1a-40bb-ac14-7a95f1ca7ff0/index.json', mockCache)).toThrowWithMessage(Error, 'Invalid URL');
+        it('throws on unsupported URLs', () => {
+            expect(() => new CAAImage(`https://archive.org/download/mbid-${dummyReleaseID}/index.json`, mockCache))
+                .toThrowWithMessage(Error, 'Invalid URL');
         });
 
-        it('only supports CAA or IA URLs', async () => {
-            expect(() => new CAAImage('https://example.com/test', mockCache)).toThrowWithMessage(Error, 'Unsupported URL');
-        });
-
-        it('uses thumbnail URL if available', async () => {
-            const image = new CAAImage(dummyReleaseGroupURL, mockCache, dummyThumbnail);
-            await image.getFileInfo();
-
-            expect(mockGetCAAInfo).toHaveBeenCalledWith(dummyCAAItemID, dummyImageID);
-        });
-
-        it('transforms full-size release coverartarchive.org URLs', async () => {
-            const image = new CAAImage(dummyCAAReleaseFullSizeURL, mockCache);
-            await image.getDimensions();
-
-            expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyFullSizeURL);
-        });
-
-        it('does not transform full-size RG coverartarchive.org URLs', async () => {
-            const image = new CAAImage(dummyReleaseGroupURL, mockCache, dummyThumbnail);
-            await image.getDimensions();
-
-            expect(mockGetImageDimensions).toHaveBeenCalledWith(dummyReleaseGroupURL);
+        it('throws on URLs with unsupported domain', () => {
+            expect(() => new CAAImage('https://example.com/test', mockCache))
+                .toThrowWithMessage(Error, 'Unsupported URL');
         });
     });
 });
 
 
 describe('queued upload image', () => {
-    const img = document.createElement('img');
+    let img: HTMLImageElement;
+    let mockGetComplete: jest.SpiedFunction<() => boolean>;
 
     beforeEach(() => {
+        img = document.createElement('img');
         jest.spyOn(img, 'naturalHeight', 'get').mockReturnValue(100);
         jest.spyOn(img, 'naturalWidth', 'get').mockReturnValue(200);
+        mockGetComplete = jest.spyOn(img, 'complete', 'get');
+        mockGetComplete.mockReturnValue(true);
     });
 
     it('loads dimensions', async () => {
         const queuedImage = new QueuedUploadImage(img);
 
         await expect(queuedImage.getDimensions()).resolves.toStrictEqual({
+            height: 100,
+            width: 200,
+        });
+    });
+
+    it('waits until image is loaded', async () => {
+        mockGetComplete.mockReturnValue(false);
+        const onResolved = jest.fn();
+        const queuedImage = new QueuedUploadImage(img);
+        const dimProm = queuedImage.getDimensions().then(onResolved);
+
+        expect(onResolved).not.toHaveBeenCalled();
+
+        img.dispatchEvent(new Event('load'));
+
+        await expect(dimProm).toResolve();
+        expect(onResolved).toHaveBeenCalledOnce();
+        expect(onResolved).toHaveBeenCalledWith({
             height: 100,
             width: 200,
         });

--- a/tests/unit/mb_caa_dimensions/test-utils/mock-data.ts
+++ b/tests/unit/mb_caa_dimensions/test-utils/mock-data.ts
@@ -22,12 +22,19 @@ export const mockCache = {
     putFileInfo: jest.fn<ReturnType<InfoCache['putFileInfo']>, Parameters<InfoCache['putFileInfo']>>(),
 };
 
-export const dummyThumbnail = 'https://archive.org/download/mbid-944da2ca-47fc-422c-af26-c3e54845ff65/mbid-944da2ca-47fc-422c-af26-c3e54845ff65-15603614015_thumb500.jpg';
-export const dummyFullSizeURL = 'https://archive.org/download/mbid-944da2ca-47fc-422c-af26-c3e54845ff65/mbid-944da2ca-47fc-422c-af26-c3e54845ff65-15603614015.jpg';
-export const dummyPDFURL = 'https://archive.org/download/mbid-82af81c4-0cfa-4382-abc6-2ec08a79b431/mbid-82af81c4-0cfa-4382-abc6-2ec08a79b431-29531260255.pdf';
-export const dummyPDFJP2URL = 'https://archive.org/download/mbid-82af81c4-0cfa-4382-abc6-2ec08a79b431/mbid-82af81c4-0cfa-4382-abc6-2ec08a79b431-29531260255_jp2.zip/mbid-82af81c4-0cfa-4382-abc6-2ec08a79b431-29531260255_jp2%2Fmbid-82af81c4-0cfa-4382-abc6-2ec08a79b431-29531260255_0000.jp2?ext=jpg';
-export const dummyReleaseGroupURL = 'https://coverartarchive.org/release-group/db4ebf13-42b0-3c47-8a06-374b6a49b645/front';
-export const dummyCAAReleaseThumbnailURL = 'https://coverartarchive.org/release/944da2ca-47fc-422c-af26-c3e54845ff65/15603614015-500.jpg';
-export const dummyCAAReleaseFullSizeURL = 'https://coverartarchive.org/release/944da2ca-47fc-422c-af26-c3e54845ff65/15603614015.jpg';
-export const dummyCAAItemID = 'mbid-944da2ca-47fc-422c-af26-c3e54845ff65';
+export const dummyReleaseID = '944da2ca-47fc-422c-af26-c3e54845ff65';
+export const dummyCAAItemID = `mbid-${dummyReleaseID}`;
 export const dummyImageID = '15603614015';
+const archivePrefix = 'https://archive.org/download';
+const caaPrefix = 'https://coverartarchive.org';
+
+export const dummyDirectThumbnailURL = `${archivePrefix}/${dummyCAAItemID}/${dummyCAAItemID}-${dummyImageID}_thumb500.jpg`;
+export const dummyDirectFullSizeURL = `${archivePrefix}/${dummyCAAItemID}/${dummyCAAItemID}-${dummyImageID}.png`;
+export const dummyCAAReleaseThumbnailURL = `${caaPrefix}/release/${dummyReleaseID}/${dummyImageID}-500.jpg`;
+export const dummyCAAReleaseFullSizeURL = `${caaPrefix}/release/${dummyReleaseID}/${dummyImageID}.png`;
+
+export const dummyDirectPDFURL = `${archivePrefix}/${dummyCAAItemID}/${dummyCAAItemID}-${dummyImageID}.pdf`;
+export const dummyCAAReleasePDFURL = `${caaPrefix}/release/${dummyReleaseID}/${dummyImageID}.pdf`;
+export const dummyPDFJP2URL = `${archivePrefix}/${dummyCAAItemID}/${dummyCAAItemID}-${dummyImageID}_jp2.zip/${dummyCAAItemID}-${dummyImageID}_jp2%2F${dummyCAAItemID}-${dummyImageID}_0000.jp2?ext=jpg`;
+
+export const dummyCAAReleaseGroupURL = `${caaPrefix}/release-group/db4ebf13-42b0-3c47-8a06-374b6a49b645/front`;


### PR DESCRIPTION
In most cases, we can use the full-size URL as the cache key. However, for release groups, the full-size URL is the CAA-redirected front image. When the RG cover is changed, this URL stays the same, so the cache isn't invalidated properly. Also, for PDFs, we were using the derived JP2 URL as the cache key instead of the PDF URL itself. This change fixes both by separating the cache key from the image URL we query. For RGs, the cache key will now be the thumbnail URL, which will change if the RG cover is changed.

Also reworked the tests to do better tests for these URL transformations and extractions. More work is needed there though, I think some of the earlier tests are doing duplicated work. Ideally, the URL transformation and extraction would be split off from the CAAImage class, but I didn't want to go into that much refactoring today.

Unfortunately, the RG image cache won't be shared with the cache of the release images, since RGs use thumbnails as keys while releases use the full-size URL. We could fix this by changing the cache key to something like `<release_id>/<image_id>` but that would require a DB upgrade to transform existing entries, and would also make the cache specific to CAA/IA URLs. The latter probably isn't too big of a problem though.

https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/92?u=ropdebee