### PR TITLE
feat(ecau): configuration options

### DIFF
--- a/src/lib/compat.ts
+++ b/src/lib/compat.ts
@@ -6,6 +6,9 @@
 // Declare v3 GM_* APIs, but not globally.
 declare function GM_xmlhttpRequest<T>(details: GM.Request<T>): void;
 declare function GM_getResourceURL(resourceName: string): string;
+declare function GM_getValue(name: string): GM.Value | undefined;
+declare function GM_setValue(name: string, value: GM.Value): void;
+declare function GM_deleteValue(name: string): void;
 declare const GM_info: typeof GM.info;
 
 function existsInGM(name: string): boolean {
@@ -24,6 +27,29 @@ export function GMxmlHttpRequest(details: GM.Request): void {
         GM.xmlHttpRequest(details);
     } else {
         GM_xmlhttpRequest(details);
+    }
+}
+
+export function GMgetValue(name: string): Promise<GM.Value | undefined> {
+    // eslint-disable-next-line sonarjs/no-use-of-empty-return-value
+    return existsInGM('getValue') ? GM.getValue(name) : Promise.resolve(GM_getValue(name));
+}
+
+export function GMsetValue(name: string, value: GM.Value): Promise<void> {
+    if (existsInGM('setValue')) {
+        return GM.setValue(name, value);
+    } else {
+        GM_setValue(name, value);
+        return Promise.resolve();
+    }
+}
+
+export function GMdeleteValue(name: string): Promise<void> {
+    if (existsInGM('deleteValue')) {
+        return GM.deleteValue(name);
+    } else {
+        GM_deleteValue(name);
+        return Promise.resolve();
     }
 }
 
