### PR TITLE
fix(ecau): support more RateYourMusic release types

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/rateyourmusic.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/rateyourmusic.ts
@@ -11,8 +11,8 @@ export class RateYourMusicProvider extends CoverArtProvider {
     public readonly name = 'RateYourMusic';
     // Include release type in the ID to make sure it doesn't redirect a single
     // to an album and vice versa, and also to simplify the URL transformation
-    // below.
-    protected readonly urlRegex = /\/release\/((?:album|single)(?:\/[^/]+){2})(?:\/|$)/;
+    // below. Release type can be "single", "album", "ep", "musicvideo", etc.
+    protected readonly urlRegex = /\/release\/(\w+(?:\/[^/]+){2})(?:\/|$)/;
 
     public async findImages(url: URL): Promise<CoverArt[]> {
         const releaseId = this.extractId(url);

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/rateyourmusic.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/rateyourmusic.test.ts
@@ -28,6 +28,22 @@ describe('rateyourmusic provider', () => {
             description: 'single buy URLs',
             url: 'https://rateyourmusic.com/release/single/hot_dad/undertale/buy',
             id: 'single/hot_dad/undertale',
+        }, {
+            description: 'EP URLs',
+            url: 'https://rateyourmusic.com/release/ep/the-atlas-moth-ken-mode/the-atlas-moth-ken-mode/',
+            id: 'ep/the-atlas-moth-ken-mode/the-atlas-moth-ken-mode',
+        }, {
+            description: 'music video URLs',
+            url: 'https://rateyourmusic.com/release/musicvideo/ken-mode/the-terror-pulse/',
+            id: 'musicvideo/ken-mode/the-terror-pulse',
+        }, {
+            description: 'additional release URLs',
+            url: 'https://rateyourmusic.com/release/additional/ken-mode/daytrotter-session/',
+            id: 'additional/ken-mode/daytrotter-session',
+        }, {
+            description: 'compilation URLs',
+            url: 'https://rateyourmusic.com/release/comp/various-artists/killed-by-canada/',
+            id: 'comp/various-artists/killed-by-canada',
         }];
 
         const unsupportedUrls = [{


### PR DESCRIPTION
We only supported "single" and "album" URLs in the past, but there can be many more release types (e.g., "ep", "musicvideo", "comp", "additional").

Nonetheless, RYM support might be broken entirely, as the JPEG images we sought previously are now locked behind a captcha. Even simply requesting a page is leading to a Cloudflare 403 page on my end, and the necessary cookies to bypass those pages aren't getting injected into the requests for some reason 🤷

Fixes #756. 