### PR TITLE
fix(ecau): copy MusicBrainz complex artwork types

### DIFF
--- a/src/lib/MB/CoverArt.ts
+++ b/src/lib/MB/CoverArt.ts
@@ -7,13 +7,13 @@ export enum ArtworkTypeIDs {
     Obi = 5,
     Other = 8,
     Poster = 11,
-    Raw = 14,  // Raw/Unedited
+    'Raw/Unedited' = 14,
     Spine = 6,
     Sticker = 10,
     Track = 7,
     Tray = 9,
     Watermark = 13,
-    Matrix = 15,  // Matrix/Runout
+    'Matrix/Runout' = 15,
     Top = 48,
     Bottom = 49,
 }

--- a/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/vgmdb.ts
@@ -86,7 +86,7 @@ function mapDiscType(mediumType: string, caption: string): MappedArtwork {
     for (const keyword of keywords) {
         // As a regular expression because it might be surrounded in parentheses
         if (/reverse|back/i.test(keyword)) {
-            type = ArtworkTypeIDs.Matrix;
+            type = ArtworkTypeIDs['Matrix/Runout'];
         } else if (!/front/i.test(keyword)) {  // Don't include "front" for e.g. "Disc Front"
             commentParts.push(keyword);
         }
@@ -127,7 +127,7 @@ const __CAPTION_TYPE_MAPPING: Record<string, MappedArtwork | ((caption: string) 
     insert: { type: ArtworkTypeIDs.Other, comment: 'Insert' }, // Or poster?
     inside: ArtworkTypeIDs.Tray,
     case: mapPackagingType.bind(undefined, 'Case'),
-    contents: ArtworkTypeIDs.Raw,
+    contents: ArtworkTypeIDs['Raw/Unedited'],
 };
 
 function convertMappingReturnValue(ret: MappedArtwork): { types: ArtworkTypeIDs[]; comment: string } {

--- a/tests/test-data/__recordings__/musicbrainz-provider_2175364407/extracting-images_1310741912/extracts-covers-for-release-with-complex-artwork-types_3075974168.warc
+++ b/tests/test-data/__recordings__/musicbrainz-provider_2175364407/extracting-images_1310741912/extracts-covers-for-release-with-complex-artwork-types_3075974168.warc
@@ -1,0 +1,145 @@
+WARC/1.1
+WARC-Filename: musicbrainz provider/extracting images/extracts covers for release with complex artwork types
+WARC-Date: 2023-12-01T14:48:49.945Z
+WARC-Type: warcinfo
+WARC-Record-ID: <urn:uuid:c735b64a-3c5c-4cf9-a731-c02ad2af1d21>
+Content-Type: application/warc-fields
+Content-Length: 119
+
+software: warcio.js
+harVersion: 1.2
+harCreator: {"name":"Polly.JS","version":"6.0.6","comment":"persister:fs-warc"}
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:a13cbd25-8b5a-4897-95b8-9c2ed81ebdf1>
+WARC-Target-URI: https://archive.org/metadata/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c
+WARC-Date: 2023-12-01T14:48:49.946Z
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:cc3f594c-92fb-4b1f-92a9-98cba1f066e0>
+Content-Type: application/http; msgtype=request
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:cf1bcce22bc9a3d3259050346936c38a9ed80cd685d2ea8a396a8e9410fb86f1
+Content-Length: 68
+
+GET /metadata/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c HTTP/1.1
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:a13cbd25-8b5a-4897-95b8-9c2ed81ebdf1>
+WARC-Target-URI: https://archive.org/metadata/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c
+WARC-Date: 2023-12-01T14:48:49.947Z
+WARC-Type: metadata
+WARC-Record-ID: <urn:uuid:6bc0ece6-5926-481a-bb8b-a4a04893bb89>
+Content-Type: application/warc-fields
+WARC-Payload-Digest: sha256:5c0e75e3ad5ce5d131aaa29b3ead2e036560a4a3cd54519c27aabc53d1999937
+WARC-Block-Digest: sha256:5c0e75e3ad5ce5d131aaa29b3ead2e036560a4a3cd54519c27aabc53d1999937
+Content-Length: 348
+
+harEntryId: f124879e743ef47e267a2fa91a25ee7e
+harEntryOrder: 0
+cache: {}
+startedDateTime: 2023-12-01T14:48:48.734Z
+time: 521
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":521,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 89
+warcRequestCookies: []
+warcResponseHeadersSize: 406
+warcResponseCookies: []
+responseDecoded: false
+
+
+WARC/1.1
+WARC-Target-URI: https://archive.org/metadata/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c
+WARC-Date: 2023-12-01T14:48:49.946Z
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:a13cbd25-8b5a-4897-95b8-9c2ed81ebdf1>
+Content-Type: application/http; msgtype=response
+WARC-Payload-Digest: sha256:5c93df14d648e58f189ef452b304d57150b00139be586a234c9102625d6120bd
+WARC-Block-Digest: sha256:30817c398e7b8744e3ae0e1e7d4eb73fc0424441edb90298b7296cb1d1751b03
+Content-Length: 17103
+
+HTTP/1.1 200 OK
+access-control-allow-origin: *
+connection: keep-alive
+content-encoding: gzip
+content-type: application/json
+date: Fri, 01 Dec 2023 14:48:49 GMT
+referrer-policy: no-referrer-when-downgrade
+server: nginx/1.25.1
+strict-transport-security: max-age=15724800
+transfer-encoding: chunked
+vary: Accept-Encoding
+x-pollyjs-finalurl: https://archive.org/metadata/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c
+
+{"created":1701441644,"d1":"ia600507.us.archive.org","d2":"ia800507.us.archive.org","dir":"/16/items/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c","files":[{"name":"__ia_thumb.jpg","source":"original","mtime":"1698617120","size":"11202","md5":"c47fd287eb738507681a7778b6f2271c","crc32":"85b2266e","sha1":"7f90bd6eeb2fd9dbb828a5a755ca203ea829920a","format":"Item Tile","rotation":"0"},{"name":"history\/files\/index.json.~1~","source":"original","old_version":"true","mtime":"1698609357","size":"821","md5":"56c7c844d18a33f9eabe093de3da7807","crc32":"ef2488bb","sha1":"b8136c82da5ef0bf6a14fd787ad9f08102a653a3","format":"JSON","viruscheck":"1698616974"},{"name":"history\/files\/index.json.~2~","source":"original","old_version":"true","mtime":"1698609381","size":"1564","md5":"f39f3e6dbf42a6ded1feba5cf7cd85b2","crc32":"675aa104","sha1":"e3977ba8072ea6f5e3ec5ffd28186dd43db94c60","format":"JSON","viruscheck":"1698616974"},{"name":"history\/files\/index.json.~3~","source":"original","old_version":"true","mtime":"1698609409","size":"2286","md5":"33d6303283161286d2ed4decf5548185","crc32":"cc4fb687","sha1":"c853c9494d1aa3427052cb4ca4d9445f875aaf83","format":"JSON","viruscheck":"1698616974"},{"name":"history\/files\/index.json.~4~","source":"original","old_version":"true","mtime":"1698609432","size":"3045","md5":"85ccf7399593cf5328546acc6a659964","crc32":"29931d1e","sha1":"1467dbe7f12abb2ed257c9a39453dfa8685163b3","format":"JSON","viruscheck":"1698616974"},{"name":"history\/files\/index.json.~5~","source":"original","old_version":"true","mtime":"1698609454","size":"3781","md5":"b4cff3919a0c187920f4dd8b48932e18","crc32":"35df11c1","sha1":"60f5e87db6c1787173f2aeed7c812ba895baf5c7","format":"JSON","viruscheck":"1698616974"},{"name":"history\/files\/index.json.~6~","source":"original","old_version":"true","mtime":"1698614500","size":"4516","md5":"06baa5abb391feb261236239f02b74d6","crc32":"ff266ea5","sha1":"22f93beccaa7c926b2c6c86a9ef975ce8a32b2e9","format":"JSON","viruscheck":"1698616974"},{"name":"index.json","source":"original","mtime":"1698614537","size":"5255","md5":"c7af0824bf96e06e4de9029788095e47","crc32":"d51094f0","sha1":"77bc2389236d5b4cfa60c06f7eb8c51d295b14ae","format":"JSON","viruscheck":"1698616974"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405.png","source":"original","mtime":"1698609343","size":"6690613","md5":"d280dbc11c235431051b025af696ed02","crc32":"d56cc86c","sha1":"788c4118a51ac3e68ab46c49550d5eb66dd54ad6","format":"PNG"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405_itemimage.jpg","source":"derivative","format":"Item Image","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405.png","mtime":"1698617006","size":"25018","md5":"6b93a62a68204abadb5e67ad59f0355e","crc32":"f564508e","sha1":"c872ee4b68fa22c2e08e97b878154e75216271d6"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405_thumb.jpg","source":"derivative","format":"JPEG Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405.png","mtime":"1698616989","size":"25018","md5":"6b93a62a68204abadb5e67ad59f0355e","crc32":"f564508e","sha1":"c872ee4b68fa22c2e08e97b878154e75216271d6"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405_thumb1200.jpg","source":"derivative","format":"JPEG 1200px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405.png","mtime":"1698617002","size":"317307","md5":"9e28bd207f65b0a45dcb2886f913103f","crc32":"f58a5c09","sha1":"e4c9a6f91d0d38fa99a6e2b0cf90850ba0df3a5a"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405_thumb250.jpg","source":"derivative","format":"JPEG 250px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405.png","mtime":"1698616994","size":"31414","md5":"a3bcb37de2133fa63c18319aeefcf667","crc32":"c25f111d","sha1":"3396ea1e39d694d2e852310b68dc64d77b3f890f"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405_thumb500.jpg","source":"derivative","format":"JPEG 500px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108042405.png","mtime":"1698616997","size":"69221","md5":"06e1e8a82cd58a9fef6b79c81f885694","crc32":"4a91b572","sha1":"5e3e57f3a3c8f1d6d0c515ebb52a9e25dfcbbd4e"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215.png","source":"original","mtime":"1698609365","size":"13251195","md5":"484f7348fff718c755cc742511a5fe74","crc32":"649f138a","sha1":"953f736e6822ce32d3c147e8cef9508c97f34cdf","format":"PNG"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215_itemimage.jpg","source":"derivative","format":"Item Image","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215.png","mtime":"1698617027","size":"15816","md5":"ec38b64321033059b2896b4474605089","crc32":"4be8370b","sha1":"927a74beace542576d873353734c77bf49c1717b"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215_thumb.jpg","source":"derivative","format":"JPEG Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215.png","mtime":"1698617011","size":"15816","md5":"ec38b64321033059b2896b4474605089","crc32":"4be8370b","sha1":"927a74beace542576d873353734c77bf49c1717b"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215_thumb1200.jpg","source":"derivative","format":"JPEG 1200px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215.png","mtime":"1698617022","size":"306782","md5":"b84823aa95299b8d753efed3cac805fc","crc32":"a7b5cf9b","sha1":"0c68c859bd709f27f8934ccdc081441485e1e818"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215_thumb250.jpg","source":"derivative","format":"JPEG 250px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215.png","mtime":"1698617015","size":"23061","md5":"c9136415eab2381eabbae763513c33fc","crc32":"31b04e41","sha1":"cf329d9633a951bfc303432f231ad831169283c7"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215_thumb500.jpg","source":"derivative","format":"JPEG 500px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108044215.png","mtime":"1698617019","size":"70449","md5":"8cad3fecd1fe11ad1aab489e873c09ab","crc32":"6c146ccd","sha1":"55e31907fd3ebbb9ad9f1d43665f242fd6b58b4d"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571.png","source":"original","mtime":"1698609388","size":"11140224","md5":"6a866b5463da59f394484c00b4cf7ce4","crc32":"9317ad27","sha1":"e19a0f5fae43b40e4700f0794b56dd2dc778092d","format":"PNG"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571_thumb.jpg","source":"derivative","format":"JPEG Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571.png","mtime":"1698617032","size":"13229","md5":"757d3e4e721fdde7bbbfe67c531a2e02","crc32":"27046cc8","sha1":"6b95a7e05c1be184fd0dc03833bf955a947abc1d"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571_thumb1200.jpg","source":"derivative","format":"JPEG 1200px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571.png","mtime":"1698617043","size":"272848","md5":"d22bbb0eef97591cb78ead4069cec385","crc32":"dcdee1cc","sha1":"f2d28623e22ab9bdd11a70fc0f16b45b1192bd14"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571_thumb250.jpg","source":"derivative","format":"JPEG 250px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571.png","mtime":"1698617035","size":"19881","md5":"8ef0cea282efd929ec3839b03d31f8e2","crc32":"9401804f","sha1":"b0014c25e557f6b3590e135ca8cbcf96ec7e2cff"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571_thumb500.jpg","source":"derivative","format":"JPEG 500px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108046571.png","mtime":"1698617039","size":"64119","md5":"3df5ab4313d3b6e5272b0ee31a035c70","crc32":"5666b256","sha1":"8b192dfea1e32f31a3560ce3502a82a440c9fa75"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319.png","source":"original","mtime":"1698609418","size":"15030056","md5":"81c9ff631f619f8e422cccc53efab9da","crc32":"b76541d9","sha1":"42aed5c465488de7c907501eff244be262d2bd7f","format":"PNG"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319_itemimage.jpg","source":"derivative","format":"Item Image","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319.png","mtime":"1698617063","size":"16163","md5":"302954422b5684c1e6998a2c6ccfbc08","crc32":"70dce5a0","sha1":"75f16095081d11903114cef5f90cd40efafbe5b1"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319_thumb.jpg","source":"derivative","format":"JPEG Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319.png","mtime":"1698617048","size":"16163","md5":"302954422b5684c1e6998a2c6ccfbc08","crc32":"70dce5a0","sha1":"75f16095081d11903114cef5f90cd40efafbe5b1"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319_thumb1200.jpg","source":"derivative","format":"JPEG 1200px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319.png","mtime":"1698617059","size":"320892","md5":"5145920e6dc1060a6ec61d54b04ca80c","crc32":"b33bb133","sha1":"b2ee8c3e65020190d833f806d026db85cf0c212c"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319_thumb250.jpg","source":"derivative","format":"JPEG 250px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319.png","mtime":"1698617052","size":"23833","md5":"9f50f7e1ebbda596936b35ba6c870b2b","crc32":"f002ef9f","sha1":"7c2a1bab39f1b90a9980968a98d7fac7eefaa472"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319_thumb500.jpg","source":"derivative","format":"JPEG 500px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319.png","mtime":"1698617056","size":"71924","md5":"bf1546bb70307e7d6b5c22a1fd02b86d","crc32":"02ee4d76","sha1":"79c132ee337ed59ff4fd9c9a8fdd9058fcfcee47"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684.png","source":"original","mtime":"1698609440","size":"13051343","md5":"6985cac1219a8833cd3f09464fbecbdc","crc32":"792edec9","sha1":"457844dc04e8e878f1a5127b372c766299da7f26","format":"PNG"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684_thumb.jpg","source":"derivative","format":"JPEG Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684.png","mtime":"1698617068","size":"13638","md5":"0f54eb53645ca42cd0d62c4460a813c5","crc32":"0a7156a5","sha1":"df5c6bbc19feb0cdecfac8954210185c392dcfe3"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684_thumb1200.jpg","source":"derivative","format":"JPEG 1200px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684.png","mtime":"1698617078","size":"285721","md5":"ca5b977ed479b2d78f50fd1507a640ce","crc32":"7d64d729","sha1":"03f6569cf0dd43257be3c4be5626235b8dab480b"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684_thumb250.jpg","source":"derivative","format":"JPEG 250px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684.png","mtime":"1698617071","size":"20684","md5":"12f69e43b3a68fb8788231f3ea3b6b90","crc32":"38816094","sha1":"7d5b0836aac7b2cfadfe3b55f1a81dc03509b216"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684_thumb500.jpg","source":"derivative","format":"JPEG 500px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684.png","mtime":"1698617075","size":"65625","md5":"4b4ec61f3d7186529ec9372cac54ea6d","crc32":"63ea2d01","sha1":"a69aeefe2bec6f58d5e6a07d343599c28b5a4cc9"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489.png","source":"original","mtime":"1698614485","size":"7077272","md5":"4b158a3d7881cf58e4b9d1a62837e501","crc32":"e60ea80f","sha1":"b56ff5b096fd73e0eee6d6cad488f3de7cb7a94f","format":"PNG"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489_thumb.jpg","source":"derivative","format":"JPEG Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489.png","mtime":"1698617083","size":"10880","md5":"705a951e1950496a641ad81aa01fcf0f","crc32":"8a85c568","sha1":"2da4e8063d0a81fd853e1fd4ae22a079c68a514e"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489_thumb1200.jpg","source":"derivative","format":"JPEG 1200px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489.png","mtime":"1698617093","size":"167240","md5":"893753adf17594a19bf7fdca89e4a2f3","crc32":"cdc37fa1","sha1":"3b6335fdaf7ee1320e705505daae8e665f6c2d04"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489_thumb250.jpg","source":"derivative","format":"JPEG 250px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489.png","mtime":"1698617086","size":"14493","md5":"0f74f69eca8bdbe3aa95b90185958d42","crc32":"7dffb173","sha1":"503f82be64b5a444cdbb040f2214e9db87092d47"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489_thumb500.jpg","source":"derivative","format":"JPEG 500px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108556489.png","mtime":"1698617090","size":"37989","md5":"adf03ea98fb103b5c02637159445f8c6","crc32":"d1aac008","sha1":"5270d1b0129b46cd34ebb35f5d4f65e3ab10b2fe"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413.png","source":"original","mtime":"1698614501","size":"7064111","md5":"784e5ed355194c24cd4fe7d589f765f0","crc32":"d1244b68","sha1":"53d8d2824e9cad15e3e9f24879c55affd241c555","format":"PNG"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413_thumb.jpg","source":"derivative","format":"JPEG Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413.png","mtime":"1698617097","size":"10891","md5":"dec3b948c15d475dd7efdb3c520031c4","crc32":"5b27e5a1","sha1":"d4b8d2c946cb46f424bc821efe0d06c9ba96eb11"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413_thumb1200.jpg","source":"derivative","format":"JPEG 1200px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413.png","mtime":"1698617109","size":"168447","md5":"c73b349d9549d2dd475ed5c1302ca1cd","crc32":"e04e10be","sha1":"6fb56782f2911ad68f9b5e4ea54f7d2a9cfb7a67"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413_thumb250.jpg","source":"derivative","format":"JPEG 250px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413.png","mtime":"1698617101","size":"14528","md5":"29b88b7080a758d28ff699fb37a38a92","crc32":"5ad16d3a","sha1":"7f1e952fd10dc408a3a6900ea713a47d0a707e65"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413_thumb500.jpg","source":"derivative","format":"JPEG 500px Thumb","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108558413.png","mtime":"1698617106","size":"38164","md5":"a973481e05a7fb2526fcc7d2641ceb42","crc32":"65d495c2","sha1":"7feb257633473edcfcefc3223743df100322f014"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c_files.xml","source":"original","format":"Metadata","md5":"514ef7a018c3fe66237ecc76ce400599","summation":"md5"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c_mb_metadata.xml","source":"original","mtime":"1698614547","size":"1212","md5":"eed543d5089020e215d91ae764dee903","crc32":"b85be94d","sha1":"c7f26b5d79a1c6d732efd7bd3898997a26aac7e8","format":"MusicBrainz Metadata","viruscheck":"1698616974"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c_meta.log","source":"derivative","format":"Metadata Log","original":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c_mb_metadata.xml","mtime":"1698617111","size":"698","md5":"d178e77ba03de6c5dc946754fd022d28","crc32":"16d3e2fe","sha1":"15feb309b09cb7d4ef0c19d9ebc28f8d27549e53"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c_meta.sqlite","source":"original","mtime":"1698616652","size":"36864","md5":"27950e2551857c7dff585deefb97f21d","crc32":"0cbd8aaa","sha1":"60fd279a7ca3ce0c9bb24808e826946836ee950b","format":"Metadata"},{"name":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c_meta.xml","source":"original","mtime":"1698617111","size":"830","md5":"063cefa8dec11592d264f638d5188f53","crc32":"b689ea52","sha1":"da1f7392803ef137411c04af108b2d1bbc730d2c","format":"Metadata"}],"files_count":51,"item_last_updated":1698617120,"item_size":75944142,"metadata":{"identifier":"mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c","collection":"coverartarchive","mediatype":"image","noindex":"true","uploader":"caa@musicbrainz.org","title":"Super\u2010G\u00e4rtner","publicdate":"2023-10-29 19:55:32","curation":"[curator]validator@archive.org[/curator][date]20231029220254[/date][comment]checked for malware[/comment]","creator":"[no artist]","date":"1985","language":"eng","external-identifier":["urn:mb_release_id:02cd52d7-2d0c-41a4-bf9c-59894bebab8c","urn:mb_artist_id:eec63d3c-3b81-4ad4-b1e4-7c147d4d2b61","urn:upc:4007187500138"]},"server":"ia800507.us.archive.org","uniq":1028878383,"workable_servers":["ia800507.us.archive.org","ia600507.us.archive.org"]}
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:b874383f-fcb0-4a5a-9b09-f2e0bed43d02>
+WARC-Target-URI: https://archive.org/download/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c/index.json
+WARC-Date: 2023-12-01T14:48:49.947Z
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:34e66eba-0cde-4a5a-aa97-abeffcef5b4a>
+Content-Type: application/http; msgtype=request
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:c702a688ae251400659b8d917febc2f29b4ab1c5fc1dc780cbd35ad06a649bf9
+Content-Length: 79
+
+GET /download/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c/index.json HTTP/1.1
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:b874383f-fcb0-4a5a-9b09-f2e0bed43d02>
+WARC-Target-URI: https://archive.org/download/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c/index.json
+WARC-Date: 2023-12-01T14:48:49.947Z
+WARC-Type: metadata
+WARC-Record-ID: <urn:uuid:ce626e36-a514-4db3-8175-24be42dba3d7>
+Content-Type: application/warc-fields
+WARC-Payload-Digest: sha256:6d151ea5b2c7dd0631415543745176bb1a8d48b3db3d95a1263f78ac14634c11
+WARC-Block-Digest: sha256:6d151ea5b2c7dd0631415543745176bb1a8d48b3db3d95a1263f78ac14634c11
+Content-Length: 349
+
+harEntryId: dfd214e19c5abadc1d1d3ff4446c0261
+harEntryOrder: 0
+cache: {}
+startedDateTime: 2023-12-01T14:48:49.257Z
+time: 675
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":675,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 100
+warcRequestCookies: []
+warcResponseHeadersSize: 686
+warcResponseCookies: []
+responseDecoded: false
+
+
+WARC/1.1
+WARC-Target-URI: https://archive.org/download/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c/index.json
+WARC-Date: 2023-12-01T14:48:49.947Z
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:b874383f-fcb0-4a5a-9b09-f2e0bed43d02>
+Content-Type: application/http; msgtype=response
+WARC-Payload-Digest: sha256:e08a2dc8c1308e358eb83299ad9f13a777bdbb7353aac0ba3e5b0bc8ea678fb1
+WARC-Block-Digest: sha256:4cb75f489c757c59fbb1cc6a2113d67a329e3070c3d697ad4d6db64a846b7f29
+Content-Length: 5958
+
+HTTP/1.1 200 OK
+accept-ranges: bytes
+access-control-allow-credentials: true
+access-control-allow-headers: Accept-Encoding,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,DNT,Pragma,Range,X-Requested-With
+access-control-allow-origin: *
+cache-control: max-age=21600
+connection: keep-alive
+content-length: 5255
+content-type: application/json
+date: Fri, 01 Dec 2023 14:48:49 GMT
+etag: "653ecd09-1487"
+expires: Fri, 01 Dec 2023 20:48:49 GMT
+last-modified: Sun, 29 Oct 2023 21:22:17 GMT
+server: nginx/1.25.1
+strict-transport-security: max-age=15724800
+x-pollyjs-finalurl: https://ia600507.us.archive.org/16/items/mbid-02cd52d7-2d0c-41a4-bf9c-59894bebab8c/index.json
+
+{"images":[{"approved":true,"back":false,"comment":"","edit":105175043,"front":true,"id":37108042405,"image":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108042405.png","thumbnails":{"1200":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108042405-1200.jpg","250":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108042405-250.jpg","500":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108042405-500.jpg","large":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108042405-500.jpg","small":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108042405-250.jpg"},"types":["Front"]},{"approved":true,"back":true,"comment":"","edit":105175048,"front":false,"id":37108044215,"image":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108044215.png","thumbnails":{"1200":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108044215-1200.jpg","250":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108044215-250.jpg","500":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108044215-500.jpg","large":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108044215-500.jpg","small":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108044215-250.jpg"},"types":["Front","Back","Spine"]},{"approved":true,"back":false,"comment":"","edit":105175056,"front":false,"id":37108046571,"image":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108046571.png","thumbnails":{"1200":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108046571-1200.jpg","250":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108046571-250.jpg","500":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108046571-500.jpg","large":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108046571-500.jpg","small":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108046571-250.jpg"},"types":[]},{"approved":true,"back":false,"comment":"Atari","edit":105176790,"front":false,"id":37108556489,"image":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108556489.png","thumbnails":{"1200":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108556489-1200.jpg","250":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108556489-250.jpg","500":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108556489-500.jpg","large":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108556489-500.jpg","small":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108556489-250.jpg"},"types":["Medium"]},{"approved":true,"back":false,"comment":"Commodore","edit":105176793,"front":false,"id":37108558413,"image":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108558413.png","thumbnails":{"1200":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108558413-1200.jpg","250":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108558413-250.jpg","500":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108558413-500.jpg","large":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108558413-500.jpg","small":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108558413-250.jpg"},"types":["Medium"]},{"approved":true,"back":false,"comment":"","edit":105175064,"front":false,"id":37108049319,"image":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108049319.png","thumbnails":{"1200":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108049319-1200.jpg","250":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108049319-250.jpg","500":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108049319-500.jpg","large":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108049319-500.jpg","small":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108049319-250.jpg"},"types":["Front","Back","Spine","Raw/Unedited"]},{"approved":true,"back":false,"comment":"","edit":105175072,"front":false,"id":37108051684,"image":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108051684.png","thumbnails":{"1200":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108051684-1200.jpg","250":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108051684-250.jpg","500":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108051684-500.jpg","large":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108051684-500.jpg","small":"http://coverartarchive.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/37108051684-250.jpg"},"types":["Raw/Unedited"]}],"release":"https://musicbrainz.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c"}
+

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/musicbrainz.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/musicbrainz.test.ts
@@ -51,6 +51,21 @@ describe('musicbrainz provider', () => {
                 types: [ArtworkTypeIDs.Obi],
                 comment: '',
             }],
+        }, {
+            desc: 'release with complex artwork types',
+            url: 'https://musicbrainz.org/release/02cd52d7-2d0c-41a4-bf9c-59894bebab8c/cover-art',
+            numImages: 7,
+            expectedImages: [{
+                index: 5,
+                urlPart: '02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108049319.png',
+                types: [ArtworkTypeIDs.Front, ArtworkTypeIDs.Back, ArtworkTypeIDs.Spine, ArtworkTypeIDs['Raw/Unedited']],
+                comment: '',
+            }, {
+                index: 6,
+                urlPart: '02cd52d7-2d0c-41a4-bf9c-59894bebab8c-37108051684.png',
+                types: [ArtworkTypeIDs['Raw/Unedited']],
+                comment: '',
+            }],
         }];
 
         const extractionFailedCases = [{

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/vgmdb.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/vgmdb.test.ts
@@ -42,9 +42,9 @@ describe('vgmdb provider', () => {
             ['Disc 1', [ArtworkTypeIDs.Medium], 'Disc 1'],
             ['DVD', [ArtworkTypeIDs.Medium], 'DVD'],
             ['CD', [ArtworkTypeIDs.Medium], 'CD'],
-            ['Disc (reverse)', [ArtworkTypeIDs.Matrix], ''],
-            ['Disc (Back)', [ArtworkTypeIDs.Matrix], ''],
-            ['Disc 1 (Back)', [ArtworkTypeIDs.Matrix], 'Disc 1'],
+            ['Disc (reverse)', [ArtworkTypeIDs['Matrix/Runout']], ''],
+            ['Disc (Back)', [ArtworkTypeIDs['Matrix/Runout']], ''],
+            ['Disc 1 (Back)', [ArtworkTypeIDs['Matrix/Runout']], 'Disc 1'],
             ['Cassette Front', [ArtworkTypeIDs.Medium], 'Front'],
             ['Vinyl A-side', [ArtworkTypeIDs.Medium], 'A-side'],
             ['Tray', [ArtworkTypeIDs.Tray], ''],
@@ -66,7 +66,7 @@ describe('vgmdb provider', () => {
             ['Case', [ArtworkTypeIDs.Front], 'Case'],
             ['Case: Back', [ArtworkTypeIDs.Back], 'Case'],
             ['Case: Inside', [ArtworkTypeIDs.Tray], 'Case'],
-            ['Contents', [ArtworkTypeIDs.Raw], ''],
+            ['Contents', [ArtworkTypeIDs['Raw/Unedited']], ''],
             [' Booklet Front & Back', [ArtworkTypeIDs.Booklet], 'Front & Back'],
             ['Booklet: Interview', [ArtworkTypeIDs.Booklet], 'Interview'],
             // ['Back Tray', [ArtworkTypeIDs.Tray], 'Back'],  // FIXME
@@ -112,7 +112,7 @@ describe('vgmdb provider', () => {
         });
 
         it('removes unnecessary parentheses', () => {
-            expect(convertCaptions({ url: 'https://example.com/', caption: 'Disc (CD1)'}))
+            expect(convertCaptions({ url: 'https://example.com/', caption: 'Disc (CD1)' }))
                 .toMatchObject({
                     types: [ArtworkTypeIDs.Medium],
                     comment: 'CD1',
@@ -123,7 +123,7 @@ describe('vgmdb provider', () => {
         });
 
         it('removes unnecessary dashes', () => {
-            expect(convertCaptions({ url: 'https://example.com/', caption: 'Disc - CD1'}))
+            expect(convertCaptions({ url: 'https://example.com/', caption: 'Disc - CD1' }))
                 .toMatchObject({
                     types: [ArtworkTypeIDs.Medium],
                     comment: 'CD1',


### PR DESCRIPTION
"Matrix/Runout" and "Raw/Unedited" could not be copied when a MB release's images were copied because the enum used the "Matrix" and "Raw" keys only. Instead, we'll use the full artwork type name as keys. This also requires changes in VGMdb's caption to artwork type mappings and related tests. Also add test case with a real release.

Fixes #708 