### PR TITLE
ci(deploy): fix wrong param name to actions/checkout

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -17,7 +17,7 @@ jobs:
           ref: refs/pull/${{ github.event.client_payload.pull_request.number }}/merge
           # Fetch the whole repository history, as we need to check out an old
           # ref to compare compiled scripts from before and after the change.
-          depth: 0
+          fetch-depth: 0
       - name: Set up environment
         uses: ./.github/actions/setup
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           # Fetch the whole repository history, as we need to check out an old
           # ref to compare compiled scripts from before and after the change.
-          depth: 0
+          fetch-depth: 0
       - name: Set up environment
         uses: ./.github/actions/setup
 

--- a/.github/workflows/renovate-check.yml
+++ b/.github/workflows/renovate-check.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           # Fetch the whole repository history, as we need to check out an old
           # ref to compare compiled scripts from before and after the change.
-          depth: 0
+          fetch-depth: 0
       - name: Set up environment
         uses: ./.github/actions/setup
       - name: Checkout second dist copy


### PR DESCRIPTION
ugh.

I'm really tempted to just push to main directly instead of going through PRs, but without PRs deployment will error out as it can't find the PR info.