### PR TITLE
fix(ecau): don't use Promise#finally.

### DIFF
--- a/src/lib/util/async.ts
+++ b/src/lib/util/async.ts
@@ -38,3 +38,14 @@ export function logFailure(promise: Promise<unknown>, message = 'An error occurr
         LOGGER.error(message, err);
     });
 }
+
+/**
+ * Polyfill for Promise.prototype.finally.
+ */
+export async function pFinally<T>(promise: Promise<T>, onFinally: () => (void | Promise<void>)): Promise<T> {
+    try {
+        return await promise;
+    } finally {
+        await onFinally();
+    }
+}

--- a/src/lib/util/observable.ts
+++ b/src/lib/util/observable.ts
@@ -1,3 +1,5 @@
+import { pFinally } from './async';
+
 interface ObservableSemaphoreCallbacks {
     onAcquired(): void;
     onReleased(): void;
@@ -96,8 +98,7 @@ export class ObservableSemaphore {
             if (result instanceof Promise) {
                 // If the function returned a promise, we shouldn't release the
                 // lock just yet, and instead wait until the promise has settled.
-                result
-                    .finally(() => { this.release(); })
+                pFinally(result, this.release.bind(this))
                     // Also need to catch this one to prevent uncaught exceptions,
                     // since this chain is "detached" from the one we return.
                     // The one we return will reject separately.


### PR DESCRIPTION
Promise#finally isn't supported in all browsers which we claim to support, so we'll use a polyfill instead of using it directly.

Closes #537.