### PR TITLE
ci: smaller time window for renovate lock file maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,23 +6,18 @@
     ":maintainLockFilesMonthly",
     ":label(dependencies)"
   ],
+  "pin": {
+    "enabled": true,
+    "automerge": true,
+    "automergeType": "branch",
+    "recreateClosed": true,
+    "schedule": ["at any time"]
+  },
+  "lockFileMaintenance": {
+    "automerge": true,
+    "automergeType": "branch"
+  },
   "packageRules": [
-    {
-      "description": "Automatically merge pinning dependencies",
-      "matchUpdateTypes": ["pin"],
-      "automerge": true,
-      "automergeType": "branch",
-      "recreateClosed": true,
-      "schedule": ["at any time"]
-    },
-    {
-      "description": "Automatically merge lock file maintenance every month",
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "automerge": true,
-      "automergeType": "branch",
-      "recreateClosed": true,
-      "schedule": ["on the first day of the month"]
-    },
     {
       "description": "Automatically merge patch and minor updates to dev dependencies",
       "matchDepTypes": ["devDependencies"],


### PR DESCRIPTION
With the overrides we specified, renovate applies lock file maintenance multiple times on the first day of the month. Instead, we'll override these options the correct way, which should inherit the standard scheduling semantics of `maintainLockFilesMonthly`.