### PR TITLE
ci: allow renovate more time to run

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,12 @@
 {
   "extends": [
     "config:base",
-    "schedule:monthly",
     ":semanticCommitTypeAll(build)",
     ":maintainLockFilesMonthly",
     ":label(dependencies)"
+  ],
+  "schedule": [
+    "on the first day of the month"
   ],
   "pin": {
     "enabled": true,


### PR DESCRIPTION
Seems like renovate hasn't been running the past few months because the default "monthly" schedule is set to be "before 4am on the first day of the month" but checking the logs, it only started running at 7am UTC today. Let's give it the entire day instead, just to make sure it runs when it should.