### PR TITLE
fix(split links): use correct ref on non-release pages

### DIFF
--- a/src/lib/MB/types.ts
+++ b/src/lib/MB/types.ts
@@ -31,9 +31,7 @@ declare global {
         MB: {
             releaseEditor?: ReleaseEditor;
             sourceExternalLinksEditor?: {
-                externalLinksEditorRef: {
-                    current: ExternalLinks;
-                };
+                current: ExternalLinks;
             };
         };
     }

--- a/src/mb_multi_external_links/index.ts
+++ b/src/mb_multi_external_links/index.ts
@@ -10,7 +10,7 @@ import { onAddEntityDialogLoaded, qsa, qsMaybe, setInputValue } from '@lib/util/
 
 function getExternalLinksEditor(mbInstance: typeof window.MB): ExternalLinks {
     // Can be found in the MB object, but exact property depends on actual page.
-    const editor = (mbInstance.releaseEditor?.externalLinks ?? mbInstance.sourceExternalLinksEditor)?.externalLinksEditorRef.current;
+    const editor = (mbInstance.releaseEditor?.externalLinks.externalLinksEditorRef ?? mbInstance.sourceExternalLinksEditor)?.current;
     assertHasValue(editor, 'Cannot find external links editor object');
     return editor;
 }


### PR DESCRIPTION
#512 fixed it for the release editor, but broke it for artists etc. Turns out the MBS change there only applied to the release editor, the other pages weren't affected by the new property.

https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/105