### PR TITLE
ci: disable renovate "temporarily"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,5 @@
 {
+  "enabled": false,
   "extends": [
     "config:base",
     ":semanticCommitTypeAll(build)",


### PR DESCRIPTION
We're failing to keep up with the automated dependency updates anyway, so let's prevent the spam and clear up bandwidth for important updates instead.