### PR TITLE
refactor(ecau): standardise 404 error messages for providers

### DIFF
--- a/src/lib/util/xhr.ts
+++ b/src/lib/util/xhr.ts
@@ -10,15 +10,15 @@ export interface FetchProgress {
     total: number;
 }
 
-// eslint-disable-next-line no-restricted-globals
+/* eslint-disable no-restricted-globals */
 type LimitedGMXHROptions = Omit<GM.Request, 'onload'|'onerror'|'onabort'|'ontimeout'|'onprogress'|'onreadystatechange'|'method'|'url'>;
 
 export interface GMXHROptions extends LimitedGMXHROptions {
-    // eslint-disable-next-line no-restricted-globals
     method?: GM.Request['method'];
     progressCb?: (progress: FetchProgress) => void;
-
+    httpErrorMessages?: Record<number, string | undefined>;
 }
+/* eslint-enable no-restricted-globals */
 
 export abstract class ResponseError extends CustomError {
     public readonly url: string | URL;
@@ -35,9 +35,11 @@ export class HTTPResponseError extends ResponseError {
     public readonly response: GM.Response<never>;
 
     // eslint-disable-next-line no-restricted-globals
-    public constructor(url: string | URL, response: GM.Response<never>) {
+    public constructor(url: string | URL, response: GM.Response<never>, errorMessage?: string) {
         /* istanbul ignore else: Should not happen */
-        if (response.statusText.trim()) {
+        if (errorMessage) {
+            super(url, errorMessage);
+        } else if (response.statusText.trim()) {
             super(url, `HTTP error ${response.status}: ${response.statusText}`);
         } else {
             super(url, `HTTP error ${response.status}`);
@@ -73,7 +75,7 @@ export async function gmxhr(url: string | URL, options?: GMXHROptions): Promise<
             ...options,
 
             onload: (resp) => {
-                if (resp.status >= 400) reject(new HTTPResponseError(url, resp));
+                if (resp.status >= 400) reject(new HTTPResponseError(url, resp, options?.httpErrorMessages?.[resp.status]));
                 else resolve(resp);
             },
             onerror: () => { reject(new NetworkError(url)); },

--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -102,15 +102,14 @@ export abstract class CoverArtProvider {
     }
 
     protected async fetchPage(url: URL, options?: GMXHROptions): Promise<string> {
-        let resp: Awaited<ReturnType<typeof gmxhr>>;
-        try {
-            resp = await gmxhr(url, options);
-        } catch (err) {
-            LOGGER.debug(`Received error when fetching ${this.name} page: ${err}`);
+        const resp = await gmxhr(url, {
             // Standardise error messages for 404 pages, otherwise the HTTP error
             // will be shown in the UI.
-            throw new Error(`${this.name} release does not exist`);
-        }
+            httpErrorMessages: {
+                404: `${this.name} release does not exist`,
+            },
+            ...options,
+        });
 
         if (typeof resp.finalUrl === 'undefined') {
             LOGGER.warn(`Could not detect if ${url.href} caused a redirect`);

--- a/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/tidal.ts
@@ -59,7 +59,11 @@ export class TidalProvider extends CoverArtProvider {
             headers: {
                 'x-tidal-token': APP_ID,
             },
+            httpErrorMessages: {
+                404: 'Tidal release does not exist',
+            },
         });
+
         const metadata = safeParseJSON<AlbumMetadata>(resp.responseText, 'Invalid response from Tidal API');
         const albumMetadata = metadata.rows[0]?.modules?.[0]?.album;
         assertHasValue(albumMetadata, 'Tidal API returned no album, 404?');

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/apple_music.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/apple_music.test.ts
@@ -96,11 +96,9 @@ describe('apple music provider', () => {
         const extractionFailedCases = [{
             desc: 'non-existent Apple Music release',
             url: 'https://music.apple.com/gb/album/123456789',
-            errorMessage: 'Apple Music release does not exist',
         }, {
             desc: 'non-existent iTunes release',
             url: 'https://itunes.apple.com/gb/album/id123456789',
-            errorMessage: 'Apple Music release does not exist',
         }];
 
         // eslint-disable-next-line jest/require-hook

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/bugs.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/bugs.test.ts
@@ -47,7 +47,6 @@ describe('bugs provider', () => {
         const extractionFailedCases = [{
             desc: 'non-existent release',
             url: 'https://music.bugs.co.kr/album/abcd',
-            errorMessage: 'Bugs! release does not exist',
         }];
 
         // eslint-disable-next-line jest/require-hook

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/datpiff.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/datpiff.test.ts
@@ -66,7 +66,6 @@ describe('datpiff provider', () => {
             desc: 'non-existent release',
             // ID is probably long enough to last quite a while before this mixtape is created :)
             url: 'https://www.datpiff.com/Deno-Blue-Crazy-The-Mixtape.1231412412435323.html',
-            errorMessage: 'DatPiff release does not exist',
         }];
 
         // eslint-disable-next-line jest/require-hook

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/discogs.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/discogs.test.ts
@@ -58,7 +58,6 @@ describe('discogs provider', () => {
         const extractionFailedCases = [{
             desc: 'non-existent release',
             url: 'https://www.discogs.com/release/32342343',
-            errorMessage: 'Discogs release does not exist',
         }];
 
         // eslint-disable-next-line jest/require-hook

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/find_images_spec.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/find_images_spec.ts
@@ -57,7 +57,7 @@ export const findImagesSpec = ({ provider, extractionCases, extractionFailedCase
             });
 
             await expect(provider.findImages(new URL(extractionFailedCase.url), false))
-                .rejects.toThrowWithMessage(Error, extractionFailedCase.errorMessage ?? 'HTTP error 404: Not Found');
+                .rejects.toThrowWithMessage(Error, extractionFailedCase.errorMessage ?? `${provider.name} release does not exist`);
         });
     }
 };

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/melon.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/melon.test.ts
@@ -39,7 +39,6 @@ describe('melon provider', () => {
         const extractionFailedCases = [{
             desc: 'non-existent release',
             url: 'https://www.melon.com/album/detail.htm?albumId=0',
-            errorMessage: 'Melon release does not exist',
         }];
 
         // eslint-disable-next-line jest/require-hook

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/tidal.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/tidal.test.ts
@@ -85,8 +85,6 @@ describe('tidal provider', () => {
         const extractionFailedCases = [{
             desc: 'non-existent release',
             url: 'https://listen.tidal.com/album/1',
-            // FIXME: Tidal provider doesn't use the base `fetchPage` and only throws a generic error.
-            errorMessage: 'HTTP error 404: Not Found',
         }];
 
         // eslint-disable-next-line jest/require-hook

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/tidal.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/tidal.test.ts
@@ -85,6 +85,8 @@ describe('tidal provider', () => {
         const extractionFailedCases = [{
             desc: 'non-existent release',
             url: 'https://listen.tidal.com/album/1',
+            // FIXME: Tidal provider doesn't use the base `fetchPage` and only throws a generic error.
+            errorMessage: 'HTTP error 404: Not Found',
         }];
 
         // eslint-disable-next-line jest/require-hook


### PR DESCRIPTION
Previously, when a release returned a 404 code, a generic HTTP error would be shown in the log. Changing this to be more specific and to include the provider name in the error message.

Not all providers have been changed though. Notably the Tidal provider will still throw a generic error because it performs custom requests. That remains to be fixed.