### PR TITLE
fix(caa dims): compatibility with new beta.MBS

### DIFF
--- a/src/mb_caa_dimensions/index.ts
+++ b/src/mb_caa_dimensions/index.ts
@@ -11,6 +11,11 @@ import { createCache } from './info-cache';
 
 import css from './style.scss';
 
+// Query for the span element containing the cover art image.
+// Old class name is "cover-art-image", new (since beta.MBS of May 24 2024) is "artwork-image".
+// TODO: Change this when new class name lands in production MBS.
+const ARTWORK_QUERY = '.cover-art-image, .artwork-image';
+
 function processPageChange(mutations: MutationRecord[], cache: InfoCache): void {
     const addedNodes = mutations.flatMap((mutation) => [...mutation.addedNodes]);
     for (const addedNode of addedNodes) {
@@ -50,7 +55,7 @@ function detectAndObserveImages(cache: InfoCache): void {
         processPageChange(mutations, cache);
     });
 
-    for (const container of qsa('.cover-art-image')) {
+    for (const container of qsa(ARTWORK_QUERY)) {
         // Seems to cover all possible cover art images except for queued upload thumbnails
         const imageElement = qsMaybe<HTMLImageElement>('img', container);
 

--- a/src/mb_caa_dimensions/style.scss
+++ b/src/mb_caa_dimensions/style.scss
@@ -29,7 +29,9 @@ div.thumb-position {
 }
 
 // Styling of the info spans
-span.cover-art-image {
+// TODO: beta.MBS of May 24 2024 changed the classname from "cover-art-image" to "artwork-image".
+//       Change this when new class name lands in production MBS.
+span.cover-art-image, span.artwork-image {
     display: inline-block;
 }
 span.ROpdebee_dimensions, span.ROpdebee_fileInfo {


### PR DESCRIPTION
Since event art went live, the classname for cover art images was changed, causing the script to not detect most images anymore. We'll use both classnames for now, since the production MBS still uses the old one, but the query can be simplified later.