### PR TITLE
fix: increase SPA ID length limit for work code validation

### DIFF
--- a/lib/work_identifiers.js
+++ b/lib/work_identifiers.js
@@ -2,7 +2,7 @@
  * API for work identifiers. See inline docs.
  */
 const MBWorkIdentifiers = (() => {
-    const VERSION = '2021.5.27';  // Just for use in edit notes, really.
+    const VERSION = '2023.12.07';  // Just for use in edit notes, really.
 
     /**
      * Helper for LatinNet agencies. Returns a validation/formatting ruleset
@@ -201,7 +201,7 @@ const MBWorkIdentifiers = (() => {
             inRegexp: /\d{0,7}/,
         },
         'SPA ID': {
-            inRegexp: /\d{0,7}/,
+            inRegexp: /\d{0,8}/,
         },
         'SPAC ID': {
             inRegexp: /\d{0,7}/,

--- a/mb_bulk_copy_work_codes.user.js
+++ b/mb_bulk_copy_work_codes.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Bulk copy-paste work codes
-// @version      2022.3.31
+// @version      2023.12.07
 // @description  Copy work identifiers from various online repertoires and paste them into MB works with ease.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -15,7 +15,7 @@
 // @match        *://*.musicbrainz.org/release/*/edit-relationships
 // @match        *://musicbrainz.org/*/create
 // @match        *://*.musicbrainz.org/*/create
-// @require      https://raw.github.com/ROpdebee/mb-userscripts/main/lib/work_identifiers.js?v=2021.5.27
+// @require      https://raw.github.com/ROpdebee/mb-userscripts/main/lib/work_identifiers.js?v=2023.12.07
 // @run-at       document-end
 // @grant        GM_getValue
 // @grant        GM_setValue

--- a/mb_validate_work_codes.user.js
+++ b/mb_validate_work_codes.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: Validate Work Codes
-// @version      2021.12.18
+// @version      2023.12.07
 // @description  Validate work identifier codes: Highlight invalid or ill-formatted work codes.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -15,7 +15,7 @@
 // @match        *://*.musicbrainz.org/collection/*
 // @exclude      *://*.musicbrainz.org/work/*/edit
 // @require      https://code.jquery.com/jquery-3.6.0.min.js
-// @require      https://raw.github.com/ROpdebee/mb-userscripts/main/lib/work_identifiers.js?v=2021.5.27
+// @require      https://raw.github.com/ROpdebee/mb-userscripts/main/lib/work_identifiers.js?v=2023.12.07
 // @run-at       document-end
 // ==/UserScript==
 


### PR DESCRIPTION
SPA IDs are sequential numbers. Sometime within the last 2.5 years, the 10 millionth SPA ID was issued, which means that an increasing amount of IDs are now 8 characters long instead of 7. However, the script associated with this library currently only looks for 7 digits, and presents (incorrect) validation errors for 8-digit SPA IDs. This change aims to ameliorate that by increasing the character length the regex allows for.