### PR TITLE
fix(ecau): warn when redirect cannot be detected

### DIFF
--- a/src/lib/util/xhr.ts
+++ b/src/lib/util/xhr.ts
@@ -65,7 +65,7 @@ export class NetworkError extends ResponseError {
 }
 
 // eslint-disable-next-line no-restricted-globals
-export async function gmxhr(url: string | URL, options?: GMXHROptions): Promise<GM.Response<never>> {
+export async function gmxhr(url: string | URL, options?: GMXHROptions): Promise<GM.Response<never> & { finalUrl?: string }> {
     return new Promise((resolve, reject) => {
         GMxmlHttpRequest({
             method: 'GET',

--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -209,7 +209,10 @@ export class ImageFetcher {
             headers: headers,
             progressCb: this.hooks.onFetchProgress?.bind(this.hooks, id, url),
         });
-        const fetchedUrl = new URL(resp.finalUrl);
+        if (typeof resp.finalUrl === 'undefined') {
+            LOGGER.warn(`Could not detect if URL ${url.href} caused a redirect`);
+        }
+        const fetchedUrl = new URL(resp.finalUrl || url);
         const wasRedirected = resp.finalUrl !== url.href;
 
         if (wasRedirected) {

--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -103,7 +103,9 @@ export abstract class CoverArtProvider {
 
     protected async fetchPage(url: URL, options?: GMXHROptions): Promise<string> {
         const resp = await gmxhr(url, options);
-        if (resp.finalUrl !== url.href && !this.isSafeRedirect(url, new URL(resp.finalUrl))) {
+        if (typeof resp.finalUrl === 'undefined') {
+            LOGGER.warn(`Could not detect if ${url.href} caused a redirect`);
+        } else if (resp.finalUrl !== url.href && !this.isSafeRedirect(url, new URL(resp.finalUrl))) {
             throw new Error(`Refusing to extract images from ${this.name} provider because the original URL redirected to ${resp.finalUrl}, which may be a different release. If this redirected URL is correct, please retry with ${resp.finalUrl} directly.`);
         }
 


### PR DESCRIPTION
In Violentmonkey, `finalUrl` on `GM.Response` can potentially be undefined, which previously led to crashes. Instead, we'll fall back on the original URL, but emit a warning when we could not detect potential redirects.