### PR TITLE
chore(build): re-enable renovate on-demand

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,4 @@
 {
-  "enabled": false,
   "extends": [
     "config:base",
     ":semanticCommitTypeAll(build)",
@@ -7,7 +6,7 @@
     ":label(dependencies)"
   ],
   "schedule": [
-    "on the first day of the month"
+    "* 0 29 2 *"
   ],
   "pin": {
     "enabled": true,
@@ -22,25 +21,7 @@
     "automerge": true,
     "automergeType": "branch",
     "schedule": [
-      "before 11am on the first day of the month"
+      "* 0 1 */3 *"
     ]
-  },
-  "packageRules": [
-    {
-      "description": "Automatically merge patch and minor updates to dev dependencies",
-      "matchDepTypes": [
-        "devDependencies"
-      ],
-      "matchUpdateTypes": [
-        "patch",
-        "minor"
-      ],
-      "automerge": true,
-      "automergeType": "branch",
-      "groupName": "dev dependencies non-major",
-      "excludePackageNames": [
-        "babel-plugin-transform-async-to-promises"
-      ]
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Renovate is scheduled to only run on Feb 29th, which is once every 4 years. I'm hoping that this will have the following effect:
- Renovate will not create update commits or PRs except one day of the year, thereby reducing its spam.
- Renovate will still monitor for updates and maintain its dependency dashboard, where the available updates will be marked as "awaiting schedule" and PRs can be created on demand.

Effectively, if this works, we'll be able to have an overview of outdated dependencies, while also being able to manually curate which pending updates we want to apply, all without a constant barrage of automated commits on a dormant repository, or a constant barrage of PR update e-mails. 🤞. As far as I know, there is no way to configure Renovate in such a way.

Also removing the grouping of dev dependencies. This was a good strategy to reduce spammy commits, but if one of the dev dependencies causes a breaking change, all updates will be blocked. If we'll manually pick and choose the updates, it's less necessary. Ideally they'd still be somewhat grouped (with separate groups for ESLint, TypeScript, Jest, and rollup) but let's not over-engineer it just yet.

Note: Version pinning and lock file maintenance are still automatic, with the latter running once every 3 months. That'll hopefully reduce the outdated browserslist warnings etc.