### PR TITLE
test(ecau): fix Discogs tests

### DIFF
--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/clears-the-cache-entry-on-failure_963532173.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/clears-the-cache-entry-on-failure_963532173.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/clears the cache entry on failure
-WARC-Date: 2023-11-30T10:12:53.907Z
+WARC-Date: 2025-05-08T16:40:41.000Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:87a72d6a-3be9-44e7-9acd-83646b7c0a16>
+WARC-Record-ID: <urn:uuid:1d517b1c-f278-44a4-a294-2687285e1ff3>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,69 +12,82 @@ harCreator: {"name":"Polly.JS","version":"6.0.6","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:c7ed1ae0-72b4-468e-aa23-6c25feae5813>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.908Z
+WARC-Concurrent-To: <urn:uuid:1ebb8d53-9d5d-44c6-8f73-08b9ee8d91fa>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:40:41.002Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:238517ea-79c1-4948-98f2-886e6c68c9e0>
+WARC-Record-ID: <urn:uuid:036ee8f7-4af0-4356-b03f-1ec89e5c3be2>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:ea089158226dec3e931969ea9ad1ce9b84eed2c0fbdae38fc9abc80e6deeab55
-Content-Length: 300
+WARC-Block-Digest: sha256:dc6d53ad8dd1dfa21b103126ef64141549893b1c214d80b074c03899b1e92fe8
+Content-Length: 641
 
-GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D HTTP/1.1
+GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D HTTP/3
+Host: www.discogs.com
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:138.0) Gecko/20100101 Firefox/138.0
+Accept: */*
+Accept-Language: en-GB,en;q=0.5
+Accept-Encoding: gzip, deflate, br, zstd
+Origin: null
+DNT: 1
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Priority: u=4
 
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:c7ed1ae0-72b4-468e-aa23-6c25feae5813>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.908Z
+WARC-Concurrent-To: <urn:uuid:1ebb8d53-9d5d-44c6-8f73-08b9ee8d91fa>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:40:41.002Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:007a4919-f98a-4a97-a0de-2cf11720cf16>
+WARC-Record-ID: <urn:uuid:59d584fe-fcec-4dec-a44f-0571507f08f5>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:252af43c8b5764839657d2105552356d980715cbed0451772ee3fe5360eb7a1a
-WARC-Block-Digest: sha256:252af43c8b5764839657d2105552356d980715cbed0451772ee3fe5360eb7a1a
-Content-Length: 644
+WARC-Payload-Digest: sha256:428fa7fc9d94ac30eeac28130519b27a6bc8600587e2c43ec158746f4c4a3b3b
+WARC-Block-Digest: sha256:428fa7fc9d94ac30eeac28130519b27a6bc8600587e2c43ec158746f4c4a3b3b
+Content-Length: 551
 
-harEntryId: 1b859ab874852bbd15bcbeb02602e936
+harEntryId: bbf35a41dd0d1d7a10f2b5f5c039e0b9
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2023-11-30T10:12:53.673Z
-time: 232
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":232,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 325
+startedDateTime: 2025-05-08T18:39:54.361+02:00
+time: 423
+timings: {"blocked":0,"dns":30,"connect":18,"ssl":0,"send":0,"wait":375,"receive":0}
+warcRequestHeadersSize: 643
 warcRequestCookies: []
-warcResponseHeadersSize: 1020
-warcResponseCookies: [{"name":"__cf_bm","value":"HUQAeo7dIauNqVF4jpr0mez3gVZRdb2QoFSFpgMb2vs-1701339173-0-AbLlzI0CMkbJinvlxPHGVT7iNbsrKzRZB3sUWLa5u4rLNuMLP2tArXeBfTo8tYDuRx+0VOvqfnPIsyy2KCF6EIA=","path":"/","expires":"2023-11-30T10:42:53.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseHeadersSize: 815
+warcResponseCookies: [{"name":"__cf_bm","value":"LptJrAqmlBc5zmV1aA.vpxDLEIZopjBr9uPW5HEoykQ-1746722395-1.0.1.1-0aR0qcCNZXZnJbUu208t.ylixnKwZ0_dZHlAd_AuQ6fekiDw2FIis5vfI8YQvikRxWol7mzRlneQUpQQJrjTfRVwN.fC8KhL3YcPd9o2RoQ"}]
 responseDecoded: false
 
 
 WARC/1.1
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.907Z
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:40:41.002Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:c7ed1ae0-72b4-468e-aa23-6c25feae5813>
+WARC-Record-ID: <urn:uuid:1ebb8d53-9d5d-44c6-8f73-08b9ee8d91fa>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:27df0f43ada11fb3497944ff382191d2cc5009a016894f0189aaed0fceed1c27
-WARC-Block-Digest: sha256:f55eff6e243c7b886e1f2a0d5d379adc2ee774028f496f90dfdf0f9da857487a
-Content-Length: 5534
+WARC-Payload-Digest: sha256:4ecbf159719456e0afdad7bb7c99637a8f0972d6908292846e5e248744b3b77d
+WARC-Block-Digest: sha256:9f660498fc6725be9766238400a3c990f2d302f0ec0f96f10acd218d13310fa4
+Content-Length: 5400
 
-HTTP/1.1 200 OK
-alt-svc: h3=":443"; ma=86400
-cf-cache-status: DYNAMIC
-cf-ray: 82e2508bba81b767-AMS
-connection: keep-alive
-content-encoding: br
+HTTP/3 200 
+date: Thu, 08 May 2025 16:39:55 GMT
 content-type: application/json; charset=utf-8
-date: Thu, 30 Nov 2023 10:12:53 GMT
-server: cloudflare
-set-cookie: __cf_bm=HUQAeo7dIauNqVF4jpr0mez3gVZRdb2QoFSFpgMb2vs-1701339173-0-AbLlzI0CMkbJinvlxPHGVT7iNbsrKzRZB3sUWLa5u4rLNuMLP2tArXeBfTo8tYDuRx+0VOvqfnPIsyy2KCF6EIA=; path=/; expires=Thu, 30-Nov-23 10:42:53 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+cf-ray: 93ca6556b9ed1afc-AMS
+cf-cache-status: DYNAMIC
+access-control-allow-origin: null
+content-encoding: gzip
 strict-transport-security: max-age=15552000
-transfer-encoding: chunked
-vary: Origin, Accept-Encoding
-x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1
-x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
+vary: Accept-Encoding, Origin
+access-control-allow-credentials: true
+x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1, ld_flag_int=1
+priority: u=4,i=?0
+set-cookie: __cf_bm=LptJrAqmlBc5zmV1aA.vpxDLEIZopjBr9uPW5HEoykQ-1746722395-1.0.1.1-0aR0qcCNZXZnJbUu208t.ylixnKwZ0_dZHlAd_AuQ6fekiDw2FIis5vfI8YQvikRxWol7mzRlneQUpQQJrjTfRVwN.fC8KhL3YcPd9o2RoQ; path=/; expires=Thu, 08-May-25 17:09:55 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+server: cloudflare
+alt-svc: h3=":443"; ma=86400
+server-timing: cfExtPri
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","tiny":{"sourceUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","tiny":{"sourceUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","tiny":{"sourceUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}}}
+{"data":{"release":{"discogsId":9892912,"title":"A Million Dreams Ago / One Look At You","images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}}}
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-for-subsequent-requests_598889563.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-for-subsequent-requests_598889563.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/reuses the cache entry for subsequent requests
-WARC-Date: 2023-11-30T10:12:53.327Z
+WARC-Date: 2025-05-08T16:41:34.204Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:3190086f-e005-4ce2-8efd-8c17ac525220>
+WARC-Record-ID: <urn:uuid:4dabaca9-585b-4ff2-94b1-b4650d9cae42>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,69 +12,83 @@ harCreator: {"name":"Polly.JS","version":"6.0.6","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:c27cd336-758a-493a-9e46-65693a01d111>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.327Z
+WARC-Concurrent-To: <urn:uuid:2407fc32-0569-4bda-8c35-18be1ee60da8>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:41:34.206Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:597b82e3-8229-410d-80e8-6f2ae4d825ef>
+WARC-Record-ID: <urn:uuid:bc9674fa-8090-48ab-8bc9-17887fdfdfb8>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:ea089158226dec3e931969ea9ad1ce9b84eed2c0fbdae38fc9abc80e6deeab55
-Content-Length: 300
+WARC-Block-Digest: sha256:c17110deaa387a821e3278940fcff05c8d3d0c01566b399126d5c6df680e4b06
+Content-Length: 655
 
-GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D HTTP/1.1
+GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D HTTP/3
+Host: www.discogs.com
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:138.0) Gecko/20100101 Firefox/138.0
+Accept: */*
+Accept-Language: en-GB,en;q=0.5
+Accept-Encoding: gzip, deflate, br, zstd
+Origin: null
+DNT: 1
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Priority: u=4
+TE: trailers
 
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:c27cd336-758a-493a-9e46-65693a01d111>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.327Z
+WARC-Concurrent-To: <urn:uuid:2407fc32-0569-4bda-8c35-18be1ee60da8>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:41:34.207Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:26a70825-4800-448b-918e-b82f69aa72da>
+WARC-Record-ID: <urn:uuid:f5d9946f-18e8-417c-8595-c2beb3d956d2>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:39d4de77d4b96a124988e210f6f566f20bb643703f07d0f3763a461fe4d0452b
-WARC-Block-Digest: sha256:39d4de77d4b96a124988e210f6f566f20bb643703f07d0f3763a461fe4d0452b
-Content-Length: 644
+WARC-Payload-Digest: sha256:1377ddd05eb27780087e24830afa2c294b05193ec5cb18637f66e0ba2655b9cd
+WARC-Block-Digest: sha256:1377ddd05eb27780087e24830afa2c294b05193ec5cb18637f66e0ba2655b9cd
+Content-Length: 550
 
