### PR TITLE
ci: don't run build-and-test twice for renovate updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,11 +10,12 @@ on:
   # Periodically run CI for CodeQL security advisories etc, in case new checks
   # are added.
   schedule:
-    - cron: '39 12 * * 0'
+    - cron: "39 12 * * 0"
 
 jobs:
   build-and-test:
     name: Build and test
+    if: "!startsWith(github.head_ref, 'renovate/')" # Already covered by renovate-check.
     uses: ROpdebee/mb-userscripts/.github/workflows/build-and-test.yml@main
 
   codeql:


### PR DESCRIPTION
renovate-check is also running this job. We can't remove it from renovate-check because otherwise it won't run without a PR. It needs to run without a PR for automerge.