### PR TITLE
fix(ecau): retry loading image contents on certain HTTP errors

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -220,7 +220,7 @@ export class ImageFetcher {
             retries: 10,
             onFailedAttempt: (err) => {
                 // Don't retry on 4xx status codes except for 429. Anything below 400 doesn't throw a HTTPResponseError.
-                if (!(err instanceof HTTPResponseError) || err.statusCode < 500 || err.statusCode !== 429) {
+                if (!(err instanceof HTTPResponseError) || (err.statusCode < 500 && err.statusCode !== 429)) {
                     throw err;
                 }
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/test-utils/dummy-data.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/test-utils/dummy-data.ts
@@ -1,6 +1,7 @@
 // Abstractions to create dummy data
 
 import type { CoverArt, FetchedImage } from '@src/mb_enhanced_cover_art_uploads/types';
+import { HTTPResponseError } from '@lib/util/xhr';
 
 export interface DummyImageData {
     blob?: Blob;
@@ -89,4 +90,17 @@ export function createXhrResponse(response?: Partial<GM.Response<never>>): GM.Re
         responseText: response.responseText ?? '',
         responseXML: response.responseXML ?? false,
     };
+}
+
+export function createHttpError(response?: Partial<GM.Response<never>>): HTTPResponseError {
+    const xhrResponse = createXhrResponse(response);
+    const err = new HTTPResponseError(xhrResponse.finalUrl, xhrResponse);
+    // If gmxhr is mocked, the HTTP errors are too, so we need to define these
+    // properties manually.
+    Object.defineProperties(err, {
+        response: { value: xhrResponse },
+        statusCode: { value: xhrResponse.status },
+        statusText: { value: xhrResponse.statusText },
+    });
+    return err;
 }


### PR DESCRIPTION
Discogs has started to rate-limit image requests. Adding a retry-loop with exponential backoff on 429/5xx HTTP errors should alleviate most of these issues, and will work for other providers too.

Manually tested on a release with 47 Discogs images. 5 retries is not enough, but 10 seems to work.

Fixes #668.