### PR TITLE
ci: put npm cache on a monthly diet

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,14 +25,32 @@ runs:
     # we restored node_modules, we'll skip the npm install step.
     # Inspired by https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/
 
+    # Cache key formats:
+    # <OS>-node-<node major version>-<year>-<month>-<package-lock.json hash>
+    # modules-<OS>-<node full version>-<year>-<month>-<package-lock.json hash>
+    #
+    # We include the year and month so that the cache gets "invalidated"/"cleared"
+    # on a monthly basis. Otherwise, since npm's cache is incremental, it'll grow
+    # indefinitely on each package upgrade. Because the cache key changes each
+    # month, the cache will be fully rebuilt and the package downloads cache
+    # will no longer contain package versions that we haven't used since the
+    # month before.
+
+    - name: Retrieve current date
+      id: curr-date
+      run:
+        echo "date=$(date +%Y-%m)" >> $GITHUB_OUTPUT
+      shell: bash
+
     - name: Cache npm package downloads
       uses: actions/cache@v3
       with:
         path: '~/.npm'
-        key: ${{ runner.os }}-node-${{ inputs.node-version }}-${{ hashFiles('package-lock.json') }}
-        # Allow restoring the download cache if package-lock.json has changed.
+        key: ${{ runner.os }}-node-${{ inputs.node-version }}-${{ steps.curr-date.outputs.date }}-${{ hashFiles('package-lock.json') }}
+        # Allow restoring the download cache if package-lock.json has changed, but only in the same month.
+        # In a different month, the cache should be rebuilt from scratch in the beginning.
         restore-keys: |
-          ${{ runner.os }}-node-${{ inputs.node-version }}
+          ${{ runner.os }}-node-${{ inputs.node-version }}-${{ steps.curr-date.outputs.date }}
 
     # Need the exact node version to prevent reusing an old node version's
     # node_modules cache.
@@ -48,7 +66,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ./node_modules
-        key: modules-${{ runner.os }}-node-${{ steps.node-version.outputs.node-version }}-${{ hashFiles('package-lock.json') }}
+        key: modules-${{ runner.os }}-node-${{ steps.node-version.outputs.node-version }}-${{ steps.curr-date.outputs.date }}-${{ hashFiles('package-lock.json') }}
         # No restore_keys here to prevent reusing node_modules if lock file has
         # changed.
 


### PR DESCRIPTION
Since we started using caching, the cache has grown in size 10-fold. Once we switched CI to use Node 18, all of a sudden cache size dropped substantially. The reason is that the npm cache is incremental, and it doesn't remove package downloads that we're no longer using. The cache therefore contains old package downloads that we haven't used in months, and that's slowing down CI since it takes longer to fetch and extract that cache.

Instead, we'll change the cache keys every month by having the keys depend on the current year and month. Therefore, we'll start off with a fresh cache on a monthly basis, and the cache won't waste unnecessary space any longer.