### PR TITLE
ci: use environment files instead of deprecated ::set-output

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -39,7 +39,7 @@ runs:
     - name: Get node version
       id: node-version
       run:
-        echo ::set-output name=node-version::`node --version`
+        echo "node-version=$(node --version)" >> $GITHUB_OUTPUT
       shell: bash
     # Cache node_modules specifically for this OS, specific node version, and
     # package-lock.json.

--- a/build/deploy.ts
+++ b/build/deploy.ts
@@ -91,9 +91,11 @@ async function scanAndPush(): Promise<void> {
             await gitDist.push();
         }
 
-        // Logging this message, it should get picked up by the Actions runner
-        // to set the step output.
-        console.log('::set-output name=deployment-info::' + encodeOutput({ scripts: updates }));
+        // Set the step's output
+        const stepOutput = `deployment-info<<EOF
+            ${encodeOutput({ scripts: updates })}
+        EOF`;
+        await fs.appendFile(process.env.GITHUB_OUTPUT!, stepOutput);
     }
 }
 


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/