### PR TITLE
feat(caa dims): add support for new event art archive (EAA)

### DIFF
--- a/src/mb_caa_dimensions/image.ts
+++ b/src/mb_caa_dimensions/image.ts
@@ -83,7 +83,7 @@ export abstract class BaseImage {
 }
 
 function caaUrlToDirectUrl(urlObject: URL): URL {
-    if (urlObject.host.match(AA_DOMAINS) && urlObject.pathname.match(/^\/(event|release)\//)) {
+    if (AA_DOMAINS.test(urlObject.host) && /^\/(event|release)\//.test(urlObject.pathname)) {
         const [releaseId, imageName] = urlObject.pathname.split('/').slice(2);
         urlObject.href = `https://archive.org/download/mbid-${releaseId}/mbid-${releaseId}-${imageName}`;
     }
@@ -110,7 +110,7 @@ function urlToCacheKey(fullSizeUrl: string, thumbnailUrl?: string): string {
     // Ideally, the cache key for RG covers would be the full size URL of the release cover,
     // but we unfortunately cannot get the original image's extension here, so we cannot construct
     // it.
-    if (urlObject.host.match(AA_DOMAINS) && urlObject.pathname.startsWith('/release-group/')) {
+    if (AA_DOMAINS.test(urlObject.host) && urlObject.pathname.startsWith('/release-group/')) {
         assertDefined(thumbnailUrl, 'Release group image requires a thumbnail URL');
         return thumbnailUrl;
     }
@@ -156,7 +156,7 @@ function urlToDirectImageUrl(url: string): string {
 function parseCAAIDs(url: string): [string, string] {
     const urlObject = new URL(url);
 
-    if (urlObject.host.match(AA_DOMAINS) && urlObject.pathname.match(/^\/(event|release)\//)) {
+    if (AA_DOMAINS.test(urlObject.host) && /^\/(event|release)\//.test(urlObject.pathname)) {
         const [releaseId, thumbName] = urlObject.pathname.split('/').slice(2);
         const imageId = thumbName.match(/^(\d+)/)?.[0];
         assertDefined(imageId, 'Malformed URL');

--- a/src/mb_caa_dimensions/image.ts
+++ b/src/mb_caa_dimensions/image.ts
@@ -7,7 +7,8 @@ import { getCAAInfo } from './caa-info';
 import { getImageDimensions } from './dimensions';
 
 const CAA_ID_REGEX = /(mbid-[a-f\d-]{36})\/mbid-[a-f\d-]{36}-(\d+)/;
-const AA_DOMAINS = /^(cover|event)artarchive\.org$/;
+const CAA_DOMAIN = 'coverartarchive.org';
+const IMG_DOMAINS = /^(cover|event)artarchive\.org$/;
 
 export interface Image {
     getDimensions(): Promise<Dimensions | undefined>;
@@ -83,7 +84,7 @@ export abstract class BaseImage {
 }
 
 function caaUrlToDirectUrl(urlObject: URL): URL {
-    if (AA_DOMAINS.test(urlObject.host) && /^\/(event|release)\//.test(urlObject.pathname)) {
+    if (IMG_DOMAINS.test(urlObject.host) && /^\/(event|release)\//.test(urlObject.pathname)) {
         const [releaseId, imageName] = urlObject.pathname.split('/').slice(2);
         urlObject.href = `https://archive.org/download/mbid-${releaseId}/mbid-${releaseId}-${imageName}`;
     }
@@ -110,7 +111,7 @@ function urlToCacheKey(fullSizeUrl: string, thumbnailUrl?: string): string {
     // Ideally, the cache key for RG covers would be the full size URL of the release cover,
     // but we unfortunately cannot get the original image's extension here, so we cannot construct
     // it.
-    if (AA_DOMAINS.test(urlObject.host) && urlObject.pathname.startsWith('/release-group/')) {
+    if (urlObject.host === CAA_DOMAIN && urlObject.pathname.startsWith('/release-group/')) {
         assertDefined(thumbnailUrl, 'Release group image requires a thumbnail URL');
         return thumbnailUrl;
     }
@@ -156,7 +157,7 @@ function urlToDirectImageUrl(url: string): string {
 function parseCAAIDs(url: string): [string, string] {
     const urlObject = new URL(url);
 
-    if (AA_DOMAINS.test(urlObject.host) && /^\/(event|release)\//.test(urlObject.pathname)) {
+    if (IMG_DOMAINS.test(urlObject.host) && /^\/(event|release)\//.test(urlObject.pathname)) {
         const [releaseId, thumbName] = urlObject.pathname.split('/').slice(2);
         const imageId = thumbName.match(/^(\d+)/)?.[0];
         assertDefined(imageId, 'Malformed URL');

--- a/src/mb_caa_dimensions/image.ts
+++ b/src/mb_caa_dimensions/image.ts
@@ -7,7 +7,7 @@ import { getCAAInfo } from './caa-info';
 import { getImageDimensions } from './dimensions';
 
 const CAA_ID_REGEX = /(mbid-[a-f\d-]{36})\/mbid-[a-f\d-]{36}-(\d+)/;
-const CAA_DOMAIN = 'coverartarchive.org';
+const AA_DOMAINS = /^(cover|event)artarchive\.org$/;
 
 export interface Image {
     getDimensions(): Promise<Dimensions | undefined>;
@@ -83,7 +83,7 @@ export abstract class BaseImage {
 }
 
 function caaUrlToDirectUrl(urlObject: URL): URL {
-    if (urlObject.host === CAA_DOMAIN && urlObject.pathname.startsWith('/release/')) {
+    if (urlObject.host.match(AA_DOMAINS) && urlObject.pathname.match(/^\/(event|release)\//)) {
         const [releaseId, imageName] = urlObject.pathname.split('/').slice(2);
         urlObject.href = `https://archive.org/download/mbid-${releaseId}/mbid-${releaseId}-${imageName}`;
     }
@@ -110,7 +110,7 @@ function urlToCacheKey(fullSizeUrl: string, thumbnailUrl?: string): string {
     // Ideally, the cache key for RG covers would be the full size URL of the release cover,
     // but we unfortunately cannot get the original image's extension here, so we cannot construct
     // it.
-    if (urlObject.host === CAA_DOMAIN && urlObject.pathname.startsWith('/release-group/')) {
+    if (urlObject.host.match(AA_DOMAINS) && urlObject.pathname.startsWith('/release-group/')) {
         assertDefined(thumbnailUrl, 'Release group image requires a thumbnail URL');
         return thumbnailUrl;
     }
@@ -156,7 +156,7 @@ function urlToDirectImageUrl(url: string): string {
 function parseCAAIDs(url: string): [string, string] {
     const urlObject = new URL(url);
 
-    if (urlObject.host === CAA_DOMAIN && urlObject.pathname.startsWith('/release/')) {
+    if (urlObject.host.match(AA_DOMAINS) && urlObject.pathname.match(/^\/(event|release)\//)) {
         const [releaseId, thumbName] = urlObject.pathname.split('/').slice(2);
         const imageId = thumbName.match(/^(\d+)/)?.[0];
         assertDefined(imageId, 'Malformed URL');

--- a/src/mb_caa_dimensions/meta.ts
+++ b/src/mb_caa_dimensions/meta.ts
@@ -6,11 +6,13 @@ const metadata: UserscriptMetadata = {
     'description': 'Displays the dimensions and size of images in the cover art archive.',
     'run-at': 'document-start',
     'match': [
+        'event/*',
         'release/*',
         'release-group/*',
         ...MB_EDIT_PAGE_PATHS,
     ].map((path) => transformMBMatchURL(path)),
     'exclude': [
+        transformMBMatchURL('event/*/edit'),
         transformMBMatchURL('release/*/edit'),
         transformMBMatchURL('release/*/edit-relationships'),
         transformMBMatchURL('release-group/*/edit'),

--- a/src/mb_caa_dimensions/style.scss
+++ b/src/mb_caa_dimensions/style.scss
@@ -46,7 +46,7 @@ a.artwork-image, a.artwork-pdf {
 // In edit pages, the container is very wide and the text wouldn't be centered nicely,
 // so add a max width to be the same as the image it's labelling.
 // Not sure why the container is so wide though.
-td.edit-cover-art {
+td.edit-cover-art, td.edit-event-art {
     span.ROpdebee_dimensions, span.ROpdebee_fileInfo {
         max-width: 250px;
     }


### PR DESCRIPTION
@vzell request:

> https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/182
>
> Could the userscript **MB: Display CAA image dimensions** be extended to the new event-art-archive?

Tested on https://musicbrainz.org/event/d1bd6d40-55f6-4e1a-91df-4c9395f95401 and sub-pages (/event-art, /edits)