### PR TITLE
fix(ecau): more improvements to VGMdb type mappings

### DIFF
--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/vgmdb.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/vgmdb.test.ts
@@ -40,7 +40,8 @@ describe('vgmdb provider', () => {
             ['Jacket Front & Back colorised', [ArtworkTypeIDs.Front, ArtworkTypeIDs.Back, ArtworkTypeIDs.Spine], 'colorised'],
             ['Disc', [ArtworkTypeIDs.Medium], ''],
             ['Disc 1', [ArtworkTypeIDs.Medium], 'Disc 1'],
-            ['DVD', [ArtworkTypeIDs.Medium], ''],
+            ['DVD', [ArtworkTypeIDs.Medium], 'DVD'],
+            ['CD', [ArtworkTypeIDs.Medium], 'CD'],
             ['Disc (reverse)', [ArtworkTypeIDs.Matrix], ''],
             ['Disc (Back)', [ArtworkTypeIDs.Matrix], ''],
             ['Disc 1 (Back)', [ArtworkTypeIDs.Matrix], 'Disc 1'],
@@ -68,6 +69,15 @@ describe('vgmdb provider', () => {
             ['Contents', [ArtworkTypeIDs.Raw], ''],
             [' Booklet Front & Back', [ArtworkTypeIDs.Booklet], 'Front & Back'],
             ['Booklet: Interview', [ArtworkTypeIDs.Booklet], 'Interview'],
+            // ['Back Tray', [ArtworkTypeIDs.Tray], 'Back'],  // FIXME
+            // ['Front Tray', [ArtworkTypeIDs.Tray], 'Front'],  // FIXME
+            ['Case Side', [ArtworkTypeIDs.Spine], 'Case'],
+            ['Box Side', [ArtworkTypeIDs.Spine], 'Box'],
+            ['Disc Front', [ArtworkTypeIDs.Medium], ''],
+            ['Blu-ray', [ArtworkTypeIDs.Medium], 'Blu‐ray'],
+            ['Sleeve Front', [ArtworkTypeIDs.Front], 'Sleeve'],
+            ['Sleeve Back', [ArtworkTypeIDs.Back], 'Sleeve'],
+            ['Sleeve Interior', [ArtworkTypeIDs.Tray], 'Sleeve'], // Might be wrong.
         ];
 
         it.each(mappingCases)('should map %s to the correct type', (caption, expectedTypes, expectedComment) => {


### PR DESCRIPTION
Should fix all of the examples reported in https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/105?u=ropdebee except Front Tray and Back Tray. Those are possible, but it'd be super ugly in the current implementation. A massive refactoring is getting more and more necessary (I'm thinking: tokenize the captions and look for combinations of keywords instead of the unflexible first word + rest of the caption stuff it's doing now).