### PR TITLE
build: use local implementation of rollup-plugin-consts

### DIFF
--- a/build/plugin-consts.ts
+++ b/build/plugin-consts.ts
@@ -1,0 +1,31 @@
+// Adapted from https://github.com/NotWoods/rollup-plugin-consts/ for Rollup 3.
+// Licensed under Apache 2.0, see https://github.com/NotWoods/rollup-plugin-consts/blob/main/LICENSE
+
+import type { Plugin } from 'rollup';
+import type { Primitive } from 'type-fest';
+
+type PrimitiveNoSymbol = Exclude<Primitive, symbol>;
+type AllowedValue = PrimitiveNoSymbol | AllowedValue[] | { [key: string | number]: AllowedValue };
+
+const moduleStart = 'consts:';
+
+export function consts(constValues: Record<string, AllowedValue>): Plugin {
+    return {
+        name: 'consts-plugin',
+        resolveId(id: string): string | undefined {
+            if (!id.startsWith(moduleStart)) return;
+            return id;
+        },
+        load(id: string): string | undefined {
+            if (!id.startsWith(moduleStart)) return;
+            const key = id.slice(moduleStart.length);
+
+            if (!(key in constValues)) {
+                this.error(`Cannot find const: ${key}`);
+                return;
+            }
+
+            return `export default ${JSON.stringify(constValues[key])}`;
+        },
+    };
+}

--- a/build/rollup.ts
+++ b/build/rollup.ts
@@ -11,12 +11,12 @@ import { nodeResolve } from '@rollup/plugin-node-resolve';
 import virtual from '@rollup/plugin-virtual';
 import postcssPresetEnv from 'postcss-preset-env';
 import { rollup } from 'rollup';
-import consts from 'rollup-plugin-consts';
 import postcss from 'rollup-plugin-postcss';
 import progress from 'rollup-plugin-progress';
 import { minify } from 'terser';
 
 import { parseChangelogEntries } from './changelog';
+import { consts } from './plugin-consts';
 import { logger } from './plugin-logger';
 import { nativejsx } from './plugin-nativejsx';
 import { updateNotifications } from './plugin-update-notifications';

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,7 +86,6 @@
         "postcss": "8.4.21",
         "postcss-preset-env": "8.0.1",
         "rollup": "2.79.1",
-        "rollup-plugin-consts": "1.1.0",
         "rollup-plugin-postcss": "4.0.2",
         "rollup-plugin-progress": "1.1.2",
         "sass": "1.58.0",
@@ -12794,15 +12793,6 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/rollup-plugin-consts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-consts/-/rollup-plugin-consts-1.1.0.tgz",
-      "integrity": "sha512-RRFKQ/IGK7Rs9q4Tb/l/bnOy0jWJUX1AYGqKbxZsgKoz61Fd9lVEmmJ8ytYQJ5hvyC5t8w9niy2svjmScoF6iw==",
-      "dev": true,
-      "peerDependencies": {
-        "rollup": ">=1.15.0 <3"
-      }
-    },
     "node_modules/rollup-plugin-postcss": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-postcss/-/rollup-plugin-postcss-4.0.2.tgz",
@@ -23422,13 +23412,6 @@
       "requires": {
         "fsevents": "~2.3.2"
       }
-    },
-    "rollup-plugin-consts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-consts/-/rollup-plugin-consts-1.1.0.tgz",
-      "integrity": "sha512-RRFKQ/IGK7Rs9q4Tb/l/bnOy0jWJUX1AYGqKbxZsgKoz61Fd9lVEmmJ8ytYQJ5hvyC5t8w9niy2svjmScoF6iw==",
-      "dev": true,
-      "requires": {}
     },
     "rollup-plugin-postcss": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
     "postcss": "8.4.21",
     "postcss-preset-env": "8.0.1",
     "rollup": "2.79.1",
-    "rollup-plugin-consts": "1.1.0",
     "rollup-plugin-postcss": "4.0.2",
     "rollup-plugin-progress": "1.1.2",
     "sass": "1.58.0",


### PR DESCRIPTION
Although the 3rd party version has been updated to support Rollup v3, the update hasn't been released yet after many months. This blocks our upgrade to Rollup 3 (#587). Since it's a very simple plugin, we can maintain our own copy.

Also improves the type declaration slightly to prevent passing in data which won't be injected properly, since it's using JSON.stringify internally.