@@ -76,7 +102,7 @@ interface CloneIntoOptions {
  * ```
  * In this way privileged code, such as an add-on, can share an object with
  * less-privileged code like a normal web page script.
- * @param {T} obj   The object to clone.
+ * @param {T} object   The object to clone.
  * @param {object} targetScope   The object to attach the object to.
  * @param {CloneIntoOptions | undefined } options   Options
  * @returns {T} A reference to the cloned object.

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,39 @@
+import { GMdeleteValue, GMgetValue, GMsetValue } from '@lib/compat';
+import { LOGGER } from '@lib/logging/logger';
+
+export class ConfigProperty<T> {
+    public readonly name: string;
+    public readonly description: string;
+    private readonly defaultValue: T;
+
+    public constructor(name: string, description: string, defaultValue: T) {
+        this.name = name;
+        this.description = description;
+        this.defaultValue = defaultValue;
+    }
+
+    public async get(): Promise<T> {
+        const storedValue = await GMgetValue(this.name);
+        if (storedValue === undefined) {
+            return this.defaultValue;
+        }
+
+        if (typeof storedValue !== 'string') {
+            LOGGER.error(`Invalid stored configuration data for property ${this.name}: expected a string, got ${storedValue}.`);
+            await GMdeleteValue(this.name);
+            return this.defaultValue;
+        }
+
+        try {
+            return JSON.parse(storedValue) as T;
+        } catch (error) {
+            LOGGER.error(`Invalid stored configuration data for property ${this.name}: Failed to parse JSON data: ${error}.`);
+            await GMdeleteValue(this.name);
+            return this.defaultValue;
+        }
+    }
+
+    public set(value: T): Promise<void> {
+        return GMsetValue(this.name, JSON.stringify(value));
+    }
+}

--- a/src/mb_enhanced_cover_art_uploads/app.ts
+++ b/src/mb_enhanced_cover_art_uploads/app.ts
@@ -11,7 +11,6 @@ import { qs } from '@lib/util/dom';
 import { ObservableSemaphore } from '@lib/util/observable';
 
 import type { BareCoverArt, QueuedImageBatch } from './types';
-import { CONFIG } from './config';
 import { ImageFetcher } from './fetch';
 import { fillEditNote } from './form';
 import { getProvider } from './providers';
@@ -78,7 +77,7 @@ export class App {
                     LOGGER.info(`Fetching ${coverArt.url}`);
                 }
                 try {
-                    const fetchResult = await this.fetcher.fetchImages(coverArt, await CONFIG.fetchFrontOnly.get());
+                    const fetchResult = await this.fetcher.fetchImages(coverArt);
                     fetchedBatches.push(fetchResult);
                 } catch (error) {
                     LOGGER.error('Failed to fetch or enqueue images', error);

--- a/src/mb_enhanced_cover_art_uploads/app.ts
+++ b/src/mb_enhanced_cover_art_uploads/app.ts
@@ -11,6 +11,7 @@ import { qs } from '@lib/util/dom';
 import { ObservableSemaphore } from '@lib/util/observable';
 
 import type { BareCoverArt, QueuedImageBatch } from './types';
+import { CONFIG } from './config';
 import { ImageFetcher } from './fetch';
 import { fillEditNote } from './form';
 import { getProvider } from './providers';
@@ -24,7 +25,6 @@ export class App {
     private readonly urlsInProgress: Set<string>;
     private readonly loggingSink = new GuiSink();
     private readonly fetchingSema: ObservableSemaphore;
-    public onlyFront = false;
 
     public constructor() {
         this.note = EditNote.withFooterFromGMInfo();
@@ -78,7 +78,7 @@ export class App {
                     LOGGER.info(`Fetching ${coverArt.url}`);
                 }
                 try {
-                    const fetchResult = await this.fetcher.fetchImages(coverArt, this.onlyFront);
+                    const fetchResult = await this.fetcher.fetchImages(coverArt, await CONFIG.fetchFrontOnly.get());
                     fetchedBatches.push(fetchResult);
                 } catch (error) {
                     LOGGER.error('Failed to fetch or enqueue images', error);

--- a/src/mb_enhanced_cover_art_uploads/config.ts
+++ b/src/mb_enhanced_cover_art_uploads/config.ts
@@ -1,5 +1,31 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 import { ConfigProperty } from '@lib/config';
+
+async function _or(...promises: Array<Promise<boolean>>): Promise<boolean> {
+    const booleans = await Promise.all(promises);
+    return booleans.some(Boolean);
+}
 
 export const CONFIG = {
     fetchFrontOnly: new ConfigProperty('fetchFrontOnly', 'Fetch front image only', false),
+    skipTrackImagesProperty: new ConfigProperty('skipTrackImages', 'Skip extracting track images', false),
+
+    get skipTrackImages(): Promise<boolean> {
+        return _or(CONFIG.fetchFrontOnly.get(), CONFIG.skipTrackImagesProperty.get());
+    },
+
+    // Provider-specific configurations
+    bandcamp: {
+        skipTrackImagesProperty: new ConfigProperty('bandcamp.skipTrackImages', 'Skip extracting track images', false),
+        get skipTrackImages(): Promise<boolean> {
+            return _or(CONFIG.skipTrackImages, CONFIG.bandcamp.skipTrackImagesProperty.get());
+        },
+    },
+
+    soundcloud: {
+        skipTrackImagesProperty: new ConfigProperty('soundcloud.skipTrackImages', 'Skip extracting track images', false),
+        get skipTrackImages(): Promise<boolean> {
+            return _or(CONFIG.skipTrackImages, CONFIG.soundcloud.skipTrackImagesProperty.get());
+        },
+    },
 } as const;

--- a/src/mb_enhanced_cover_art_uploads/config.ts
+++ b/src/mb_enhanced_cover_art_uploads/config.ts
@@ -1,0 +1,5 @@
+import { ConfigProperty } from '@lib/config';
+
+export const CONFIG = {
+    fetchFrontOnly: new ConfigProperty('fetchFrontOnly', 'Fetch front image only', false),
+} as const;

--- a/src/mb_enhanced_cover_art_uploads/config.ts
+++ b/src/mb_enhanced_cover_art_uploads/config.ts
@@ -28,4 +28,8 @@ export const CONFIG = {
             return _or(CONFIG.skipTrackImages, CONFIG.soundcloud.skipTrackImagesProperty.get());
         },
     },
+
+    vgmdb: {
+        keepEntireComment: new ConfigProperty('vgmdb.keepEntireComment', 'Keep entire cover art comment', false),
+    },
 } as const;

--- a/src/mb_enhanced_cover_art_uploads/config.ts
+++ b/src/mb_enhanced_cover_art_uploads/config.ts
@@ -20,6 +20,7 @@ export const CONFIG = {
         get skipTrackImages(): Promise<boolean> {
             return _or(CONFIG.skipTrackImages, CONFIG.bandcamp.skipTrackImagesProperty.get());
         },
+        squareCropFirst: new ConfigProperty('bandcamp.squareCropFirst', 'Place square cropped artwork before original artwork', false),
     },
 
     soundcloud: {

--- a/src/mb_enhanced_cover_art_uploads/meta.ts
+++ b/src/mb_enhanced_cover_art_uploads/meta.ts
@@ -25,6 +25,10 @@ const metadata: UserscriptMetadata = {
         'GM.xmlhttpRequest',
         // Used for some favicons
         'GM.getResourceURL',
+        // Configuration settings
+        'GM.getValue',
+        'GM.setValue',
+        'GM.deleteValue',
     ],
     'connect': '*',
     'require': ['https://github.com/qsniyg/maxurl/blob/ef4cd2c5d66ba9cca9c487a25579d1a6bd10ca06/userscript.user.js?raw=true'],

--- a/src/mb_enhanced_cover_art_uploads/providers/bandcamp.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/bandcamp.ts
@@ -9,6 +9,7 @@ import { getImageDimensions } from '@src/mb_caa_dimensions/dimensions';
 
 import type { CoverArt } from '../types';
 import type { ParsedTrackImage } from './base';
+import { CONFIG } from '../config';
 import { ProviderWithTrackImages } from './base';
 
 export class BandcampProvider extends ProviderWithTrackImages {
@@ -24,7 +25,7 @@ export class BandcampProvider extends ProviderWithTrackImages {
             .join('/');
     }
 
-    public async findImages(url: URL, onlyFront = false): Promise<CoverArt[]> {
+    public async findImages(url: URL): Promise<CoverArt[]> {
         const responseDocument = parseDOM(await this.fetchPage(url), url.href);
         const albumCoverUrl = this.extractCover(responseDocument);
 
@@ -39,8 +40,9 @@ export class BandcampProvider extends ProviderWithTrackImages {
             LOGGER.warn('Bandcamp release has no cover');
         }
 
-        // Don't bother extracting track images if we only need the front cover
-        const trackImages = onlyFront ? [] : await this.findTrackImages(responseDocument, albumCoverUrl);
+        const trackImages = (await CONFIG.bandcamp.skipTrackImages)
+            ? []
+            : await this.findTrackImages(responseDocument, albumCoverUrl);
 
         return this.amendSquareThumbnails([...covers, ...trackImages]);
     }

--- a/src/mb_enhanced_cover_art_uploads/providers/bandcamp.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/bandcamp.ts
@@ -159,17 +159,20 @@ export class BandcampProvider extends ProviderWithTrackImages {
                 return [cover];
             }
 
-            // Queue originals before the thumbnail
-            return [{
+            const originalCover: CoverArt = {
                 ...cover,
                 comment: filterNonNull([cover.comment, 'Bandcamp full-sized cover']).join(' - '),
-            }, {
+            };
+            const squareCrop: CoverArt = {
                 types: cover.types,
                 // *_16.jpg URLs are the largest square crop available, always 700x700
                 url: new URL(cover.url.href.replace(/_\d+\.(\w+)$/, '_16.$1')),
                 comment: filterNonNull([cover.comment, 'Bandcamp square crop']).join(' - '),
                 skipMaximisation: true,
-            }];
+            };
+
+            const squareCropFirst = await CONFIG.bandcamp.squareCropFirst.get();
+            return squareCropFirst ? [squareCrop, originalCover] : [originalCover, squareCrop];
         })).then((nestedCovers) => nestedCovers.flat());
     }
 

--- a/src/mb_enhanced_cover_art_uploads/providers/base.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/base.ts
@@ -46,10 +46,9 @@ export abstract class CoverArtProvider {
      * Find the provider's images.
      *
      * @param      {string}     url           The URL to the release. Guaranteed to have passed validation.
-     * @param      {boolean}    onlyFront     True if we'll only enqueue the front image, can be used to skip expensive lookups. Providers can still return all images, they'll be filtered later.
      * @return     {Promise<CoverArt[]>}  List of cover arts that should be imported.
      */
-    public abstract findImages(url: URL, onlyFront: boolean): Promisable<CoverArt[]>;
+    public abstract findImages(url: URL): Promisable<CoverArt[]>;
 
     /**
      * Postprocess a fetched image. By default, does nothing, however,

--- a/src/mb_enhanced_cover_art_uploads/seeding/vgmdb.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/vgmdb.tsx
@@ -55,7 +55,7 @@ function getMBReleases(): Promise<string[]> {
 }
 
 async function extractCovers(): Promise<VGMdbCovers> {
-    const covers = VGMdbProvider.extractCoversFromDOMGallery(qs('#cover_gallery'));
+    const covers = await VGMdbProvider.extractCoversFromDOMGallery(qs('#cover_gallery'));
 
     // Split the extracted covers into public and private, to provide the option
     // to seed only private covers.

--- a/src/mb_enhanced_cover_art_uploads/ui/main.scss
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.scss
@@ -2,18 +2,10 @@
     display: inline-block;
     margin-left: 32px;
     vertical-align: middle;
+    position: relative;
 
     > * {
         display: block;
-    }
-
-    > label {
-        display: inline;
-        float: none !important; // Need to set !important because MB's own CSS has more specific selectors.
-    }
-
-    > input[type="checkbox"] {
-        display: inline;
     }
 
     > a {
@@ -24,6 +16,58 @@
     + span {
         margin-left: 32px;
     }
+}
+
+.ROpdebee_ecau_config {
+    // Positioning this absolutely allows the URL pasting input field to be
+    // vertically centered in relation to the rest of the content in the row.
+    position: absolute;
+    width: 100%;
+
+    input[type="checkbox"], label {
+        display: inline;
+        vertical-align: center;
+    }
+
+    label {
+        float: none !important; // Need to set !important because MB's own CSS has more specific selectors.
+        margin-left: 0.5em;
+    }
+
+    details {
+        padding: 0.5em 0.5em 0;
+    }
+
+    // Position the "Supported providers" link on the top right.
+    a#ROpdebee_ecau_providers_link {
+        position: absolute;
+        top: 0.5em;
+        right: 0.5em;
+    }
+
+    .ROpdebee_ecau_config_options {
+        // Absolute positioning so that it "pops up" over the thumbnails etc.,
+        // rather than resizing the entire row and shifting all other elements.
+        position: absolute;
+        width: 95%;
+        padding: 0.5em;
+        background-color: #ddd;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+    }
+
+    summary {
+        font-weight: bold;
+        margin: -0.5em -0.5em 0;
+        padding: 0.5em;
+        cursor: pointer;
+        width: fit-content;
+    }
+
+    summary:hover {
+        text-decoration: underline;
+    }
+
 }
 
 .ROpdebee_import_url_buttons {

--- a/src/mb_enhanced_cover_art_uploads/ui/main.scss
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.scss
@@ -12,7 +12,7 @@
         float: none !important; // Need to set !important because MB's own CSS has more specific selectors.
     }
 
-    > input#ROpdebee_paste_front_only {
+    > input[type="checkbox"] {
         display: inline;
     }
 

--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -86,11 +86,12 @@ function parsePlainURLs(text: string): string[] {
     return text.trim().split(/\s+/);
 }
 
-function createCheckbox(property: ConfigProperty<boolean>): [HTMLInputElement, HTMLLabelElement] {
+function createCheckbox(property: ConfigProperty<boolean>): HTMLElement {
+    const propertyId = `ROpdebee_ecau_${property.name}`;
     const checkbox = (
         <input
             type="checkbox"
-            id={property.name}
+            id={propertyId}
         />) as HTMLInputElement;
 
     // The property getter is async, so we need to do some trickery to get the
@@ -109,13 +110,34 @@ function createCheckbox(property: ConfigProperty<boolean>): [HTMLInputElement, H
         LOGGER.error(`Error when initialising value for ${property.name} checkbox: ${error}`);
     });
 
-    const labelElement = (
-        <label htmlFor={property.name}>
-            {property.description}
-        </label>
-    ) as HTMLLabelElement;
+    return (
+        <div>
+            {checkbox}
+            <label htmlFor={propertyId}>
+                {property.description}
+            </label>
+        </div>
+    );
+}
 
-    return [checkbox, labelElement];
+function createConfig(): HTMLElement {
+    return (
+        <div className="ROpdebee_ecau_config">
+            <a
+                href="https://github.com/ROpdebee/mb-userscripts/blob/main/src/mb_enhanced_cover_art_uploads/docs/supported_providers.md"
+                target="_blank"
+                id="ROpdebee_ecau_providers_link"
+            >
+                Supported providers
+            </a>
+            <details>
+                <summary>Configure…</summary>
+                <div className="ROpdebee_ecau_config_options">
+                    {createCheckbox(CONFIG.fetchFrontOnly)}
+                </div>
+            </details>
+        </div>
+    );
 }
 
 export class InputForm implements FetcherHooks {
@@ -183,20 +205,11 @@ export class InputForm implements FetcherHooks {
                 }}
             />) as HTMLInputElement;
 
-        const [onlyFrontCheckbox, onlyFrontLabel] = createCheckbox(CONFIG.fetchFrontOnly);
-
         // Container element for the URL input and additional information
         const container = (
             <div className="ROpdebee_paste_url_cont">
                 {this.urlInput}
-                <a
-                    href="https://github.com/ROpdebee/mb-userscripts/blob/main/src/mb_enhanced_cover_art_uploads/docs/supported_providers.md"
-                    target="_blank"
-                >
-                    Supported providers
-                </a>
-                {onlyFrontCheckbox}
-                {onlyFrontLabel}
+                {createConfig()}
             </div>
         );
 

--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -134,6 +134,11 @@ function createConfig(): HTMLElement {
                 <summary>Configure…</summary>
                 <div className="ROpdebee_ecau_config_options">
                     {createCheckbox(CONFIG.fetchFrontOnly)}
+                    {createCheckbox(CONFIG.skipTrackImagesProperty)}
+                    <h3>Bandcamp</h3>
+                    {createCheckbox(CONFIG.bandcamp.skipTrackImagesProperty)}
+                    <h3>Soundcloud</h3>
+                    {createCheckbox(CONFIG.soundcloud.skipTrackImagesProperty)}
                 </div>
             </details>
         </div>

--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -137,6 +137,7 @@ function createConfig(): HTMLElement {
                     {createCheckbox(CONFIG.skipTrackImagesProperty)}
                     <h3>Bandcamp</h3>
                     {createCheckbox(CONFIG.bandcamp.skipTrackImagesProperty)}
+                    {createCheckbox(CONFIG.bandcamp.squareCropFirst)}
                     <h3>Soundcloud</h3>
                     {createCheckbox(CONFIG.soundcloud.skipTrackImagesProperty)}
                     <h3>VGMdb</h3>

--- a/src/mb_enhanced_cover_art_uploads/ui/main.tsx
+++ b/src/mb_enhanced_cover_art_uploads/ui/main.tsx
@@ -139,6 +139,8 @@ function createConfig(): HTMLElement {
                     {createCheckbox(CONFIG.bandcamp.skipTrackImagesProperty)}
                     <h3>Soundcloud</h3>
                     {createCheckbox(CONFIG.soundcloud.skipTrackImagesProperty)}
+                    <h3>VGMdb</h3>
+                    {createCheckbox(CONFIG.vgmdb.keepEntireComment)}
                 </div>
             </details>
         </div>

--- a/src/mb_multi_external_links/index.ts
+++ b/src/mb_multi_external_links/index.ts
@@ -124,6 +124,7 @@ async function run(windowInstance: Window): Promise<void> {
     // functionality as soon as possible without waiting for the whole page to load.
     const editor = await retryTimes(() => getExternalLinksEditor(windowInstance.MB), 100, 50);
     const splitter = new LinkSplitter(editor);
+    // TODO: Switch to ConfigProperty -- Needs event listeners on ConfigProperty.
     const [checkboxElement, labelElement] = createPersistentCheckbox('ROpdebee_multi_links_no_split', "Don't split links", () => {
         splitter.toggle();
     });

--- a/tests/unit/lib/config.test.ts
+++ b/tests/unit/lib/config.test.ts
@@ -1,0 +1,55 @@
+import { GMsetValue } from '@lib/compat';
+import { ConfigProperty } from '@lib/config';
+import { mockGMdeleteValue, mockGMgetValue, mockGMsetValue } from '@test-utils/gm-mocks';
+
+beforeEach(() => {
+    const mockStorage = new Map<string, unknown>();
+
+    mockGMdeleteValue.mockImplementation((name: string) => {
+        mockStorage.delete(name);
+        return Promise.resolve();
+    });
+
+    mockGMgetValue.mockImplementation((name: string) => {
+        return Promise.resolve(mockStorage.get(name));
+    });
+
+    mockGMsetValue.mockImplementation((name: string, value: GM.Value) => {
+        mockStorage.set(name, value);
+        return Promise.resolve();
+    });
+});
+
+describe('configuration properties', () => {
+    const property = new ConfigProperty<string>('testProperty', 'Test property', 'default');
+
+    it('gets the default value if no value is set', async () => {
+        await expect(property.get()).resolves.toBe('default');
+    });
+
+    it('gets the set value if one is set', async () => {
+        await expect(property.set('test123')).toResolve();
+
+        await expect(property.get()).resolves.toBe('test123');
+    });
+
+    it('supports complex types', async () => {
+        const property = new ConfigProperty<{ test: number }>('testProperty', 'Test property', { test: 123 });
+
+        await expect(property.get()).resolves.toStrictEqual({ test: 123 });
+        await expect(property.set({ test: 456 })).toResolve();
+        await expect(property.get()).resolves.toStrictEqual({ test: 456 });
+    });
+
+    it('gets the default value if a non-string value is stored', async () => {
+        await GMsetValue('testProperty', 123);
+
+        await expect(property.get()).resolves.toBe('default');
+    });
+
+    it('gets the default value if an invalid value is stored', async () => {
+        await GMsetValue('testProperty', '"dde');
+
+        await expect(property.get()).resolves.toBe('default');
+    });
+});

--- a/tests/unit/mb_enhanced_cover_art_uploads/config.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/config.test.ts
@@ -1,0 +1,50 @@
+import { CONFIG } from '@src/mb_enhanced_cover_art_uploads/config';
+import { mockGMdeleteValue, mockGMgetValue, mockGMsetValue } from '@test-utils/gm-mocks';
+
+beforeEach(() => {
+    const mockStorage = new Map<string, unknown>();
+
+    mockGMdeleteValue.mockImplementation((name: string) => {
+        mockStorage.delete(name);
+        return Promise.resolve();
+    });
+
+    mockGMgetValue.mockImplementation((name: string) => {
+        return Promise.resolve(mockStorage.get(name));
+    });
+
+    mockGMsetValue.mockImplementation((name: string, value: GM.Value) => {
+        mockStorage.set(name, value);
+        return Promise.resolve();
+    });
+});
+
+describe('ecau config', () => {
+    describe('skip track images', () => {
+        it.each([
+            [true, true, true],
+            [true, false, true],
+            [false, true, true],
+            [false, false, false],
+        ])('is $2 when property set to $1 and only front is $0', async (onlyFrontValue, propertyValue, outcome) => {
+            await CONFIG.fetchFrontOnly.set(onlyFrontValue);
+            await CONFIG.skipTrackImagesProperty.set(propertyValue);
+
+            await expect(CONFIG.skipTrackImages).resolves.toBe(outcome);
+        });
+    });
+
+    describe.each(['bandcamp', 'soundcloud'] as const)('%s-specific skip track images', (provider: 'bandcamp' | 'soundcloud') => {
+        it.each([
+            [true, true, true],
+            [true, false, true],
+            [false, true, true],
+            [false, false, false],
+        ])('is $2 when property set to $1 and global property is $0', async (globalPropertyValue, propertyValue, outcome) => {
+            await CONFIG.skipTrackImagesProperty.set(globalPropertyValue);
+            await CONFIG[provider].skipTrackImagesProperty.set(propertyValue);
+
+            await expect(CONFIG[provider].skipTrackImages).resolves.toBe(outcome);
+        });
+    });
+});

--- a/tests/unit/mb_enhanced_cover_art_uploads/fetch.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/fetch.test.ts
@@ -8,6 +8,7 @@ import { LOGGER } from '@lib/logging/logger';
 import { ArtworkTypeIDs } from '@lib/MB/cover-art';
 import { HTTPResponseError } from '@lib/util/request';
 import { NetworkError, request } from '@lib/util/request';
+import { CONFIG } from '@src/mb_enhanced_cover_art_uploads/config';
 import { ImageFetcher } from '@src/mb_enhanced_cover_art_uploads/fetch';
 import { enqueueImage } from '@src/mb_enhanced_cover_art_uploads/form';
 import { getMaximisedCandidates } from '@src/mb_enhanced_cover_art_uploads/maximise';
@@ -465,7 +466,7 @@ describe('fetching images from providers', () => {
     it('returns no images if provider provides no images', async () => {
         mockFindImages.mockResolvedValueOnce([]);
 
-        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false))
+        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
             .resolves.toMatchObject({
                 images: [],
                 containerUrl: {
@@ -480,7 +481,7 @@ describe('fetching images from providers', () => {
             createCoverArt('https://example.com/2'),
         ]);
 
-        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false))
+        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
             .resolves.toMatchObject({
                 images: [{
                     content: {
@@ -506,7 +507,7 @@ describe('fetching images from providers', () => {
             }),
         ]);
 
-        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false))
+        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
             .resolves.toMatchObject({
                 images: [{
                     content: {
@@ -524,7 +525,7 @@ describe('fetching images from providers', () => {
         const cover = createCoverArt('https://example.com/1');
         mockFindImages.mockResolvedValue([cover, cover]);
 
-        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false))
+        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
             .resolves.toMatchObject({
                 images: [{
                     content: {
@@ -557,7 +558,7 @@ describe('fetching images from providers', () => {
             .mockImplementationOnce(mockedImplementation)
             .mockImplementationOnce(mockedImplementation);
 
-        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false))
+        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
             .resolves.toMatchObject({
                 images: [{
                     content: {
@@ -578,7 +579,7 @@ describe('fetching images from providers', () => {
         ]);
         mockFetchImageContents.mockRejectedValueOnce(new Error('1 has an unsupported file type'));
 
-        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false))
+        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
             .resolves.toMatchObject({
                 images: [],
                 containerUrl: {
@@ -595,7 +596,7 @@ describe('fetching images from providers', () => {
             }),
         ]);
 
-        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false))
+        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
             .resolves.toMatchObject({
                 images: [{
                     wasMaximised: false,
@@ -617,7 +618,7 @@ describe('fetching images from providers', () => {
             createCoverArt('https://example.com/2'),
         ]);
 
-        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, provider, false))
+        await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, provider))
             .resolves.toMatchObject({
                 images: [{
                     originalUrl: {
@@ -635,7 +636,7 @@ describe('fetching images from providers', () => {
                 comment: 'comment',
             }),
         ]);
-        await fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false);
+        await fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider);
 
         expect(mockEnqueueImage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Bad type defs.
@@ -648,6 +649,16 @@ describe('fetching images from providers', () => {
     });
 
     describe('fetching only front images', () => {
+        const fetchFrontOnlyPropertySpy = jest.spyOn(CONFIG.fetchFrontOnly, 'get');
+
+        beforeEach(() => {
+            fetchFrontOnlyPropertySpy.mockResolvedValue(true);
+        });
+
+        afterAll(() => {
+            fetchFrontOnlyPropertySpy.mockRestore();
+        });
+
         it('removes non-front images', async () => {
             mockFindImages.mockResolvedValueOnce([
                 createCoverArt({
@@ -660,7 +671,7 @@ describe('fetching images from providers', () => {
                 }),
             ]);
 
-            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, true))
+            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
                 .resolves.toMatchObject({
                     images: [{
                         originalUrl: {
@@ -684,7 +695,7 @@ describe('fetching images from providers', () => {
                 }),
             ]);
 
-            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, true))
+            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
                 .resolves.toMatchObject({
                     images: [{
                         originalUrl: {
@@ -708,7 +719,7 @@ describe('fetching images from providers', () => {
                 }),
             ]);
 
-            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, true))
+            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
                 .resolves.toMatchObject({
                     images: expect.toBeArrayOfSize(2) as QueuedImage[],
                 });
@@ -727,7 +738,7 @@ describe('fetching images from providers', () => {
                 }),
             ]);
 
-            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, true))
+            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
                 .resolves.toMatchObject({
                     images: [{
                         originalUrl: {
@@ -754,7 +765,7 @@ describe('fetching images from providers', () => {
                 .mockResolvedValueOnce(resolvedValue)
                 .mockResolvedValueOnce(resolvedValue);
 
-            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, true))
+            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
                 .resolves.toMatchObject({
                     images: [{
                         originalUrl: {
@@ -763,9 +774,12 @@ describe('fetching images from providers', () => {
                         types: [ArtworkTypeIDs.Front],
                     }],
                 });
+
             // Call again but allow non-front now, should only return the last one since the first is already
             // done.
-            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false))
+            fetchFrontOnlyPropertySpy.mockResolvedValueOnce(false);
+
+            await expect(fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider))
                 .resolves.toMatchObject({
                     images: [{
                         originalUrl: {
@@ -786,7 +800,7 @@ describe('fetching images from providers', () => {
                 comment: 'comment',
             }),
         ]);
-        await fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider, false);
+        await fetchImagesFromProvider({ url: new URL('https://example.com') }, fakeProvider);
 
         expect(hooks.onFetchStarted).toHaveBeenCalledWith(0, new URL('https://example.com/1'));
         expect(hooks.onFetchFinished).toHaveBeenCalledWith(0);
@@ -813,7 +827,7 @@ describe('fetching images', () => {
     });
 
     it('fetches single image if no provider found', async () => {
-        const result = await fetcher.fetchImages({ url: new URL('https://example.com/1') }, false);
+        const result = await fetcher.fetchImages({ url: new URL('https://example.com/1') });
 
         expect(result.images).toBeArrayOfSize(1);
         expect(result.images[0]).toMatchObject({
@@ -835,7 +849,7 @@ describe('fetching images', () => {
             }),
         ]);
 
-        const result = await fetcher.fetchImages({ url: new URL('https://example.com/1') }, false);
+        const result = await fetcher.fetchImages({ url: new URL('https://example.com/1') });
 
         expect(result.images).toBeArrayOfSize(2);
         expect(result.images[0]).toMatchObject({
@@ -854,9 +868,9 @@ describe('fetching images', () => {
     });
 
     it('does not fetch URL which was already fetched', async () => {
-        await fetcher.fetchImages({ url: new URL('https://example.com/1') }, false);
+        await fetcher.fetchImages({ url: new URL('https://example.com/1') });
 
-        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }, false))
+        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }))
             .resolves.toHaveProperty('images', []);
     });
 
@@ -867,10 +881,10 @@ describe('fetching images', () => {
             createCoverArt('https://example.com/2'),
         ]);
 
-        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }, false))
+        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }))
             .resolves.toHaveProperty('images', expect.toBeArrayOfSize(2));
         // Second fetch should be blocked, since all previous images are done.
-        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }, false))
+        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }))
             .resolves.toHaveProperty('images', []);
         expect(mockFindImages).toHaveBeenCalledOnce();
     });
@@ -884,14 +898,14 @@ describe('fetching images', () => {
         mockFetchImageContents.mockRejectedValueOnce(new Error('test'));
 
         // First fetch will fail to fetch the first of the two images.
-        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }, false))
+        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }))
             .resolves.toHaveProperty('images', [
                 expect.objectContaining({
                     fetchedUrl: new URL('https://example.com/2'),
                 }),
             ]);
         // Second fetch should now only fetch the first image, second one already fetched previously.
-        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }, false))
+        await expect(fetcher.fetchImages({ url: new URL('https://example.com/1') }))
             .resolves.toHaveProperty('images', [
                 expect.objectContaining({
                     fetchedUrl: new URL('https://example.com/1'),
@@ -901,7 +915,7 @@ describe('fetching images', () => {
     });
 
     it('does not fetch maximised URL which was already fetched previously', async () => {
-        await fetcher.fetchImages({ url: new URL('https://example.com/1') }, false);
+        await fetcher.fetchImages({ url: new URL('https://example.com/1') });
 
         // Simulate 1 being maximal version of 2
         // eslint-disable-next-line @typescript-eslint/require-await
@@ -914,12 +928,12 @@ describe('fetching images', () => {
             return undefined;
         });
 
-        await expect(fetcher.fetchImages({ url: new URL('https://example.com/2') }, false))
+        await expect(fetcher.fetchImages({ url: new URL('https://example.com/2') }))
             .resolves.toHaveProperty('images', []);
     });
 
     it('enqueues the image', async () => {
-        await fetcher.fetchImages({ url: new URL('https://example.com/1'), types: [ArtworkTypeIDs.Medium], comment: 'comment' }, false);
+        await fetcher.fetchImages({ url: new URL('https://example.com/1'), types: [ArtworkTypeIDs.Medium], comment: 'comment' });
 
         expect(mockEnqueueImage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Bad type defs.
@@ -930,7 +944,7 @@ describe('fetching images', () => {
     });
 
     it('calls the hooks', async () => {
-        await fetcher.fetchImages({ url: new URL('https://example.com/1') }, false);
+        await fetcher.fetchImages({ url: new URL('https://example.com/1') });
 
         expect(hooks.onFetchStarted).toHaveBeenCalledWith(0, new URL('https://example.com/1'));
         expect(hooks.onFetchFinished).toHaveBeenCalledWith(0);

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/bandcamp.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/bandcamp.test.ts
@@ -1,5 +1,6 @@
 import { ArtworkTypeIDs } from '@lib/MB/cover-art';
 import { getImageDimensions } from '@src/mb_caa_dimensions/dimensions';
+import { CONFIG } from '@src/mb_enhanced_cover_art_uploads/config';
 import { BandcampProvider } from '@src/mb_enhanced_cover_art_uploads/providers/bandcamp';
 import { itBehavesLike } from '@test-utils/shared-behaviour';
 
@@ -123,7 +124,10 @@ describe('bandcamp provider', () => {
         });
 
         it('grabs no track covers if they will not be used', async () => {
-            const coverUrls = await provider.findImages(new URL('https://nyokee.bandcamp.com/album/quarantine-pixel-party'), true);
+            const spy = jest.spyOn(CONFIG.bandcamp, 'skipTrackImages', 'get');
+            spy.mockResolvedValueOnce(true);
+
+            const coverUrls = await provider.findImages(new URL('https://nyokee.bandcamp.com/album/quarantine-pixel-party'));
 
             expect(coverUrls).toBeArrayOfSize(1);
             expect(coverUrls[0]).toMatchCoverArt({

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/bandcamp.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/bandcamp.test.ts
@@ -86,21 +86,25 @@ describe('bandcamp provider', () => {
         // eslint-disable-next-line jest/require-hook
         itBehavesLike(findImagesSpec, { provider, extractionCases, extractionFailedCases });
 
-        it('grabs square thumbnails for non-square covers', async () => {
+        it.each([false, true])('grabs square thumbnails for non-square covers', async (orderSquareFirst) => {
             mockGetImageDimensions.mockResolvedValueOnce({
                 // Actual dimensions of that image.
                 height: 1714,
                 width: 4096,
             });
+            jest.spyOn(CONFIG.bandcamp.squareCropFirst, 'get').mockResolvedValueOnce(orderSquareFirst);
+            const squareIndex = orderSquareFirst ? 0 : 1;
+            const originalIndex = orderSquareFirst ? 1 : 0;
+
             const coverUrls = await provider.findImages(new URL('https://level2three.bandcamp.com/track/the-bridge'));
 
             expect(coverUrls).toBeArrayOfSize(2);
-            expect(coverUrls[0]).toMatchCoverArt({
+            expect(coverUrls[originalIndex]).toMatchCoverArt({
                 urlPart: 'a4081865950_10.jpg',
                 types: [ArtworkTypeIDs.Front],
                 comment: 'Bandcamp full-sized cover',
             });
-            expect(coverUrls[1]).toMatchCoverArt({
+            expect(coverUrls[squareIndex]).toMatchCoverArt({
                 urlPart: 'a4081865950_16.jpg',
                 types: [ArtworkTypeIDs.Front],
                 comment: 'Bandcamp square crop',

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/find-images-spec.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/find-images-spec.ts
@@ -40,7 +40,7 @@ export const findImagesSpec = ({ provider, extractionCases, extractionFailedCase
 
     if (extractionCases.length > 0) {
         it.each(extractionCases)('extracts covers for $description', async (extractionCase) => {
-            const covers = await provider.findImages(new URL(extractionCase.url), false);
+            const covers = await provider.findImages(new URL(extractionCase.url));
 
             expect(covers).toBeArrayOfSize(extractionCase.imageCount);
 
@@ -56,7 +56,7 @@ export const findImagesSpec = ({ provider, extractionCases, extractionFailedCase
                 recordFailedRequests: true,
             });
 
-            await expect(provider.findImages(new URL(extractionFailedCase.url), false))
+            await expect(provider.findImages(new URL(extractionFailedCase.url)))
                 .rejects.toThrowWithMessage(Error, extractionFailedCase.errorMessage ?? `${provider.name} release does not exist`);
         });
     }

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/soundcloud.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/soundcloud.test.ts
@@ -1,5 +1,6 @@
 import { LOGGER } from '@lib/logging/logger';
 import { ArtworkTypeIDs } from '@lib/MB/cover-art';
+import { CONFIG } from '@src/mb_enhanced_cover_art_uploads/config';
 import { SoundCloudProvider } from '@src/mb_enhanced_cover_art_uploads/providers/soundcloud';
 import { setupPolly } from '@test-utils/pollyjs';
 import { itBehavesLike } from '@test-utils/shared-behaviour';
@@ -136,7 +137,10 @@ describe('soundcloud provider', () => {
         itBehavesLike(findImagesSpec, { provider, extractionCases, extractionFailedCases, pollyContext });
 
         it('grabs no track images if they will not be used', async () => {
-            const covers = await provider.findImages(new URL('https://soundcloud.com/officialpandaeyes/sets/isolationep'), true);
+            const spy = jest.spyOn(CONFIG.soundcloud, 'skipTrackImages', 'get');
+            spy.mockResolvedValueOnce(true);
+
+            const covers = await provider.findImages(new URL('https://soundcloud.com/officialpandaeyes/sets/isolationep'));
 
             expect(covers).toBeArrayOfSize(1);
             expect(covers[0]).toMatchCoverArt({

--- a/tests/unit/utils/gm-mocks.ts
+++ b/tests/unit/utils/gm-mocks.ts
@@ -3,4 +3,7 @@
 /* eslint-disable jest/unbound-method -- Fine */
 export const mockGMgetResourceURL = GM.getResourceUrl as jest.MockedFunction<typeof GM.getResourceUrl>;
 export const mockGMxmlHttpRequest = GM.xmlHttpRequest as jest.MockedFunction<typeof GM.xmlHttpRequest>;
+export const mockGMgetValue = GM.getValue as jest.MockedFunction<typeof GM.getValue>;
+export const mockGMsetValue = GM.setValue as jest.MockedFunction<typeof GM.setValue>;
+export const mockGMdeleteValue = GM.deleteValue as jest.MockedFunction<typeof GM.deleteValue>;
 /* eslint-enable jest/unbound-method */

--- a/tests/unit/utils/setup-gm-mocks.ts
+++ b/tests/unit/utils/setup-gm-mocks.ts
@@ -1,6 +1,9 @@
 global.GM = {
     xmlHttpRequest: jest.fn(),
     getResourceUrl: jest.fn(),
+    getValue: jest.fn(),
+    setValue: jest.fn(),
+    deleteValue: jest.fn(),
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     info: {} as GM.ScriptInfo,
 } as unknown as typeof GM;


### PR DESCRIPTION
Add various configuration options:
- Global + provider-specific option to skip extracting track images, separately from choosing whether to only extract the front covers.
- VGMdb: Option to keep entire comment (closes #657)
- Bandcamp: Option to put square crop before the original, non-square cover art (closes #443).

These configuration options are consolidated in a single configuration object and configurable from a new collapsible drop-down in the UI.

Known limitations:
- Getting and setting the options is asynchronous because it requires GM.get/setValue, which are also async. This causes some functions to be async only because they need to read config options, which is a pity.
- There's some code duplication between the config and the UI, in that both need to specify the same properties. This could perhaps be refactored in the future so that the UI renderer traverses the config object and determines the properties dynamically.
- The interface differs between the “real” properties and the computed ones (e.g., `skipTrackImages` vs `skipTrackImagesProperty`), in which the former requires `get()` and the latter can be accessed directly. Again, this could be refactored in the future.