### PR TITLE
ci(deploy): check for changes against base instead of previous deploy

### DIFF
--- a/build/check-scripts-unchanged.ts
+++ b/build/check-scripts-unchanged.ts
@@ -20,7 +20,7 @@ async function checkUserscriptsChanged(): Promise<void> {
             throw new Error('I encountered a userscript which has not been deployed yet!');
         }
 
-        // Check against the main branch's HEAD.
+        // Check against the main branch.
         if (await userscriptHasChanged(scriptName, 'main')) {
             throw new Error(`Userscript ${scriptName} would be changed`);
         }

--- a/build/check-scripts-unchanged.ts
+++ b/build/check-scripts-unchanged.ts
@@ -20,7 +20,8 @@ async function checkUserscriptsChanged(): Promise<void> {
             throw new Error('I encountered a userscript which has not been deployed yet!');
         }
 
-        if (await userscriptHasChanged(scriptName, previousVersion, distRepo)) {
+        // Check against the main branch's HEAD.
+        if (await userscriptHasChanged(scriptName, 'main')) {
             throw new Error(`Userscript ${scriptName} would be changed`);
         }
     }

--- a/build/deploy.ts
+++ b/build/deploy.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import simpleGit from 'simple-git';
 
-import type { DeployedScript, DeployInfo, PullRequestInfo } from './types-deploy';
+import type { DeployedScript, DeployInfo, PullRequestInfo, PushEventPayload, RepositoryDispatchEventPayload } from './types-deploy';
 import { updateChangelog } from './changelog';
 import { buildUserscript } from './rollup';
 import { getPreviousReleaseVersion, incrementVersion, userscriptHasChanged } from './versions';
@@ -21,7 +21,7 @@ if (!process.env.PR_INFO) {
 const prInfo = JSON.parse(process.env.PR_INFO) as PullRequestInfo;
 
 // We're using a separate clone of the same repo here. gitDist is checked out
-// to the `dist` branch of our repo. We're using the separate copy  so we can
+// to the `dist` branch of our repo. We're using the separate copy so we can
 // simultaneously build from the main branch into the dist branch, while also
 // committing to dist, without constantly having to change branches.
 const gitDist = simpleGit(distRepo);
@@ -29,12 +29,28 @@ const gitDist = simpleGit(distRepo);
 async function commitIfUpdated(scriptName: string): Promise<DeployedScript | undefined> {
     console.log(`Checking ${scriptName}…`);
     const previousVersion = await getPreviousReleaseVersion(scriptName, distRepo);
+    const isNewScript = !previousVersion;
     const nextVersion = incrementVersion(previousVersion);
 
-    if (!previousVersion) {
+    // Always deploy new scripts.
+    if (isNewScript) {
         console.log(`First release: ${nextVersion}`);
         return commitUpdate(scriptName, nextVersion);
-    } else if (await userscriptHasChanged(scriptName, previousVersion, distRepo)) {
+    }
+
+    const isPreview = process.env.GITHUB_EVENT_NAME !== 'push';
+    const payloadText = await fs.readFile(process.env.GITHUB_EVENT_PATH!, 'utf8');
+    const payload = JSON.parse(payloadText) as unknown;
+    const baseRef = isPreview
+        ? (payload as RepositoryDispatchEventPayload).client_payload.pull_request.base.sha
+        : (payload as PushEventPayload).before;
+
+    // For existing scripts, we need to check whether the newly pushed changes
+    // lead to a change in the compiled scripts. We don't check against the
+    // previously deployed version, since there may have been changes that were
+    // not deployed following a `skip cd` tag.
+    // See https://github.com/ROpdebee/mb-userscripts/issues/600
+    if (await userscriptHasChanged(scriptName, baseRef)) {
         console.log(`${previousVersion} -> ${nextVersion}`);
         return commitUpdate(scriptName, nextVersion);
     }

--- a/build/deploy.ts
+++ b/build/deploy.ts
@@ -41,8 +41,11 @@ async function commitIfUpdated(scriptName: string): Promise<DeployedScript | und
     const isPreview = process.env.GITHUB_EVENT_NAME !== 'push';
     const payloadText = await fs.readFile(process.env.GITHUB_EVENT_PATH!, 'utf8');
     const payload = JSON.parse(payloadText) as unknown;
+    // The commit before the changes we want to deploy differs for previews and
+    // actual deployments. For previews, make sure we compare to the base branch's
+    // HEAD rather than the commit on which the PR is based, which may be outdated.
     const baseRef = isPreview
-        ? (payload as RepositoryDispatchEventPayload).client_payload.pull_request.base.sha
+        ? (payload as RepositoryDispatchEventPayload).client_payload.pull_request.base.ref
         : (payload as PushEventPayload).before;
 
     // For existing scripts, we need to check whether the newly pushed changes

--- a/build/types-deploy.ts
+++ b/build/types-deploy.ts
@@ -26,7 +26,7 @@ export interface RepositoryDispatchEventPayload {
     client_payload: {
         pull_request: {
             base: {
-                sha: string;
+                ref: string;
             };
         };
     };

--- a/build/types-deploy.ts
+++ b/build/types-deploy.ts
@@ -18,6 +18,20 @@ export interface PullRequestInfo {
     labels: string[];
 }
 
+export interface PushEventPayload {
+    before: string;
+}
+
+export interface RepositoryDispatchEventPayload {
+    client_payload: {
+        pull_request: {
+            base: {
+                sha: string;
+            };
+        };
+    };
+}
+
 /*
  * Type declarations extracted from @octokit/rest. We could just add it as a
  * dev dependency, but we're currently only using it for GitHub Actions


### PR DESCRIPTION
The continuous deployment checks whether changes have been made to the scripts and deploys an update if so. However, it was checking against the latest deployed version, rather than the "previous version". These two are different if the `skip cd` tag is used. This led the deployment to deploy updates for PRs that did not change the scripts at all, because an old, not-yet-deployed change was skipped previously.

Instead, we'll now check against the compiled scripts based on the "previous" commit ref. For pushes to main, this is the commit before the push (even when multiple commits are pushed); for deployment previews in PRs, this is the base branch of the PR; for checking for changes in automated dependency updates, this is the main branch.

This should fix #600.

To test this, we'll merge #593 and #598 with `skip cd` tags, generate a deployment preview for #580 (which should cause no deployments), and merge #580, which also shouldn't cause a deployment.