### PR TITLE
fix(inline recs): Crash when no existing div.ars

### DIFF
--- a/mb_qol_inline_recording_tracks.user.js
+++ b/mb_qol_inline_recording_tracks.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: QoL: Inline all recording's tracks on releases
-// @version      2024.5.1
+// @version      2024.5.2
 // @description  Display all tracks and releases on which a recording appears from the release page.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -94,7 +94,7 @@ function insertRows(recordingTd, recordingInfo) {
 }
 
 function loadAndInsert() {
-    let recAnchors = document.querySelectorAll('table.medium td > a[href^="/recording/"]:first-child, table.medium td > span:first-child > a[href^="/recording/"]:first-child');
+    let recAnchors = document.querySelectorAll('table.medium td > a[href^="/recording/"]:first-child, table.medium td > span:first-child > a[href^="/recording/"]:first-child, table.medium td > span:first-child > span:first-child > a[href^="/recording/"]:first-child');
     let todo = [...recAnchors]
         .map((a) => [a.closest('td'), a.href.split('/recording/')[1]])
         .filter(([td]) => !td.querySelector('div.ars.ROpdebee_inline_tracks'));

--- a/mb_qol_inline_recording_tracks.user.js
+++ b/mb_qol_inline_recording_tracks.user.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         MB: QoL: Inline all recording's tracks on releases
-// @version      2022.6.14
+// @version      2024.5.1
 // @description  Display all tracks and releases on which a recording appears from the release page.
 // @author       ROpdebee
 // @license      MIT; https://opensource.org/licenses/MIT
@@ -84,8 +84,13 @@ function insertRows(recordingTd, recordingInfo) {
         .map(formatRow)
         .map(row => '<dl class="ars"><dt>appears on:</dt><dd>' + row + '</dd></dl>')
         .join('\n');
-    recordingTd.querySelector('div.ars')
-        .insertAdjacentHTML('beforebegin', '<div class="ars ROpdebee_inline_tracks">' + rowElements + '</div>');
+    rowElements = '<div class="ars ROpdebee_inline_tracks">' + rowElements + '</div>';
+    let existingArs = recordingTd.querySelector('div.ars');
+    if (existingArs) {
+        existingArs.insertAdjacentHTML('beforebegin', rowElements);
+    } else {
+        recordingTd.insertAdjacentHTML('beforeend', rowElements);
+    }
 }
 
 function loadAndInsert() {


### PR DESCRIPTION
I noticed that this userscript relies on mb_INLINE-STUFF to run properly.

Example release with no AR, no AcoustID and no ISRC (quick! it is being removed!)
https://musicbrainz.org/release/1f3a402f-7265-42ea-803a-f3cf8c508e7c

Or any other releases with credits at bottom and no mb_INLINE-STUFF running
https://musicbrainz.org/release/b4e8f7f4-e35c-42eb-a043-9605e4784aff