### PR TITLE
fix(ecau): skip maximised images which are actually videos

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -213,10 +213,10 @@ export class ImageFetcher {
             LOGGER.warn(`Could not detect if URL ${url.href} caused a redirect`);
         }
         const fetchedUrl = new URL(resp.finalUrl || url);
-        const wasRedirected = resp.finalUrl !== url.href;
+        const wasRedirected = fetchedUrl.href !== url.href;
 
         if (wasRedirected) {
-            LOGGER.warn(`Followed redirect of ${url.href} -> ${resp.finalUrl} while fetching image contents`);
+            LOGGER.warn(`Followed redirect of ${url.href} -> ${fetchedUrl.href} while fetching image contents`);
         }
 
         const { mimeType, isImage } = await this.determineMimeType(resp);

--- a/src/mb_enhanced_cover_art_uploads/maximise.ts
+++ b/src/mb_enhanced_cover_art_uploads/maximise.ts
@@ -265,7 +265,10 @@ async function* maximiseGeneric(smallurl: URL): AsyncIterable<MaximisedImage> {
 
     for (const maximisedResult of results) {
         // Filter out results that will definitely not work
-        if (maximisedResult.fake || maximisedResult.bad) continue;
+        // FIXME: We blanket-ban videos at the moment, even though in the future
+        // we may want videos (e.g. Apple Music front cover videos). Currently
+        // videos aren't supported though.
+        if (maximisedResult.fake || maximisedResult.bad || maximisedResult.video) continue;
         try {
             yield {
                 ...maximisedResult,

--- a/tests/unit/mb_enhanced_cover_art_uploads/maximise.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/maximise.test.ts
@@ -63,6 +63,14 @@ describe('maximising images', () => {
         expect(result).toBeEmpty();
     });
 
+    it('skips videos', async () => {
+        setIMUResult([{ video: true } as unknown as maxurlResult]);
+
+        const result = await asyncIteratorToArray(getMaximisedCandidates(new URL('https://example.com/')));
+
+        expect(result).toBeEmpty();
+    });
+
     it('eventually returns all images', async () => {
         setIMUResult([{ url: 'https://example.com/max' }, { url: 'https://example.com/max2' }] as unknown as maxurlResult[]);
 


### PR DESCRIPTION
\+ a follow-up to #541 where the logging code wasn't properly updated, leading to a warning for both "Could not determine whether redirected" and "Followed redirect to `undefined`" to display simultaneously.

https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/105