### PR TITLE
chore(deps): remove deprecated `@types` packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,8 +39,6 @@
         "@types/greasemonkey": "4.0.7",
         "@types/jest": "29.5.12",
         "@types/jest-when": "3.5.5",
-        "@types/postcss-preset-env": "7.7.0",
-        "@types/rollup__plugin-virtual": "2.0.4",
         "@types/rollup-plugin-progress": "1.1.4",
         "@types/setup-polly-jest": "0.5.5",
         "@typescript-eslint/eslint-plugin": "6.20.0",
@@ -5101,16 +5099,6 @@
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "dev": true
     },
-    "node_modules/@types/postcss-preset-env": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@types/postcss-preset-env/-/postcss-preset-env-7.7.0.tgz",
-      "integrity": "sha512-biD8MwSiZo1Nztn1cIBPMcKNKzgFyU05AB96HIF9y3G4f9vdx2O60DHCSpWXChTp6mOEGu15fqIw2DetVVjghw==",
-      "dev": true,
-      "dependencies": {
-        "autoprefixer": "^10.4.7",
-        "postcss": "^8.4.14"
-      }
-    },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
@@ -5121,42 +5109,6 @@
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
       "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow=="
-    },
-    "node_modules/@types/rollup__plugin-virtual": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/rollup__plugin-virtual/-/rollup__plugin-virtual-2.0.4.tgz",
-      "integrity": "sha512-tkLlpHg1qJd9SE7boNEI2HW4tBkVKwjBJ1D8TahTSRH9LD5RrW9ECdP+a59cDdVQk6lgJhV1x7HRpvxpP7ySuA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "rollup": "^1.31.1"
-      }
-    },
-    "node_modules/@types/rollup__plugin-virtual/node_modules/acorn": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/@types/rollup__plugin-virtual/node_modules/rollup": {
-      "version": "1.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.32.1.tgz",
-      "integrity": "sha512-/2HA0Ec70TvQnXdzynFffkjA6XN+1e2pEv/uKS5Ulca40g2L7KuOE3riasHoNVHOsFD5KKZgDsMk1CP3Tw9s+A==",
-      "dev": true,
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      }
     },
     "node_modules/@types/rollup-plugin-progress": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -49,8 +49,6 @@
     "@types/greasemonkey": "4.0.7",
     "@types/jest": "29.5.12",
     "@types/jest-when": "3.5.5",
-    "@types/postcss-preset-env": "7.7.0",
-    "@types/rollup__plugin-virtual": "2.0.4",
     "@types/rollup-plugin-progress": "1.1.4",
     "@types/setup-polly-jest": "0.5.5",
     "@typescript-eslint/eslint-plugin": "6.20.0",


### PR DESCRIPTION
These are deprecated as the respective packages ship their own type definitions.