### PR TITLE
fix(inline recs): Handle video recordings

### DIFF
--- a/mb_qol_inline_recording_tracks.user.js
+++ b/mb_qol_inline_recording_tracks.user.js
@@ -94,7 +94,7 @@ function insertRows(recordingTd, recordingInfo) {
 }
 
 function loadAndInsert() {
-    let recAnchors = document.querySelectorAll('table.medium td > a[href^="/recording/"]:first-child, table.medium td > span:first-child > a[href^="/recording/"]:first-child, table.medium td > span:first-child > span:first-child > a[href^="/recording/"]:first-child');
+    let recAnchors = document.querySelectorAll('table.medium td > a[href^="/recording/"], table.medium td > span > a[href^="/recording/"], table.medium td > span > span > a[href^="/recording/"]');
     let todo = [...recAnchors]
         .map((a) => [a.closest('td'), a.href.split('/recording/')[1]])
         .filter(([td]) => !td.querySelector('div.ars.ROpdebee_inline_tracks'));


### PR DESCRIPTION
Remove `:first-child`, not needed and blocking video recordings detection

The selector is already strict enough to not catch recordings from `div.ars` (I guess it was the reason for those)

Examples where video data track was not handled before this commit: https://musicbrainz.org/release/d9e494dd-9386-48e4-8c52-9764dd8b8a0f
https://musicbrainz.org/release/0a5be94f-3429-46bd-9b1d-07dcb0209098

Release with recordings in inline relationships (on CD 23): https://musicbrainz.org/release/70dcde39-81ed-45e8-bdb3-f511112a3880

There was not problem with non-video data tracks:
https://musicbrainz.org/release/b63ca2ff-782e-45fc-bfb9-b74dc6aefe00

---

@ROpdebee, may I leave you manage the version number, OK?
My 3 concurrent PR have no conflict between themselves:

- #764
- This
- #777 