### PR TITLE
fix(ecau): indicate progress when fetching single images

### DIFF
--- a/src/lib/util/array.ts
+++ b/src/lib/util/array.ts
@@ -41,6 +41,6 @@ export function collatedSort(array: string[]): string[] {
     return array.sort(coll.compare.bind(coll));
 }
 
-export function enumerate<T>(array: T[]): Array<[T, number]> {
+export function enumerate<T>(array: readonly T[]): Array<[T, number]> {
     return array.map((el, idx) => [el, idx]);
 }

--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -56,7 +56,6 @@ export class ImageFetcher {
         }
 
         const { types: defaultTypes, comment: defaultComment } = coverArt;
-        LOGGER.info(`Attempting to fetch ${url}`);
         const result = await this.fetchImageFromURL(url);
         if (!result) {
             return { images: [] };


### PR DESCRIPTION
Moving the direct image fetching log message to the caller instead of the fetcher since the caller knows how many URLs need to be processed whereas the fetcher doesn't. It'd make a bit more sense to have it in the fetcher, but that'd require more refactoring that I don't want to do right now.

https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/94?u=ropdebee