### PR TITLE
build: generate README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # MB Userscripts
+
 ![GitHub Test Workflow Status](https://img.shields.io/github/workflow/status/ROpdebee/mb-userscripts/nightly%20tests?label=tests)
 ![GitHub Deployment Workflow Status](https://img.shields.io/github/workflow/status/ROpdebee/mb-userscripts/deploy?label=deployment)
 ![Codecov](https://img.shields.io/codecov/c/gh/ROpdebee/mb-userscripts)
@@ -22,6 +23,7 @@ Blinds editor and voter details before your votes are cast.
 [![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_blind_votes.user.js?raw=1)
 [![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_blind_votes.user.js)
 
+
 ## MB: Bulk copy-paste work codes
 
 Quickly copy-paste work identifiers (ISWC, agency work codes) from [CISAC's ISWCNet](https://iswcnet.cisac.org/search) or [GEMA repertoire search](https://online.gema.de/werke/search.faces?lang=en) into a MusicBrainz work.
@@ -29,12 +31,15 @@ Quickly copy-paste work identifiers (ISWC, agency work codes) from [CISAC's ISWC
 [![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_bulk_copy_work_codes.user.js?raw=1)
 [![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_bulk_copy_work_codes.user.js)
 
+
 ## MB: Display CAA image dimensions
 
 Loads and displays the image dimensions of images in the cover art archive.
 
-[![Install](https://img.shields.io/badge/dynamic/json?label=install&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FROpdebee%2Fmb-userscripts%2Fdist%2Fmb_caa_dimensions.metadata.json&logo=tampermonkey&style=for-the-badge&color=informational)](https://raw.github.com/ROpdebee/mb-userscripts/dist/mb_caa_dimensions.user.js)
+[![Install](https://img.shields.io/badge/dynamic/json?label=install&query=%24.version&url=https%3A%2F%2Fraw.github.com%2FROpdebee%2Fmb-userscripts%2Fdist%2Fmb_caa_dimensions.metadata.json&logo=tampermonkey&style=for-the-badge&color=informational)](https://raw.github.com/ROpdebee/mb-userscripts/dist/mb_caa_dimensions.user.js)
 [![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](src/mb_caa_dimensions)
+[![Changelog](https://img.shields.io/badge/changelog-grey?style=for-the-badge)](https://github.com/ROpdebee/mb-userscripts/blob/dist/mb_caa_dimensions.changelog.md)
+
 
 ## MB: Enhanced Cover Art Uploads
 
@@ -49,9 +54,43 @@ In a nutshell:
 
 Full list of supported artwork providers [here](src/mb_enhanced_cover_art_uploads/docs/supported_providers.md).
 
-[![Install](https://img.shields.io/badge/dynamic/json?label=install&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FROpdebee%2Fmb-userscripts%2Fdist%2Fmb_enhanced_cover_art_uploads.metadata.json&logo=tampermonkey&style=for-the-badge&color=informational)](https://raw.github.com/ROpdebee/mb-userscripts/dist/mb_enhanced_cover_art_uploads.user.js)
+[![Install](https://img.shields.io/badge/dynamic/json?label=install&query=%24.version&url=https%3A%2F%2Fraw.github.com%2FROpdebee%2Fmb-userscripts%2Fdist%2Fmb_enhanced_cover_art_uploads.metadata.json&logo=tampermonkey&style=for-the-badge&color=informational)](https://raw.github.com/ROpdebee/mb-userscripts/dist/mb_enhanced_cover_art_uploads.user.js)
 [![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](src/mb_enhanced_cover_art_uploads)
 [![Changelog](https://img.shields.io/badge/changelog-grey?style=for-the-badge)](https://github.com/ROpdebee/mb-userscripts/blob/dist/mb_enhanced_cover_art_uploads.changelog.md)
+
+
+## MB: QoL: Inline all recording's tracks on releases
+
+Display all tracks and releases on which a recording appears from the release page. Makes it easier to check whether live or DJ-mix recordings are wrongly linked to other tracks.
+
+[![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_qol_inline_recording_tracks.user.js?raw=1)
+[![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_qol_inline_recording_tracks.user.js)
+
+
+## MB: QoL: Paste multiple external links at once
+
+Paste multiple external links at once into the external link editor. Input is split on whitespace (newlines, tabs, spaces, etc.) and fed into the link editor separately.
+
+[![Install](https://img.shields.io/badge/dynamic/json?label=install&query=%24.version&url=https%3A%2F%2Fraw.github.com%2FROpdebee%2Fmb-userscripts%2Fdist%2Fmb_multi_external_links.metadata.json&logo=tampermonkey&style=for-the-badge&color=informational)](https://raw.github.com/ROpdebee/mb-userscripts/dist/mb_multi_external_links.user.js)
+[![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](src/mb_multi_external_links)
+[![Changelog](https://img.shields.io/badge/changelog-grey?style=for-the-badge)](https://github.com/ROpdebee/mb-userscripts/blob/dist/mb_multi_external_links.changelog.md)
+
+
+## MB: QoL: Seed the batch recording comments script
+
+Seed the recording comments for the batch recording comments userscripts with live and DJ-mix data. Can save a bunch of keystrokes when setting live or DJ-mix disambiguation comments. DJ-mix comments are derived from the release title. Live comments are derived from "recorded at place", "recorded in area", and "recording of work" advanced relationships.
+
+[![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_qol_seed_recording_disambiguation.user.js?raw=1)
+[![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_qol_seed_recording_disambiguation.user.js)
+
+
+## MB: QoL: Select All Update Recordings
+
+Add buttons to release editor to select all "Update recordings" checkboxes. Differs from the built-in "Select All" checkboxes in that it doesn't lock the checkboxes to a given state, enabling you to deselect some checkboxes.
+
+[![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_qol_select_all_update_recordings.user.js?raw=1)
+[![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_qol_select_all_update_recordings.user.js)
+
 
 ## MB: Supercharged Cover Art Edits
 
@@ -60,37 +99,10 @@ Supercharges reviewing cover art edits. Displays release information on CAA edit
 [![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_supercharged_caa_edits.user.js?raw=1)
 [![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_supercharged_caa_edits.user.js)
 
+
 ## MB: Validate Work Codes
 
 Validate work attributes on various MB pages. Highlights invalid (red) or ill-formatted (yellow) work codes.
 
 [![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_validate_work_codes.user.js?raw=1)
 [![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_validate_work_codes.user.js)
-
-## Smaller Quality of Life Scripts
-Smaller scripts that offer minor QoL improvements.
-
-### MB: QoL: Select All Update Recordings
-Add buttons to release editor to select all "Update recordings" checkboxes. Differs from the built-in "Select All" checkboxes in that it doesn't lock the checkboxes to a given state, enabling you to deselect some checkboxes.
-
-[![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_qol_select_all_update_recordings.user.js?raw=1)
-[![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_qol_select_all_update_recordings.user.js)
-
-### MB: QoL: Inline all recording's tracks on releases
-Display all tracks and releases on which a recording appears from the release page. Makes it easier to check whether live or DJ-mix recordings are wrongly linked to other tracks.
-
-[![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_qol_inline_recording_tracks.user.js?raw=1)
-[![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_qol_inline_recording_tracks.user.js)
-
-### MB: QoL: Seed the batch recording comments script
-Seed the recording comments for the batch recording comments userscripts with live and DJ-mix data. Can save a bunch of keystrokes when setting live or DJ-mix disambiguation comments. DJ-mix comments are derived from the release title. Live comments are derived from "recorded at place", "recorded in area", and "recording of work" advanced relationships.
-
-[![Install](https://img.shields.io/badge/install-latest-informational?style=for-the-badge&logo=tampermonkey)](mb_qol_seed_recording_disambiguation.user.js?raw=1)
-[![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](mb_qol_seed_recording_disambiguation.user.js)
-
-### MB: QoL: Paste multiple external links at once
-Paste multiple external links at once into the external link editor. Input is split on whitespace (newlines, tabs, spaces, etc.) and fed into the link editor separately.
-
-[![Install](https://img.shields.io/badge/dynamic/json?label=install&query=%24.version&url=https%3A%2F%2Fraw.githubusercontent.com%2FROpdebee%2Fmb-userscripts%2Fdist%2Fmb_multi_external_links.metadata.json&logo=tampermonkey&style=for-the-badge&color=informational)](https://raw.github.com/ROpdebee/mb-userscripts/dist/mb_multi_external_links.user.js)
-[![Source](https://img.shields.io/badge/source-grey?style=for-the-badge&logo=github)](src/mb_multi_external_links)
-[![Changelog](https://img.shields.io/badge/changelog-grey?style=for-the-badge)](https://github.com/ROpdebee/mb-userscripts/blob/dist/mb_multi_external_links.changelog.md)

--- a/build/build.ts
+++ b/build/build.ts
@@ -1,10 +1,23 @@
+import fs from 'node:fs/promises';
+
+import { generateReadmeContent } from './generate-readme';
 import { buildUserscripts } from './rollup';
 import { getVersionForToday } from './versions';
+
+async function checkReadmeContent(): Promise<void> {
+    const actualContent = await fs.readFile('README.md', 'utf8');
+    const expectedContent = await generateReadmeContent();
+
+    if (actualContent !== expectedContent) {
+        throw new Error('README content has changed. Please regenerate (npm run generate-readme).');
+    }
+}
 
 // Don't use await at the top level, this is incompatible with node and
 // CommonJS modules.
 buildUserscripts(getVersionForToday())
+    .then(checkReadmeContent)
     .catch((err) => {
         console.error(err);
-        throw err;
+        process.exit(1);
     });

--- a/build/generate-readme.ts
+++ b/build/generate-readme.ts
@@ -129,7 +129,7 @@ function generateSection(data: UserscriptData): string {
     `;
 }
 
-async function generateReadmeContent(): Promise<string> {
+export async function generateReadmeContent(): Promise<string> {
     const userscriptData = await getUserscriptData();
     userscriptData.push(...LEGACY_SCRIPT_DATA);
     userscriptData.sort((a, b) => a.name < b.name ? -1 : 1);

--- a/build/generate-readme.ts
+++ b/build/generate-readme.ts
@@ -1,0 +1,152 @@
+import fs from 'node:fs/promises';
+
+import dedent from 'ts-dedent';
+
+import { MetadataGenerator } from './plugin-userscript';
+
+const PREAMBLE = dedent`
+  # MB Userscripts
+
+  ![GitHub Test Workflow Status](https://img.shields.io/github/workflow/status/ROpdebee/mb-userscripts/nightly%20tests?label=tests)
+  ![GitHub Deployment Workflow Status](https://img.shields.io/github/workflow/status/ROpdebee/mb-userscripts/deploy?label=deployment)
+  ![Codecov](https://img.shields.io/codecov/c/gh/ROpdebee/mb-userscripts)
+  [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
+  [![GitHub license](https://img.shields.io/github/license/ROpdebee/mb-userscripts)](https://github.com/ROpdebee/mb-userscripts/blob/main/LICENSE)
+
+  Collection of userscripts for MusicBrainz.
+
+  [Dedicated support thread](https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947)
+
+  ## Installing
+
+  To use these userscripts, you need a userscript add-on or extension such as [Tampermonkey](https://www.tampermonkey.net/), [Violentmonkey](https://violentmonkey.github.io/), or [Greasemonkey](https://addons.mozilla.org/en-GB/firefox/addon/greasemonkey/) installed in your browser. More information can be found [here](https://stackapps.com/tags/script/info), [here](https://openuserjs.org/about/Userscript-Beginners-HOWTO), or [here](https://userscripts-mirror.org/about/installing.html).
+
+  _Note: Although we aim to support all browsers and userscript add-ons, we currently cannot guarantee universal compatibility. If you discover a compatibility problem, please [submit an issue](https://github.com/ROpdebee/mb-userscripts/issues/new) and state your browser and userscript engine versions._
+`;
+
+interface UserscriptData {
+    id: string;
+    name: string;
+    blurb: string;
+    urls?: {
+        metadata: string;
+        install: string;
+        source: string;
+        changelog: string;
+    };
+}
+
+const LEGACY_SCRIPT_DATA: UserscriptData[] = [
+    {
+        id: 'mb_blind_votes',
+        name: 'MB: Blind Votes',
+        blurb: 'Blinds editor and voter details before your votes are cast.',
+    },
+    {
+        id: 'mb_bulk_copy_work_codes',
+        name: 'MB: Bulk copy-paste work codes',
+        blurb: 'Quickly copy-paste work identifiers (ISWC, agency work codes) from [CISAC\'s ISWCNet](https://iswcnet.cisac.org/search) or [GEMA repertoire search](https://online.gema.de/werke/search.faces?lang=en) into a MusicBrainz work.',
+    },
+    {
+        id: 'mb_supercharged_caa_edits',
+        name: 'MB: Supercharged Cover Art Edits',
+        blurb: 'Supercharges reviewing cover art edits. Displays release information on CAA edits. Enables image comparisons on removed and added images.',
+    },
+    {
+        id: 'mb_validate_work_codes',
+        name: 'MB: Validate Work Codes',
+        blurb: 'Validate work attributes on various MB pages. Highlights invalid (red) or ill-formatted (yellow) work codes.',
+    },
+    {
+        id: 'mb_qol_select_all_update_recordings',
+        name: 'MB: QoL: Select All Update Recordings',
+        blurb: 'Add buttons to release editor to select all "Update recordings" checkboxes. Differs from the built-in "Select All" checkboxes in that it doesn\'t lock the checkboxes to a given state, enabling you to deselect some checkboxes.',
+    },
+    {
+        id: 'mb_qol_inline_recording_tracks',
+        name: "MB: QoL: Inline all recording's tracks on releases",
+        blurb: 'Display all tracks and releases on which a recording appears from the release page. Makes it easier to check whether live or DJ-mix recordings are wrongly linked to other tracks.',
+    },
+    {
+        id: 'mb_qol_seed_recording_disambiguation',
+        name: 'MB: QoL: Seed the batch recording comments script',
+        blurb: 'Seed the recording comments for the batch recording comments userscripts with live and DJ-mix data. Can save a bunch of keystrokes when setting live or DJ-mix disambiguation comments. DJ-mix comments are derived from the release title. Live comments are derived from "recorded at place", "recorded in area", and "recording of work" advanced relationships.',
+    },
+];
+
+async function getUserscriptData(): Promise<UserscriptData[]> {
+    const srcDirs = await fs.readdir('./src');
+    const userscriptIds = srcDirs
+        .filter((name) => name.startsWith('mb'));
+
+    return Promise.all(userscriptIds
+        .map(async (userscriptId) => {
+            const metaGen = await MetadataGenerator.create({
+                userscriptName: userscriptId,
+                branchName: 'dist',
+                version: '',
+            });
+            const userscriptMeta = await metaGen.loadMetadata();
+
+            return {
+                id: userscriptId,
+                name: userscriptMeta.name,
+                blurb: userscriptMeta.blurb,
+                urls: {
+                    metadata: metaGen.gitURLs.constructRawURL('dist', `${userscriptId}.metadata.json`),
+                    install: metaGen.gitURLs.constructRawURL('dist', `${userscriptId}.user.js`),
+                    source: `src/${userscriptId}`,
+                    changelog: metaGen.gitURLs.constructBlobURL('dist', `${userscriptId}.changelog.md`),
+                },
+            };
+        }));
+}
+
+function generateSection(data: UserscriptData): string {
+    const badgeBase = 'https://img.shields.io/badge';
+    const installBadge = data.urls
+        ? `${badgeBase}/dynamic/json?label=install&query=%24.version&url=${encodeURIComponent(data.urls.metadata)}&logo=tampermonkey&style=for-the-badge&color=informational`
+        : `${badgeBase}/install-latest-informational?style=for-the-badge&logo=tampermonkey`;
+    const installUrl = data.urls?.install ?? `${data.id}.user.js?raw=1`;
+    const sourceBadge = `${badgeBase}/source-grey?style=for-the-badge&logo=github`;
+    const sourceUrl = data.urls?.source ?? `${data.id}.user.js`;
+
+    let links = dedent`
+      [![Install](${installBadge})](${installUrl})
+      [![Source](${sourceBadge})](${sourceUrl})
+    `;
+    if (data.urls?.changelog) {
+        links += `\n[![Changelog](${badgeBase}/changelog-grey?style=for-the-badge)](${data.urls.changelog})`;
+    }
+
+    return dedent`
+      ## ${data.name}
+
+      ${data.blurb}
+
+      ${links}
+
+    `;
+}
+
+async function generateReadmeContent(): Promise<string> {
+    const userscriptData = await getUserscriptData();
+    userscriptData.push(...LEGACY_SCRIPT_DATA);
+    userscriptData.sort((a, b) => a.name < b.name ? -1 : 1);
+
+    return dedent`
+      ${PREAMBLE}
+
+      ${userscriptData.map((data) => generateSection(data)).join('\n\n')}
+    `;
+}
+
+async function generateReadme(): Promise<void> {
+    await fs.writeFile('README.md', await generateReadmeContent());
+}
+
+// eslint-disable-next-line unicorn/prefer-module
+if (require.main === module) {
+    generateReadme()
+        .catch(console.error);
+}

--- a/build/plugin-userscript.ts
+++ b/build/plugin-userscript.ts
@@ -161,7 +161,7 @@ export class MetadataGenerator {
      *
      * @return     {Promise<UserscriptMetadata>}  The userscript's metadata.
      */
-    private async loadMetadata(): Promise<AllUserscriptMetadata> {
+    public async loadMetadata(): Promise<AllUserscriptMetadata> {
         const metadataFile = path.resolve('./src', this.options.userscriptName, 'meta.ts');
         // eslint-disable-next-line no-unsanitized/method -- Fine.
         const specificMetadata = (await import(metadataFile) as { default: UserscriptMetadata }).default;
@@ -205,6 +205,7 @@ export class MetadataGenerator {
      */
     private createMetadataBlock(metadata: Readonly<AllUserscriptMetadata>): string {
         const metadataLines = Object.entries<string | readonly string[]>(metadata)
+            .filter((entry) => this.options.metadataOrder.includes(entry[0]))
             .sort((a: readonly [string, unknown], b: readonly [string, unknown]) =>
                 this.options.metadataOrder.indexOf(a[0]) - this.options.metadataOrder.indexOf(b[0]))
             .flatMap(this.createMetadataLines.bind(this));

--- a/build/versions.ts
+++ b/build/versions.ts
@@ -69,7 +69,7 @@ async function buildTempUserscript(scriptName: string): Promise<string> {
         buildUserscript("${scriptName}", "0.0.0", "${path.resolve(outputDir)}")
             .catch((err) => {
                 console.error(err);
-                throw err;
+                process.exit(1);
             });
     `;
     await fs.writeFile('isolatedBuilder.ts', builderSource);

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,6 +93,7 @@
         "setup-polly-jest": "0.11.0",
         "simple-git": "3.14.1",
         "terser": "5.15.1",
+        "ts-dedent": "2.2.0",
         "ts-jest": "29.0.3",
         "ts-node": "10.9.1",
         "tsconfig-paths": "4.1.0",
@@ -13410,6 +13411,15 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
     "node_modules/ts-jest": {
       "version": "29.0.3",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.0.3.tgz",
@@ -23929,6 +23939,12 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.0.tgz",
       "integrity": "sha512-wdBacIvfF3z0iFL8uRvTKwr8iwBrKIQ5cUDSRismp5O9N35O7qla3KX+B0FLfD6L8Frey/vVmEdLoal0lULzSQ=="
+    },
+    "ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true
     },
     "ts-jest": {
       "version": "29.0.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.cjs --max-warnings=0",
     "typecheck": "ts-node -r tsconfig-paths/register build/check-tsconfig.ts && tsc -b",
     "deploy": "NODE_ENV=production ts-node -r tsconfig-paths/register build/deploy.ts",
-    "test": "NODE_NO_WARNINGS=1 jest --coverage"
+    "test": "NODE_NO_WARNINGS=1 jest --coverage",
+    "generate-readme": "ts-node -r tsconfig-paths/register build/generate-readme.ts"
   },
   "repository": {
     "type": "git",
@@ -100,6 +101,7 @@
     "setup-polly-jest": "0.11.0",
     "simple-git": "3.14.1",
     "terser": "5.15.1",
+    "ts-dedent": "2.2.0",
     "ts-jest": "29.0.3",
     "ts-node": "10.9.1",
     "tsconfig-paths": "4.1.0",

--- a/src/lib/util/metadata.ts
+++ b/src/lib/util/metadata.ts
@@ -13,6 +13,7 @@ export interface UserscriptCustomMetadata {
     grant?: readonly string[] | string;
     connect?: readonly string[] | string;
     resource?: readonly string[] | string;
+    blurb: string;
 }
 
 export interface UserscriptDefaultMetadata {

--- a/src/mb_caa_dimensions/meta.ts
+++ b/src/mb_caa_dimensions/meta.ts
@@ -15,6 +15,7 @@ const metadata: UserscriptMetadata = {
         transformMBMatchURL('release/*/edit-relationships'),
         transformMBMatchURL('release-group/*/edit'),
     ],
+    blurb: 'Loads and displays the image dimensions of images in the cover art archive.',
 };
 
 export default metadata;

--- a/src/mb_enhanced_cover_art_uploads/meta.ts
+++ b/src/mb_enhanced_cover_art_uploads/meta.ts
@@ -1,3 +1,5 @@
+import dedent from 'ts-dedent';
+
 import type { UserscriptMetadata } from '@lib/util/metadata';
 import { transformMBMatchURL } from '@lib/util/metadata';
 
@@ -26,6 +28,18 @@ const metadata: UserscriptMetadata = {
     connect: '*',
     require: ['https://github.com/qsniyg/maxurl/blob/4b8661ee2d7a856dc6c4a9b910664584b397d45a/userscript.user.js?raw=true'],
     resource: ['amazonFavicon https://www.amazon.com/favicon.ico'],
+    blurb: dedent`
+      Enhance the cover art uploader!
+
+      In a nutshell:
+
+      * Upload directly from an image URL
+      * One-click import artwork from Discogs/Spotify/Apple Music/... attached to the release (or, alternatively, paste the URL)
+      * Automatically retrieve the largest version of an image through [ImageMaxURL](https://github.com/qsniyg/maxurl)
+      * Seed the cover art upload form from a-tisket.
+
+      Full list of supported artwork providers [here](src/mb_enhanced_cover_art_uploads/docs/supported_providers.md).
+    `,
 };
 
 export default metadata;

--- a/src/mb_multi_external_links/meta.ts
+++ b/src/mb_multi_external_links/meta.ts
@@ -14,6 +14,7 @@ const metadata: UserscriptMetadata = {
         '*/create',
         '*/create?*',
     ].map((path) => transformMBMatchURL(path)),
+    blurb: 'Paste multiple external links at once into the external link editor. Input is split on whitespace (newlines, tabs, spaces, etc.) and fed into the link editor separately.',
 };
 
 export default metadata;


### PR DESCRIPTION
Instead of manually updating the information in the README, which can be cumbersome with all of the links, let's use a script to generate it automatically. It also supports the legacy JS scripts, so that should make it easier to do the TS migration for each script individually without needing to spend time changing the README.

I've also added a check to the build process so that the build (and by extension, CI) will fail if the README becomes outdated.