### PR TITLE
feat(ecau): Seed cover art from Harmony release actions pages

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/meta.ts
+++ b/src/mb_enhanced_cover_art_uploads/meta.ts
@@ -18,6 +18,7 @@ const metadata: UserscriptMetadata = {
         '*://atisket.pulsewidth.org.uk/*',
         '*://etc.marlonob.info/atisket/*',
         '*://vgmdb.net/album/*',
+        '*://harmony.pulsewidth.org.uk/*',
     ],
     'exclude': ['*://atisket.pulsewidth.org.uk/'],
     'grant': [

--- a/src/mb_enhanced_cover_art_uploads/meta.ts
+++ b/src/mb_enhanced_cover_art_uploads/meta.ts
@@ -18,7 +18,7 @@ const metadata: UserscriptMetadata = {
         '*://atisket.pulsewidth.org.uk/*',
         '*://etc.marlonob.info/atisket/*',
         '*://vgmdb.net/album/*',
-        '*://harmony.pulsewidth.org.uk/*',
+        '*://harmony.pulsewidth.org.uk/release/actions*',
     ],
     'exclude': ['*://atisket.pulsewidth.org.uk/'],
     'grant': [

--- a/src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
@@ -9,7 +9,7 @@ import { SeedParameters } from '../parameters';
 
 export const HarmonySeeder: Seeder = {
     supportedDomains: ['harmony.pulsewidth.org.uk'],
-    supportedRegexes: [/\/release\/actions\?release_mbid=([a-f\d-]{36})/],
+    supportedRegexes: [/\/release\/actions.*release_mbid=([a-f\d-]{36})/],
 
     insertSeedLinks(): void {
         // Extract the MBID from the URL parameters

--- a/src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
@@ -1,0 +1,74 @@
+// src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
+
+import { LOGGER } from '@lib/logging/logger';
+import { logFailure } from '@lib/util/async';
+import { qs, qsa, qsMaybe } from '@lib/util/dom';
+
+import type { Seeder } from '../base';
+import { SeedParameters } from '../parameters';
+
+export const HarmonySeeder: Seeder = {
+    supportedDomains: ['harmony.pulsewidth.org.uk'],
+    supportedRegexes: [/\/release\/actions\?release_mbid=([a-f\d-]{36})/],
+
+    insertSeedLinks(): void {
+        // Extract the MBID from the URL parameters
+        const urlParams = new URLSearchParams(window.location.search);
+        const mbid = urlParams.get('release_mbid');
+        if (!mbid) {
+            LOGGER.error("Release MBID not found in URL.");
+            return;
+        }
+
+        addSeedLinksToCovers([mbid], document.location.href);
+    }
+};
+
+function addSeedLinksToCovers(mbids: string[], origin: string): void {
+    // Find cover image elements on the page
+    const covers = qsa<HTMLElement>('figure.cover-image');
+    
+    if (covers.length === 0) {
+        LOGGER.warn("No cover images found on the page.");
+        return;
+    }
+
+    for (const coverElement of covers) {
+        addSeedLinkToCover(coverElement, mbids, origin);
+    }
+}
+
+function addSeedLinkToCover(coverElement: HTMLElement, mbids: string[], origin: string): void {
+    const img = qs<HTMLImageElement>('img', coverElement);
+    const imgUrl = img.src.replace(/\/250x250bb\.jpg/, '/1000x1000bb.jpg'); // Get high-quality image URL
+
+    const parameters = new SeedParameters([{
+        url: new URL(imgUrl),
+        // Set Front type
+        types: [1]
+    }], origin);
+
+    for (const mbid of mbids) {
+        const seedUrl = parameters.createSeedURL(mbid);
+
+        // Create the link element
+        const link = (
+            <span className="label add-cover-art-link" onClick={() => window.open(seedUrl, '_blank')}>
+                + Add Cover Art
+            </span>
+        );
+
+        // Add CSS for the link
+        const style = document.createElement('style');
+        style.textContent = `
+            .add-cover-art-link {
+                min-height: 1.2em;
+                cursor: pointer;
+            }
+        `;
+        document.head.appendChild(style);
+
+        // Append the link to the cover container
+        coverElement.childNodes[1].appendChild(link);
+    }
+}

--- a/src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
@@ -19,6 +19,13 @@ export const HarmonySeeder: Seeder = {
             return;
         }
 
+        // Use a cached link as the origin instead of the page URL itself,
+        // so that we link to the state at the time the image was submitted.
+        if (!originUrl.searchParams.has('ts')) {
+            // It is safe to use the current time if we don't have a permalink already.
+            const cacheTimestamp = Math.floor(Date.now() / 1000);
+            originUrl.searchParams.set('ts', cacheTimestamp.toString());
+        }
         addSeedLinksToCovers(mbid, originUrl.href);
     },
 };

--- a/src/mb_enhanced_cover_art_uploads/seeding/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/seeding/index.ts
@@ -2,11 +2,13 @@
 
 import { AtasketSeeder, AtisketSeeder } from './atisket';
 import { registerSeeder } from './base';
+import { HarmonySeeder } from './harmony'; 
 import { MusicBrainzSeeder } from './musicbrainz';
 import { VGMdbSeeder } from './vgmdb';
 
 registerSeeder(AtisketSeeder);
 registerSeeder(AtasketSeeder);
+registerSeeder(HarmonySeeder); 
 registerSeeder(MusicBrainzSeeder);
 registerSeeder(VGMdbSeeder);
 

--- a/src/mb_enhanced_cover_art_uploads/seeding/index.ts
+++ b/src/mb_enhanced_cover_art_uploads/seeding/index.ts
@@ -2,13 +2,13 @@
 
 import { AtasketSeeder, AtisketSeeder } from './atisket';
 import { registerSeeder } from './base';
-import { HarmonySeeder } from './harmony'; 
+import { HarmonySeeder } from './harmony';
 import { MusicBrainzSeeder } from './musicbrainz';
 import { VGMdbSeeder } from './vgmdb';
 
 registerSeeder(AtisketSeeder);
 registerSeeder(AtasketSeeder);
-registerSeeder(HarmonySeeder); 
+registerSeeder(HarmonySeeder);
 registerSeeder(MusicBrainzSeeder);
 registerSeeder(VGMdbSeeder);
 


### PR DESCRIPTION
Added support for harmony.pulsewidth.org.uk to the Enhanced Cover Art Uploads userscript. This allows users to easily add cover art from the Harmony importer to MusicBrainz releases with a single click, similar to the existing a-tisket integration. 