### PR TITLE
fix(inline recs): Fix mb.org exclude rules and add mb.eu match rule

### DIFF
--- a/mb_qol_inline_recording_tracks.user.js
+++ b/mb_qol_inline_recording_tracks.user.js
@@ -7,9 +7,10 @@
 // @namespace    https://github.com/ROpdebee/mb-userscripts
 // @downloadURL  https://raw.github.com/ROpdebee/mb-userscripts/main/mb_qol_inline_recording_tracks.user.js
 // @updateURL    https://raw.github.com/ROpdebee/mb-userscripts/main/mb_qol_inline_recording_tracks.user.js
+// @match        *://*.musicbrainz.eu/release/*
 // @match        *://*.musicbrainz.org/release/*
-// @exclude      *://*.musicbrainz.org/release/add
-// @exclude      *://*.musicbrainz.org/release/*/edit*
+// @exclude      */release/*/*
+// @exclude      */release/add
 // @run-at       document-end
 // @grant        none
 // ==/UserScript==


### PR DESCRIPTION
Exclude rule syntax is like include, not like match (//*.mb.org does not match //mb.org, only test.mb.org, beta.mb.org) Before this commit, exclude rules are not applied to main //mb.org website

I am also excluding more unrelated pages (open edits, edit history page 2+, details, cover arts, ...)

Add mb.eu support

---

@ROpdebee, may I leave you manage the version number, OK?
My 3 concurrent PR have no conflict between themselves:

- #764
- #776 
- This