-harEntryId: 1b859ab874852bbd15bcbeb02602e936
+harEntryId: bbf35a41dd0d1d7a10f2b5f5c039e0b9
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2023-11-30T10:12:52.718Z
-time: 605
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":605,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 325
+startedDateTime: 2025-05-08T18:41:08.579+02:00
+time: 815
+timings: {"blocked":-1,"dns":0,"connect":0,"ssl":0,"send":0,"wait":815,"receive":0}
+warcRequestHeadersSize: 643
 warcRequestCookies: []
-warcResponseHeadersSize: 1020
-warcResponseCookies: [{"name":"__cf_bm","value":"lZwk3VoV1wHm2lXAMa3i_bvT9mvz_CwOVFGH3iXkGac-1701339173-0-AaO00fA1zo7tctm3zefBDK/YE25UHD9D0swDDO9oPJxTf7yYgLUjdqAW1E8YDgZhgE+y1wPpW9k2OHVppjauH/0=","path":"/","expires":"2023-11-30T10:42:53.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseHeadersSize: 815
+warcResponseCookies: [{"name":"__cf_bm","value":"Q7dvZlOV.REc1d19f19RCuotxtIiK4ALvYgIvW_b6cA-1746722469-1.0.1.1-EH5c0K7M_ghRpT0Js3d.BECJfecKru76fDrAgcuuQgaPTODhKhTtCmq_vXoTBOibxz_TUW9ZHY9E.NrNSLR3F873yZQkReSg3CWBBNkdya0"}]
 responseDecoded: false
 
 
 WARC/1.1
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.327Z
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:41:34.206Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:c27cd336-758a-493a-9e46-65693a01d111>
+WARC-Record-ID: <urn:uuid:2407fc32-0569-4bda-8c35-18be1ee60da8>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:27df0f43ada11fb3497944ff382191d2cc5009a016894f0189aaed0fceed1c27
-WARC-Block-Digest: sha256:94df08469d65a540c1e70ad9c05e08ef20ea8be9e30f90b683ac4f77958812b6
-Content-Length: 5534
+WARC-Payload-Digest: sha256:4ecbf159719456e0afdad7bb7c99637a8f0972d6908292846e5e248744b3b77d
+WARC-Block-Digest: sha256:5b7c1cff09e392a832708f373d4d2c1e6759a6f258fafba34583c391f68d6ed7
+Content-Length: 5400
 
-HTTP/1.1 200 OK
-alt-svc: h3=":443"; ma=86400
-cf-cache-status: DYNAMIC
-cf-ray: 82e25085bdbdb767-AMS
-connection: keep-alive
-content-encoding: br
+HTTP/3 200 
+date: Thu, 08 May 2025 16:41:09 GMT
 content-type: application/json; charset=utf-8
-date: Thu, 30 Nov 2023 10:12:53 GMT
-server: cloudflare
-set-cookie: __cf_bm=lZwk3VoV1wHm2lXAMa3i_bvT9mvz_CwOVFGH3iXkGac-1701339173-0-AaO00fA1zo7tctm3zefBDK/YE25UHD9D0swDDO9oPJxTf7yYgLUjdqAW1E8YDgZhgE+y1wPpW9k2OHVppjauH/0=; path=/; expires=Thu, 30-Nov-23 10:42:53 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+cf-ray: 93ca67265c740a65-AMS
+cf-cache-status: DYNAMIC
+access-control-allow-origin: null
+content-encoding: gzip
 strict-transport-security: max-age=15552000
-transfer-encoding: chunked
-vary: Origin, Accept-Encoding
-x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1
-x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
+vary: Accept-Encoding, Origin
+access-control-allow-credentials: true
+x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1, ld_flag_int=1
+priority: u=4,i=?0
+set-cookie: __cf_bm=Q7dvZlOV.REc1d19f19RCuotxtIiK4ALvYgIvW_b6cA-1746722469-1.0.1.1-EH5c0K7M_ghRpT0Js3d.BECJfecKru76fDrAgcuuQgaPTODhKhTtCmq_vXoTBOibxz_TUW9ZHY9E.NrNSLR3F873yZQkReSg3CWBBNkdya0; path=/; expires=Thu, 08-May-25 17:11:09 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+server: cloudflare
+alt-svc: h3=":443"; ma=86400
+server-timing: cfExtPri
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","tiny":{"sourceUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","tiny":{"sourceUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","tiny":{"sourceUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}}}
+{"data":{"release":{"discogsId":9892912,"title":"A Million Dreams Ago / One Look At You","images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}}}
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-while-maximising-images_2688171962.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/caching-API-responses_1012471802/reuses-the-cache-entry-while-maximising-images_2688171962.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/caching API responses/reuses the cache entry while maximising images
-WARC-Date: 2023-11-30T10:12:53.668Z
+WARC-Date: 2025-05-08T16:42:09.155Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:7d06ded1-b7d5-4acf-9c38-1817c6dbe7fb>
+WARC-Record-ID: <urn:uuid:80b297d9-ddec-47c4-8f02-6134c2c042e3>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,69 +12,82 @@ harCreator: {"name":"Polly.JS","version":"6.0.6","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:51720171-7993-48b8-b646-4e341e1a8e63>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.669Z
+WARC-Concurrent-To: <urn:uuid:0cc4522e-a01b-48b9-9d18-80ae497c0c08>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:42:09.157Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:2d338a00-1c75-45c6-8020-863409ef20da>
+WARC-Record-ID: <urn:uuid:98ca938c-5424-4523-a15a-2a903b0f72d4>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:ea089158226dec3e931969ea9ad1ce9b84eed2c0fbdae38fc9abc80e6deeab55
-Content-Length: 300
+WARC-Block-Digest: sha256:dc6d53ad8dd1dfa21b103126ef64141549893b1c214d80b074c03899b1e92fe8
+Content-Length: 641
 
-GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D HTTP/1.1
+GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D HTTP/3
+Host: www.discogs.com
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:138.0) Gecko/20100101 Firefox/138.0
+Accept: */*
+Accept-Language: en-GB,en;q=0.5
+Accept-Encoding: gzip, deflate, br, zstd
+Origin: null
+DNT: 1
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Priority: u=4
 
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:51720171-7993-48b8-b646-4e341e1a8e63>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.669Z
+WARC-Concurrent-To: <urn:uuid:0cc4522e-a01b-48b9-9d18-80ae497c0c08>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:42:09.157Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:fee27fa6-31a8-4dba-929f-8c2a9d72a0f7>
+WARC-Record-ID: <urn:uuid:b374221a-1fd3-46d9-842c-f8946b4f9199>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:e2fe309120069042513818ba81d1db5f296b0a00847e91aa30b04352f1b112d0
-WARC-Block-Digest: sha256:e2fe309120069042513818ba81d1db5f296b0a00847e91aa30b04352f1b112d0
-Content-Length: 644
+WARC-Payload-Digest: sha256:631e79a7051f5fdd4b6be9d9505cbae05061e2acb1b9783c45a70f15996384bb
+WARC-Block-Digest: sha256:631e79a7051f5fdd4b6be9d9505cbae05061e2acb1b9783c45a70f15996384bb
+Content-Length: 550
 
-harEntryId: 1b859ab874852bbd15bcbeb02602e936
+harEntryId: bbf35a41dd0d1d7a10f2b5f5c039e0b9
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2023-11-30T10:12:53.331Z
-time: 333
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":333,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 325
+startedDateTime: 2025-05-08T18:41:49.211+02:00
+time: 426
+timings: {"blocked":0,"dns":0,"connect":20,"ssl":0,"send":0,"wait":406,"receive":0}
+warcRequestHeadersSize: 643
 warcRequestCookies: []
-warcResponseHeadersSize: 1020
-warcResponseCookies: [{"name":"__cf_bm","value":"kvAJimzjmKmRluVP8CBS8XSexXIg2uKEfQ2kI5GdCHg-1701339173-0-AaGpMdix0aunix9BZmpVLDwXpYpmZhKhcuCC2IVDqmSKpenDZ0DupEg33yeAsvllWdYUlUWnSAj1YLpV8ZmWq2I=","path":"/","expires":"2023-11-30T10:42:53.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseHeadersSize: 815
+warcResponseCookies: [{"name":"__cf_bm","value":"xFj0u8TD6whK3xNL0QJaWGahC7.hXVinyD.cqtzRkL0-1746722509-1.0.1.1-BrCC7VnQ8hQFS4i0jG8pmIlUvLSLR1tAtX1NcFX4jLt0DChjLoI95DZlUxDnQdhsydQJmwPK0lbO61OTuoXElzUrEMFl6u1Q5jTlcDp3rU0"}]
 responseDecoded: false
 
 
 WARC/1.1
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:53.669Z
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:42:09.157Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:51720171-7993-48b8-b646-4e341e1a8e63>
+WARC-Record-ID: <urn:uuid:0cc4522e-a01b-48b9-9d18-80ae497c0c08>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:27df0f43ada11fb3497944ff382191d2cc5009a016894f0189aaed0fceed1c27
-WARC-Block-Digest: sha256:3f284fe0863a2afb6b77aed4c9625ff4e3a6aa624b27714ca5fef8c0633aa8a4
-Content-Length: 5534
+WARC-Payload-Digest: sha256:4ecbf159719456e0afdad7bb7c99637a8f0972d6908292846e5e248744b3b77d
+WARC-Block-Digest: sha256:b72bbc9ab414d580656608c3d3beecf97cd3d4b676e41ab346ecc8ea8d67b55f
+Content-Length: 5400
 
-HTTP/1.1 200 OK
-alt-svc: h3=":443"; ma=86400
-cf-cache-status: DYNAMIC
-cf-ray: 82e2508988e5b767-AMS
-connection: keep-alive
-content-encoding: br
+HTTP/3 200 
+date: Thu, 08 May 2025 16:41:49 GMT
 content-type: application/json; charset=utf-8
-date: Thu, 30 Nov 2023 10:12:53 GMT
-server: cloudflare
-set-cookie: __cf_bm=kvAJimzjmKmRluVP8CBS8XSexXIg2uKEfQ2kI5GdCHg-1701339173-0-AaGpMdix0aunix9BZmpVLDwXpYpmZhKhcuCC2IVDqmSKpenDZ0DupEg33yeAsvllWdYUlUWnSAj1YLpV8ZmWq2I=; path=/; expires=Thu, 30-Nov-23 10:42:53 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+cf-ray: 93ca68246ef21de3-AMS
+cf-cache-status: DYNAMIC
+access-control-allow-origin: null
+content-encoding: gzip
 strict-transport-security: max-age=15552000
-transfer-encoding: chunked
-vary: Origin, Accept-Encoding
-x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1
-x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
+vary: Accept-Encoding, Origin
+access-control-allow-credentials: true
+x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1, ld_flag_int=1
+priority: u=4,i=?0
+set-cookie: __cf_bm=xFj0u8TD6whK3xNL0QJaWGahC7.hXVinyD.cqtzRkL0-1746722509-1.0.1.1-BrCC7VnQ8hQFS4i0jG8pmIlUvLSLR1tAtX1NcFX4jLt0DChjLoI95DZlUxDnQdhsydQJmwPK0lbO61OTuoXElzUrEMFl6u1Q5jTlcDp3rU0; path=/; expires=Thu, 08-May-25 17:11:49 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+server: cloudflare
+alt-svc: h3=":443"; ma=86400
+server-timing: cfExtPri
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","tiny":{"sourceUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","tiny":{"sourceUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","tiny":{"sourceUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}}}
+{"data":{"release":{"discogsId":9892912,"title":"A Million Dreams Ago / One Look At You","images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}}}
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/extracts-covers-for-release_2308446907.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/extracts-covers-for-release_2308446907.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/extracting images/extracts covers for release
-WARC-Date: 2023-11-30T10:12:52.476Z
+WARC-Date: 2025-05-08T16:33:14.932Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:27dc52e1-8bec-42ba-b5bc-c59994668df2>
+WARC-Record-ID: <urn:uuid:890b6407-7198-40df-858a-2a671176afe6>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,69 +12,84 @@ harCreator: {"name":"Polly.JS","version":"6.0.6","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:df799ece-f13e-4dfb-902e-bbd1e5d47cb3>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:52.478Z
+WARC-Concurrent-To: <urn:uuid:bcac7a4f-fdcd-424e-a42a-47df54dccfce>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:33:14.934Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:396f9226-dedb-4515-a5ae-38e3f29433ce>
+WARC-Record-ID: <urn:uuid:af42b3ef-7d46-445e-8bc8-3522d02aa395>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:ea089158226dec3e931969ea9ad1ce9b84eed2c0fbdae38fc9abc80e6deeab55
-Content-Length: 300
+WARC-Block-Digest: sha256:1bd7834d55a07a43536757c4f72ca6caa41b03f05e0cb98a690a0e9b1cc6fe92
+Content-Length: 775
 
-GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D HTTP/1.1
+GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D HTTP/2
+Host: www.discogs.com
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:138.0) Gecko/20100101 Firefox/138.0
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+Accept-Language: en-GB,en;q=0.5
+Accept-Encoding: gzip, deflate, br, zstd
+Alt-Used: www.discogs.com
+Upgrade-Insecure-Requests: 1
+Priority: u=0, i
+Origin: null
+DNT: 1
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+TE: trailers
 
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:df799ece-f13e-4dfb-902e-bbd1e5d47cb3>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:52.478Z
+WARC-Concurrent-To: <urn:uuid:bcac7a4f-fdcd-424e-a42a-47df54dccfce>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:33:14.934Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:a5dab867-eaa6-49eb-9e2f-5f2f9c186985>
+WARC-Record-ID: <urn:uuid:9ea8e6c8-56fe-4a78-b305-da4964010e4d>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:6ef6812080e883124b24baa0a92e5b34603fdec051c84def0cb473e459070109
-WARC-Block-Digest: sha256:6ef6812080e883124b24baa0a92e5b34603fdec051c84def0cb473e459070109
-Content-Length: 644
+WARC-Payload-Digest: sha256:25b885cfb842d945d6a4a6abdddcb956f8e69102bbc31e19a654a3645f9ded0a
+WARC-Block-Digest: sha256:25b885cfb842d945d6a4a6abdddcb956f8e69102bbc31e19a654a3645f9ded0a
+Content-Length: 550
 
-harEntryId: 1b859ab874852bbd15bcbeb02602e936
+harEntryId: bbf35a41dd0d1d7a10f2b5f5c039e0b9
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2023-11-30T10:12:52.103Z
-time: 367
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":367,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 325
+startedDateTime: 2025-05-08T18:32:23.811+02:00
+time: 362
+timings: {"blocked":-1,"dns":0,"connect":0,"ssl":0,"send":0,"wait":362,"receive":0}
+warcRequestHeadersSize: 763
 warcRequestCookies: []
-warcResponseHeadersSize: 1020
-warcResponseCookies: [{"name":"__cf_bm","value":"m9A7bzbXI3uduBDaq5.zeOf0d9KSHmFS.z1hoDWjDaA-1701339172-0-ARHq+kXgxRZ0CQkvjcT0UYVjfh3VR2nct1MElyovwW19imNsAqtxCA6k98aCnjYlWQxFwnSoHu5E2FmNQj0UOKU=","path":"/","expires":"2023-11-30T10:42:52.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseHeadersSize: 790
+warcResponseCookies: [{"name":"__cf_bm","value":"5KNWCTjOshKCfxhMYs69ecGaxv5zbgL4f_2MmkibV5g-1746721944-1.0.1.1-OpGu0KXcXJWM3xo8GeEdWphe6ix7iPMdRf5rrFuvU0FVW44XIRuIQr036c2zyQwvAzVkDwevbsVIOxzSUDShGczsDrSCpIEGstFqNrFpffs"}]
 responseDecoded: false
 
 
 WARC/1.1
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:52.477Z
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:33:14.934Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:df799ece-f13e-4dfb-902e-bbd1e5d47cb3>
+WARC-Record-ID: <urn:uuid:bcac7a4f-fdcd-424e-a42a-47df54dccfce>
 Content-Type: application/http; msgtype=response
-WARC-Payload-Digest: sha256:27df0f43ada11fb3497944ff382191d2cc5009a016894f0189aaed0fceed1c27
-WARC-Block-Digest: sha256:0a1152264b50c91e2a8687edd474537c6b14725c0009f87399823ae77b250fb2
-Content-Length: 5534
+WARC-Payload-Digest: sha256:4ecbf159719456e0afdad7bb7c99637a8f0972d6908292846e5e248744b3b77d
+WARC-Block-Digest: sha256:ce14bf023184fc1a261715aebf034a0df79ef59140302724e08f87d34d490dcb
+Content-Length: 5375
 
-HTTP/1.1 200 OK
-alt-svc: h3=":443"; ma=86400
-cf-cache-status: DYNAMIC
-cf-ray: 82e25082baebb767-AMS
-connection: keep-alive
-content-encoding: br
+HTTP/2 200 
+date: Thu, 08 May 2025 16:32:24 GMT
 content-type: application/json; charset=utf-8
-date: Thu, 30 Nov 2023 10:12:52 GMT
-server: cloudflare
-set-cookie: __cf_bm=m9A7bzbXI3uduBDaq5.zeOf0d9KSHmFS.z1hoDWjDaA-1701339172-0-ARHq+kXgxRZ0CQkvjcT0UYVjfh3VR2nct1MElyovwW19imNsAqtxCA6k98aCnjYlWQxFwnSoHu5E2FmNQj0UOKU=; path=/; expires=Thu, 30-Nov-23 10:42:52 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+cf-ray: 93ca5a587e6fc23f-AMS
+cf-cache-status: DYNAMIC
+access-control-allow-origin: null
+content-encoding: gzip
 strict-transport-security: max-age=15552000
-transfer-encoding: chunked
-vary: Origin, Accept-Encoding
-x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1
-x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A9892912%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
+vary: Accept-Encoding, Origin
+access-control-allow-credentials: true
+x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1, ld_flag_int=1
+set-cookie: __cf_bm=5KNWCTjOshKCfxhMYs69ecGaxv5zbgL4f_2MmkibV5g-1746721944-1.0.1.1-OpGu0KXcXJWM3xo8GeEdWphe6ix7iPMdRf5rrFuvU0FVW44XIRuIQr036c2zyQwvAzVkDwevbsVIOxzSUDShGczsDrSCpIEGstFqNrFpffs; path=/; expires=Thu, 08-May-25 17:02:24 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+server: cloudflare
+alt-svc: h3=":443"; ma=86400
+X-Firefox-Spdy: h2
 
-{"data":{"release":{"discogsId":9892912,"images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","tiny":{"sourceUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","tiny":{"sourceUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","tiny":{"sourceUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}}}
+{"data":{"release":{"discogsId":9892912,"title":"A Million Dreams Ago / One Look At You","images":{"totalCount":3,"edges":[{"node":{"id":"SW1hZ2U6NDQwNTM4MDM=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/fAtlM0FvrCXGm3LGd3UCGF4iDHcc_S9hHW_xw89vXZc/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MPDZnLHLvqDXD9VgXjG6EuxI5mrTCMqjoysNLPs7n9g/rs:fit/g:sm/q:90/h:600/w:576/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":626,"height":652,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg","width":144,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6NDQwNTM4MDQ=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/hc0uV6Bwbi7tip1mDGMD5ID-MEcDS8N_620UUVCE1Tw/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/YUazmsa2FN7AEVL9uiiQcP7Akm7YzvWbOfBmlcBnp0E/rs:fit/g:sm/q:90/h:600/w:598/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":641,"height":643,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","webpUrl":"https://i.discogs.com/-Iog9XgEfZCcC6u3SAfDh8sawIC3Q6wkZG-Qfx3Mhss/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny00MDQ4LmpwZWc.jpeg","width":149,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"},{"node":{"id":"SW1hZ2U6MjcyNjYxODA=","nsfw":false,"tiny":{"sourceUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/MALqZVcfxIa1KN0wqaDlv-KrCx2g_hr1ZLAsbOLW5O0/rs:fit/g:sm/q:40/h:150/w:150/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"fullsize":{"sourceUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/lc-HuQ8YhjbAzL1wbsE0ZYTNm62hhRX-23bpK01moEo/rs:fit/g:sm/q:90/h:600/w:528/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":1392,"height":1580,"__typename":"ImageInfo"},"thumbnail":{"sourceUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","webpUrl":"https://i.discogs.com/XeRMIJqT9OJs9VB4rRSL5aR_S0QE3spYx7O0v7A2fPg/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTQ4ODA2NzM0/MS0yODcyLmpwZWc.jpeg","width":132,"height":150,"__typename":"ImageInfo"},"__typename":"Image"},"__typename":"ImagesEdge"}],"__typename":"ImagesConnection"},"__typename":"Release"}}}
 

--- a/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/throws-on-non-existent-release_1189313548.warc
+++ b/tests/test-data/__recordings__/discogs-provider_883142520/extracting-images_1310741912/throws-on-non-existent-release_1189313548.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: discogs provider/extracting images/throws on non-existent release
-WARC-Date: 2023-11-30T10:12:52.708Z
+WARC-Date: 2025-05-08T16:37:58.046Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:ba2c35a1-49d0-4755-a651-359e666e612f>
+WARC-Record-ID: <urn:uuid:2755152c-afe7-40bc-91df-485d44269912>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,68 +12,82 @@ harCreator: {"name":"Polly.JS","version":"6.0.6","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:14a247eb-0603-495d-be7c-a0ebf4873367>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:52.709Z
+WARC-Concurrent-To: <urn:uuid:00588160-f894-4555-9ec1-25fde3e931f4>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A999999999%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:37:58.048Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:8ea5d014-7b4a-4fc4-a0e0-8650deabe8c3>
+WARC-Record-ID: <urn:uuid:e1ba9831-d7c0-49f9-83e4-5861e36b18e1>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-WARC-Block-Digest: sha256:d750b3e2ad514d0037f89d61f9efccfe05be2bea983873575eeb115db88ca3e3
-Content-Length: 301
+WARC-Block-Digest: sha256:74362447fdd73468a460701e4accc86795516c5568e8f68ccdb7eb217213a4dc
+Content-Length: 643
 
-GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D HTTP/1.1
+GET /internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A999999999%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D HTTP/3
+Host: www.discogs.com
+User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:138.0) Gecko/20100101 Firefox/138.0
+Accept: */*
+Accept-Language: en-GB,en;q=0.5
+Accept-Encoding: gzip, deflate, br, zstd
+Origin: null
+DNT: 1
+Connection: keep-alive
+Sec-Fetch-Dest: empty
+Sec-Fetch-Mode: cors
+Sec-Fetch-Site: cross-site
+Priority: u=4
 
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:14a247eb-0603-495d-be7c-a0ebf4873367>
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:52.709Z
+WARC-Concurrent-To: <urn:uuid:00588160-f894-4555-9ec1-25fde3e931f4>
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A999999999%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:37:58.048Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:bdb1f517-6e10-4b5d-a2c9-f1a9a54ae5a4>
+WARC-Record-ID: <urn:uuid:47bdd4da-9814-4e81-9e26-f58d5ec62287>
 Content-Type: application/warc-fields
-WARC-Payload-Digest: sha256:a44b42bedf0fb0b5194faf81d97e9855b8acb6a107b640f4a430d88e5ec3c526
-WARC-Block-Digest: sha256:a44b42bedf0fb0b5194faf81d97e9855b8acb6a107b640f4a430d88e5ec3c526
-Content-Length: 643
+WARC-Payload-Digest: sha256:57a32a3f5c7ce2ee90fcc25d48b400a172aaced1bac6b8f6598eb6e5447cc8ec
+WARC-Block-Digest: sha256:57a32a3f5c7ce2ee90fcc25d48b400a172aaced1bac6b8f6598eb6e5447cc8ec
+Content-Length: 550
 
-harEntryId: 605ff88ad0ad43bf6dbcae541a9a63c1
+harEntryId: 425e20bd9d89b1f922ef79da7240dcaf
 harEntryOrder: 0
 cache: {}
-startedDateTime: 2023-11-30T10:12:52.489Z
-time: 218
-timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":218,"receive":0,"ssl":-1}
-warcRequestHeadersSize: 326
+startedDateTime: 2025-05-08T18:37:14.862+02:00
+time: 448
+timings: {"blocked":0,"dns":0,"connect":14,"ssl":0,"send":0,"wait":434,"receive":0}
+warcRequestHeadersSize: 645
 warcRequestCookies: []
-warcResponseHeadersSize: 991
-warcResponseCookies: [{"name":"__cf_bm","value":"RmY0bWi2YvUc8V1qAeVHZ9ojSITq3tprTz6iuxs_mks-1701339172-0-AVtDXzIayf1G1NEQygHPtkhF6y5VioB+ppC/EEkNWxwwnMfuBZUAx5+p5PRmEL/bbSTSsABucSUIyGYg8X2jkOg=","path":"/","expires":"2023-11-30T10:42:52.000Z","domain":".discogs.com","httpOnly":true,"secure":true,"sameSite":"None"}]
+warcResponseHeadersSize: 815
+warcResponseCookies: [{"name":"__cf_bm","value":"ZuqwxxONcYJ.IAVg8C.HsNoV5hqYbtckbSLDPMm97MM-1746722235-1.0.1.1-BIYxluZHhkxwy5q3MurtKZcCEtHzJiyjuQW.xcvzuyRc9MUmxgNg.nnprphrTTuC3FXocnkfCDSj2sZa_nF_J9TLJYtbiWA3HqVi.yQx4Z4"}]
 responseDecoded: false
 
 
 WARC/1.1
-WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
-WARC-Date: 2023-11-30T10:12:52.708Z
+WARC-Target-URI: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A999999999%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22c7033a9fd1facb3e69fa50074b47e8aa0076857a968e6ed086153840e02b988a%22%7D%7D
+WARC-Date: 2025-05-08T16:37:58.048Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:14a247eb-0603-495d-be7c-a0ebf4873367>
+WARC-Record-ID: <urn:uuid:00588160-f894-4555-9ec1-25fde3e931f4>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:a9afa3078d4bc051d472df2be27c0a495235113e3f126e0b6983e92ce22e0310
-WARC-Block-Digest: sha256:edb5d7a9916daeb072aef6812c3bbbfe91a538b26d5cbccdd95bf3a4790106be
-Content-Length: 1033
+WARC-Block-Digest: sha256:487b6d84d6aca2ad1d34caead11314414e4779259c4a3073634d9bd59c29a2bd
+Content-Length: 840
 
-HTTP/1.1 200 OK
-alt-svc: h3=":443"; ma=86400
-cf-cache-status: DYNAMIC
-cf-ray: 82e250844c7eb767-AMS
-connection: keep-alive
-content-length: 25
+HTTP/3 200 
+date: Thu, 08 May 2025 16:37:15 GMT
 content-type: application/json; charset=utf-8
-date: Thu, 30 Nov 2023 10:12:52 GMT
-server: cloudflare
-set-cookie: __cf_bm=RmY0bWi2YvUc8V1qAeVHZ9ojSITq3tprTz6iuxs_mks-1701339172-0-AVtDXzIayf1G1NEQygHPtkhF6y5VioB+ppC/EEkNWxwwnMfuBZUAx5+p5PRmEL/bbSTSsABucSUIyGYg8X2jkOg=; path=/; expires=Thu, 30-Nov-23 10:42:52 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+cf-ray: 93ca6171ad414f5f-AMS
+cf-cache-status: DYNAMIC
+access-control-allow-origin: null
+content-encoding: gzip
 strict-transport-security: max-age=15552000
-vary: Origin, Accept-Encoding
-x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1
-x-pollyjs-finalurl: https://www.discogs.com/internal/release-page/api/graphql?operationName=ReleaseAllImages&variables=%7B%22discogsId%22%3A32342343%2C%22count%22%3A500%7D&extensions=%7B%22persistedQuery%22%3A%7B%22version%22%3A1%2C%22sha256Hash%22%3A%22cd0fe8a7199e97a9027f676838dd25bf88346435f7096fddd79b055d68ea98c8%22%7D%7D
+vary: Accept-Encoding, Origin
+access-control-allow-credentials: true
+x-discogs-flags: ssr_login=1, ssr_user=0, ssr_defer=0, disable_ads=0, esi_header=1, ld_flag_int=1
+priority: u=4,i=?0
+set-cookie: __cf_bm=ZuqwxxONcYJ.IAVg8C.HsNoV5hqYbtckbSLDPMm97MM-1746722235-1.0.1.1-BIYxluZHhkxwy5q3MurtKZcCEtHzJiyjuQW.xcvzuyRc9MUmxgNg.nnprphrTTuC3FXocnkfCDSj2sZa_nF_J9TLJYtbiWA3HqVi.yQx4Z4; path=/; expires=Thu, 08-May-25 17:07:15 GMT; domain=.discogs.com; HttpOnly; Secure; SameSite=None
+server: cloudflare
+alt-svc: h3=":443"; ma=86400
+server-timing: cfExtPri
 
 {"data":{"release":null}}
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/discogs.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/discogs.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-disabled-tests */
 import { DiscogsProvider } from '@src/mb_enhanced_cover_art_uploads/providers/discogs';
 import { setupPolly } from '@test-utils/pollyjs';
 import { itBehavesLike } from '@test-utils/shared-behaviour';
@@ -36,7 +35,7 @@ describe('discogs provider', () => {
         itBehavesLike(urlMatchingSpec, { provider, supportedUrls, unsupportedUrls });
     });
 
-    describe.skip('extracting images', () => {
+    describe('extracting images', () => {
         const extractionCases = [{
             description: 'release',
             url: 'https://www.discogs.com/release/9892912',
@@ -58,14 +57,14 @@ describe('discogs provider', () => {
 
         const extractionFailedCases = [{
             description: 'non-existent release',
-            url: 'https://www.discogs.com/release/32342343',
+            url: 'https://www.discogs.com/release/999999999',
         }];
 
         // eslint-disable-next-line jest/require-hook
         itBehavesLike(findImagesSpec, { provider, extractionCases, extractionFailedCases, pollyContext });
     });
 
-    describe.skip('maximising image', () => {
+    describe('maximising image', () => {
         it('finds the image', async () => {
             const maxUrl = await DiscogsProvider.maximiseImage(new URL('https://i.discogs.com/wAcTcCu1v8cmYfw_D_I00DNR_RcxJfBUMb3ls7yG9Wo/rs:fit/g:sm/q:40/h:300/w:300/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTk4OTI5/MTItMTU3OTQ1Njcw/Ny0yMzIwLmpwZWc.jpeg'));
 
@@ -81,7 +80,7 @@ describe('discogs provider', () => {
         });
     });
 
-    describe.skip('caching API responses', () => {
+    describe('caching API responses', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Needed to spy on private method.
         const requestSpy = jest.spyOn(DiscogsProvider as any, 'actuallyGetReleaseImages');
         const discogsUrl = new URL('https://www.discogs.com/release/9892912');


### PR DESCRIPTION
They were disabled a while ago in #762 because of Cloudflare protection. Now that we have the recording replacer script from #816, we can actually update the recordings and start using the tests again.

Also updated the negative test case as it pointed to a release that now exists. The new ID is the largest ID that the API currently accepts.