### PR TITLE
ci: larger schedule for renovate lock file maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,7 +19,10 @@
   },
   "lockFileMaintenance": {
     "automerge": true,
-    "automergeType": "branch"
+    "automergeType": "branch",
+    "schedule": [
+      "before 11am on the first day of the month"
+    ]
   },
   "packageRules": [
     {


### PR DESCRIPTION
Same reason as #677, but instead of allowing the whole day, we'll only allow it in the morning. Otherwise it may create multiple commits in the same day. It might still do so, but at least it won't be doing to the entire day.