### PR TITLE
fix(ecau): update URL of Spotify favicon

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/spotify.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/spotify.ts
@@ -4,7 +4,7 @@ import { HeadMetaPropertyProvider } from './base';
 
 export class SpotifyProvider extends HeadMetaPropertyProvider {
     public readonly supportedDomains = ['open.spotify.com'];
-    public readonly favicon = 'https://open.scdn.co/cdn/images/favicon32.8e66b099.png';
+    public readonly favicon = 'https://open.spotifycdn.com/cdn/images/favicon32.8e66b099.png';
     public readonly name = 'Spotify';
     protected readonly urlRegex = /\/album\/(\w+)/;
 


### PR DESCRIPTION
The old URL is no longer working and the unbalanced look of the import buttons with one of the icons missing is annoying me.