### PR TITLE
fix(ecau): fix seed parameters not iterable error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6061,9 +6061,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001582",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001582.tgz",
-      "integrity": "sha512-vsJG3V5vgfduaQGVxL53uSX/HUzxyr2eA8xCo36OLal7sRcSZbibJtLeh0qja4sFOr/QQGt4opB4tOy+eOgAxg==",
+      "version": "1.0.30001643",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001643.tgz",
+      "integrity": "sha512-ERgWGNleEilSrHM6iUz/zJNSQTP8Mr21wDWpdgvRwcTXGAq6jMtOUPP4dqFPTdKqZ2wKTdtB+uucZ3MRpAUSmg==",
       "dev": true,
       "funding": [
         {
@@ -6078,7 +6078,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chalk": {
       "version": "2.4.2",

--- a/src/mb_enhanced_cover_art_uploads/seeding/parameters.ts
+++ b/src/mb_enhanced_cover_art_uploads/seeding/parameters.ts
@@ -70,7 +70,7 @@ export class SeedParameters {
 
     public static decode(seedParameters: URLSearchParams): SeedParameters {
         let images: BareCoverArt[] = [];
-        for (const [key, value] of seedParameters.entries()) {
+        for (const [key, value] of seedParameters) {
             // only image parameters can be decoded to cover art images
             if (!key.startsWith('x_seed.image.')) continue;
 


### PR DESCRIPTION
When ECAU is injected in the content context in Firefox, it uses the `URLSearchParams` from the page context via an x-ray. However, a [bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1023984) prevents us from iterating through the result of the `entries()` call. Instead, we can iterate through the `URLSearchParams` directly.

Fixes #773.