### PR TITLE
ci(deploy): detect changes caused by dependency versions

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -3,5 +3,8 @@ import { getVersionForToday } from './versions';
 
 // Don't use await at the top level, this is incompatible with node and
 // CommonJS modules.
-buildUserscripts(getVersionForToday()).
-    catch(console.error);
+buildUserscripts(getVersionForToday())
+    .catch((err) => {
+        console.error(err);
+        throw err;
+    });

--- a/build/versions.ts
+++ b/build/versions.ts
@@ -1,9 +1,9 @@
+import { exec } from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { promisify } from 'node:util';
 
 import simpleGit from 'simple-git';
-
-import { buildUserscript } from './rollup';
 
 export function getVersionForToday(): string {
     const today = new Date();
@@ -58,7 +58,26 @@ export async function getPreviousReleaseVersion(userscriptName: string, buildDir
 
 async function buildTempUserscript(scriptName: string): Promise<string> {
     const outputDir = await fs.mkdtemp(scriptName);
-    await buildUserscript(scriptName, '0.0.0', outputDir);
+
+    // Need to run this in its own process because we may need to change the
+    // versions of dependencies and ensure the node process uses the correct
+    // version. We also can't just change the `build.ts` script to accept
+    // arguments because we may need to compare to a version in which the script
+    // hadn't been changed yet.
+    const builderSource = `
+        import { buildUserscript } from "build/rollup";
+        buildUserscript("${scriptName}", "0.0.0", "${path.resolve(outputDir)}")
+            .catch((err) => {
+                console.error(err);
+                throw err;
+            });
+    `;
+    await fs.writeFile('isolatedBuilder.ts', builderSource);
+    const command = 'npm i --no-audit && npx ts-node -r tsconfig-paths/register isolatedBuilder.ts';
+    const { stderr, stdout } = await promisify(exec)(command);
+    if (stderr) console.error(stderr);
+    if (stdout) console.log(stdout);
+
     const content = fs.readFile(path.join(outputDir, `${scriptName}.user.js`), 'utf8');
     await fs.rm(outputDir, { recursive: true });
     return content;
@@ -68,7 +87,9 @@ export async function userscriptHasChanged(scriptName: string, compareToRef: str
     // We'll check whether the userscript has changed by building both the
     // latest code as well as the code at `baseRef`, then diffing them.
     // If there's a diff, we assume it needs a new release.
-    const currentVersion = await buildTempUserscript(scriptName);
+
+    // Build previous version before current version so that the current
+    // dependency versions are installed after everything is finished.
 
     // Temporarily check out the base ref
     const repo = simpleGit();
@@ -79,6 +100,8 @@ export async function userscriptHasChanged(scriptName: string, compareToRef: str
     } finally {
         await repo.checkout('-');
     }
+
+    const currentVersion = await buildTempUserscript(scriptName);
 
     return currentVersion !== previousVersion;
 }


### PR DESCRIPTION
TL;DR: When comparing compiled scripts, we'll compile them in a child process and make sure that the dependencies are installed according to the lock file.

See #593.