### PR TITLE
ci(deploy): fetch full repository history

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,6 +15,9 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
+          # Fetch the whole repository history, as we need to check out an old
+          # ref to compare compiled scripts from before and after the change.
+          depth: 0
       - name: Set up environment
         uses: ./.github/actions/setup
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          # Fetch the whole repository history, as we need to check out an old
+          # ref to compare compiled scripts from before and after the change.
+          depth: 0
       - name: Set up environment
         uses: ./.github/actions/setup
 

--- a/.github/workflows/renovate-check.yml
+++ b/.github/workflows/renovate-check.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          # Fetch the whole repository history, as we need to check out an old
+          # ref to compare compiled scripts from before and after the change.
+          depth: 0
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Checkout second dist copy
@@ -28,7 +32,7 @@ jobs:
         env:
           NODE_ENV: production  # Necessary to ensure we minify in the preview
         run: npx ts-node -r tsconfig-paths/register build/check-scripts-unchanged.ts repoDist
-      
+
       - name: Display changes that would be made
         if: always()
         run: git diff


### PR DESCRIPTION
We were only fetching at depth 1, which meant we couldn't check out an older commit to compare compiled scripts during deployment.

_Seems like every time I change something about CI, I need to do a follow-up PR to fix a bug in CI 🤔_