### PR TITLE
ci: upload codecov coverage data in separate job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -52,7 +52,27 @@ jobs:
 
       - name: Run jest
         run: npm run test
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage
+          path: ./coverage/lcov.info
+          retention-days: 7
+
+  upload-coverage:
+    needs: [test]
+    runs-on: ubuntu-latest
+    name: Upload coverage data
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage
+
       - name: Upload coverage data
         uses: codecov/codecov-action@v3
         with:
           files: ./coverage/lcov.info
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Codecov uploads are a bit flaky. Uploading the coverage data in a separate job allows us to fail and re-run that job and that job only, without needing to re-run tests. Also use token to avoid most upload flakes.