### PR TITLE
ci: configure renovate to create a single PR per month

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "extends": [
     "config:base",
-    "schedule:weekends",
+    "schedule:monthly",
     ":semanticCommitTypeAll(build)",
     ":maintainLockFilesMonthly",
     ":label(dependencies)"
@@ -11,7 +11,9 @@
     "automerge": true,
     "automergeType": "branch",
     "recreateClosed": true,
-    "schedule": ["at any time"]
+    "schedule": [
+      "at any time"
+    ]
   },
   "lockFileMaintenance": {
     "automerge": true,
@@ -20,11 +22,19 @@
   "packageRules": [
     {
       "description": "Automatically merge patch and minor updates to dev dependencies",
-      "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["patch", "minor"],
+      "matchDepTypes": [
+        "devDependencies"
+      ],
+      "matchUpdateTypes": [
+        "patch",
+        "minor"
+      ],
       "automerge": true,
       "automergeType": "branch",
-      "schedule": ["at any time"]
+      "groupName": "dev dependencies (non-major)",
+      "excludePackageNames": [
+        "babel-plugin-transform-async-to-promises"
+      ]
     }
   ]
 }


### PR DESCRIPTION
The package update spam is getting out of hand, and the vast majority of recent commits are updates to dev dependencies. The previous config could make sense when the repo is very active, but this repo hasn't been very active in the past few months except for merging dependency updates. That maintenance effort is better spent elsewhere, so reducing the frequency of automated updates makes sense.

Patch and minor upgrades should all be grouped into a single monthly PR, and will be auto-merged if CI passes and the compiled scripts are unaffected. Major upgrades and any upgrade to production dependencies will still be raised as a PR, but also just once a month.

We're explicitly ignoring one package due to #624, so if a future update to that package is available, it'll still be a separate PR. If that update is merged, we should also remove it from the ignored packages.