### PR TITLE
fix: remove extraneous spacing in JSX-transpiled HTML

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11452,8 +11452,9 @@
     },
     "node_modules/nativejsx": {
       "version": "4.3.0",
-      "resolved": "git+ssh://git@github.com/ROpdebee/nativejsx.git#f2bed01d621bb158134e13ed3abb9be9e265cd00",
+      "resolved": "git+ssh://git@github.com/ROpdebee/nativejsx.git#dc9d4694ff92c78f76b153e44af69948b035a5a4",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "acorn": "^8.3.0",
         "acorn-jsx": "^5.3.1",


### PR DESCRIPTION
Update nativejsx to trim extraneous whitespace. An example of the bug can be seen in the recent caa_dims changelog notifications, where there's a space before the period after the anchor. Normal JSX allegedly removes such whitespace, so we should too.