### PR TITLE
fix(ecau): prevent image blob from unloading before upload

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/fetch.ts
+++ b/src/mb_enhanced_cover_art_uploads/fetch.ts
@@ -5,6 +5,7 @@ import { getFromPageContext } from '@lib/compat';
 import { LOGGER } from '@lib/logging/logger';
 import { ArtworkTypeIDs } from '@lib/MB/CoverArt';
 import { enumerate } from '@lib/util/array';
+import { blobToBuffer } from '@lib/util/blob';
 import { HTTPResponseError, request } from '@lib/util/request';
 import { urlBasename } from '@lib/util/urls';
 
@@ -257,12 +258,17 @@ export class ImageFetcher {
             throw new Error('Expected to receive an image, but received text. Perhaps this provider is not supported yet?');
         }
 
+        // Convert and copy the response blob to a buffer.
+        // We copy the content to make sure the contents do not get unloaded
+        // before the image is uploaded. See https://github.com/ROpdebee/mb-userscripts/issues/582
+        const contentBuffer = await blobToBuffer(resp.blob);
+
         return {
             requestedUrl: url,
             fetchedUrl,
             wasRedirected,
             file: new File(
-                [resp.blob],
+                [contentBuffer],
                 this.createUniqueFilename(fileName, id, mimeType),
                 { type: mimeType }),
         };


### PR DESCRIPTION
It appears that Violentmonkey's implementation of `GM.xhr` with a blob `responseType` causes the blob to become unloaded if the response itself goes out of scope. When that happens, the image we enqueued for uploading will become empty, and the upload will fail. To prevent this from happening, we'll instead copy the buffer, which should prevent the contents from being unloaded.