### PR TITLE
revert: test(ecau): convince TS of jest mock types

### DIFF
--- a/tests/unit/mb_enhanced_cover_art_uploads/seeding/atisket/dimensions.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/seeding/atisket/dimensions.test.ts
@@ -23,8 +23,8 @@ describe('local storage cache', () => {
         size: 567,
     };
 
-    const lsSetItemSpy = jest.spyOn(window.Storage.prototype, 'setItem') as jest.SpiedFunction<Storage['setItem']>;
-    const lsGetItemSpy = jest.spyOn(window.Storage.prototype, 'getItem') as jest.SpiedFunction<Storage['getItem']>;
+    const lsSetItemSpy = jest.spyOn(window.Storage.prototype, 'setItem');
+    const lsGetItemSpy = jest.spyOn(window.Storage.prototype, 'getItem');
 
     function mockLocalStorage(fakeLocalStorage: Record<string, string | undefined>): void {
         lsGetItemSpy.mockImplementation((key) => {


### PR DESCRIPTION
This reverts commit 0a104b762557185ba515fdb18f1c10d0be0dd5df.

The type declarations have been fixed so this additional verbosity is no longer necessary.