### PR TITLE
fix(ecau): handle relative URLs in og:image providers

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -149,7 +149,7 @@ export abstract class HeadMetaPropertyProvider extends CoverArtProvider {
 
         const coverElmt = qs<HTMLMetaElement>('head > meta[property="og:image"]', respDocument);
         return [{
-            url: new URL(coverElmt.content),
+            url: new URL(coverElmt.content, url),
             types: [ArtworkTypeIDs.Front],
         }];
     }


### PR DESCRIPTION
Bugs redirects to the mobile site on mobile devices, where the og:image property holds a relative URL. If we add the base URL of the page, it should be able to correctly resolve those.

See https://github.com/ROpdebee/mb-userscripts/issues/547#issuecomment-1272552566.