### PR TITLE
build(deps): allow renovate to pin dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
       "matchUpdateTypes": ["pin"],
       "automerge": true,
       "automergeType": "branch",
+      "recreateClosed": true,
       "schedule": ["at any time"]
     },
     {
@@ -19,6 +20,7 @@
       "matchUpdateTypes": ["lockFileMaintenance"],
       "automerge": true,
       "automergeType": "branch",
+      "recreateClosed": true,
       "schedule": ["on the first day of the month"]
     },
     {


### PR DESCRIPTION
The config didn't allow renovate to create new pin dependency updates since there were existing PRs under the same name.