### PR TITLE
build: update minimum required versions of browsers

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,7 @@
-# Same as MBS
-chrome >= 49
-edge >= 14
-firefox >= 52
-safari >= 12
+# Browser versions released since 2021-01-01
+chrome >= 88
+edge >= 88
+firefox >= 85
+# Safari 15 was released after 2021-01-01, but we need at least version 15 to support IDBCursor.request, which is needed by idb. See https://caniuse.com/mdn-api_idbcursor_request
+safari >= 15
+opera >= 73

--- a/babel.config.cjs
+++ b/babel.config.cjs
@@ -16,24 +16,10 @@ const prodConfig = {
         ['@babel/preset-env', {
             corejs: '3.19',
             useBuiltIns: 'entry',
-            exclude: [
-                // Don't transform async functions and async generators using
-                // babel itself, this is handled by a plugin.
-                '@babel/plugin-transform-async-to-generator',
-                '@babel/plugin-proposal-async-generator-functions',
-            ],
         }],
     ],
     plugins: [
         '@babel/plugin-syntax-jsx',
-        // Transform async/await into promises. Need to do this before plugin-transform-runtime
-        // as that will transpile to generators with regenerator. This will skip
-        // complex async things, like async generators, those will still be handled
-        // by babel itself. However, transforming "simple" async/await to promises
-        // leads to a severely smaller footprint in the output.
-        ['babel-plugin-transform-async-to-promises', {
-            externalHelpers: true,
-        }],
         ['@babel/plugin-transform-runtime', {
             regenerator: true,
             helpers: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@types/setup-polly-jest": "0.5.5",
         "@typescript-eslint/eslint-plugin": "6.13.1",
         "@typescript-eslint/parser": "6.13.1",
-        "babel-plugin-transform-async-to-promises": "0.8.16",
         "confusing-browser-globals": "1.0.11",
         "conventional-commits-parser": "5.0.0",
         "core-js": "3.33.3",
@@ -5424,12 +5423,6 @@
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
       }
-    },
-    "node_modules/babel-plugin-transform-async-to-promises": {
-      "version": "0.8.16",
-      "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.16.tgz",
-      "integrity": "sha512-mm0UMekJVOTuIlkGIEH1fpnExyTIIJ2/L5ixTTI1zAVdMpbG7Em3LiS92p0TCWKiMkHhYYinz/zn2D/BPPJaxA==",
-      "dev": true
     },
     "node_modules/babel-preset-current-node-syntax": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@types/setup-polly-jest": "0.5.5",
     "@typescript-eslint/eslint-plugin": "6.13.1",
     "@typescript-eslint/parser": "6.13.1",
-    "babel-plugin-transform-async-to-promises": "0.8.16",
     "confusing-browser-globals": "1.0.11",
     "conventional-commits-parser": "5.0.0",
     "core-js": "3.33.3",

--- a/src/lib/util/domain_dispatch.ts
+++ b/src/lib/util/domain_dispatch.ts
@@ -79,7 +79,6 @@ export class DispatchMap<Leaf> {
         return this.retrieve([...splitDomain(domain)].reverse());
     }
 
-    // Workaround for https://github.com/babel/babel/issues/13875
     private _get(domainPart: '' | '*'): Leaf | undefined;
     private _get(domainPart: string): Leaf | DispatchMap<Leaf> | undefined;
     private _get(domainPart: string): Leaf | DispatchMap<Leaf> | undefined {

--- a/src/mb_enhanced_cover_art_uploads/maximise.ts
+++ b/src/mb_enhanced_cover_art_uploads/maximise.ts
@@ -240,15 +240,8 @@ export interface MaximisedImage {
 
 export async function* getMaximisedCandidates(smallurl: URL): AsyncGenerator<MaximisedImage, void, undefined> {
     const exceptionFn = IMU_EXCEPTIONS.get(smallurl.hostname);
-    // Workaround for https://github.com/rpetrich/babel-plugin-transform-async-to-promises/issues/80
-    // Cannot use yield*, so we'll loop over the results manually and yield all
-    // of the results individually.
-    // Use `exceptionFn` if it exists, otherwise maximise it as a generic image.
     const iterable = await (exceptionFn ?? maximiseGeneric)(smallurl);
-
-    for await (const item of iterable) {
-        yield item;
-    }
+    yield* iterable;
 }
 
 async function* maximiseGeneric(smallurl: URL): AsyncIterable<MaximisedImage> {


### PR DESCRIPTION
Going forward, we'll only support browsers versions released since 2021. These changes should reduce the size of the transpiled scripts substantially.