### PR TITLE
fix(ecau): allow retrying provider URLs when some images failed

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -172,11 +172,11 @@ export class ImageFetcher {
             }
         }
 
-        if (!hasMoreImages) {
+        if (!hasMoreImages && queuedResults.length === finalImages.length) {
             // Don't mark the whole provider URL as done if we haven't grabbed
-            // all images.
+            // all images or some images failed.
             this.doneImages.add(url.href);
-        } else {
+        } else if (hasMoreImages) {
             LOGGER.warn(`Not all images were fetched: ${images.length - finalImages.length} covers were skipped.`);
         }
 


### PR DESCRIPTION
https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/94?u=ropdebee

We were marking a provider as done even if some (or even all!) of the images failed to fetch. This change will allow retrying when one or more images failed to fetch. Only the failed images will be retried, the ones that are already queued will be skipped via pre-existing logic.