### PR TITLE
chore(deps): remove eslint-plugin-deprecation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,7 +8,6 @@ const baseEslintConfig = {
         './configs/eslint/general.cjs',
         './configs/eslint/typescript.cjs',
         './configs/eslint/style.cjs',
-        './configs/eslint/deprecation.cjs',
         './configs/eslint/sort-imports.cjs',
         './configs/eslint/eslint-comments.cjs',
         './configs/eslint/sonarjs.cjs',

--- a/configs/eslint/deprecation.cjs
+++ b/configs/eslint/deprecation.cjs
@@ -1,8 +1,0 @@
-module.exports = {
-    plugins: [
-        'deprecation',
-    ],
-    rules: {
-        'deprecation/deprecation': 'error',
-    },
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "core-js": "3.35.1",
         "eslint": "8.56.0",
         "eslint-plugin-array-func": "4.0.0",
-        "eslint-plugin-deprecation": "2.0.0",
         "eslint-plugin-jest": "27.6.3",
         "eslint-plugin-jest-async": "1.0.3",
         "eslint-plugin-jest-formatting": "3.1.0",
@@ -7327,21 +7326,6 @@
       },
       "peerDependencies": {
         "eslint": ">=8.40.0"
-      }
-    },
-    "node_modules/eslint-plugin-deprecation": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-deprecation/-/eslint-plugin-deprecation-2.0.0.tgz",
-      "integrity": "sha512-OAm9Ohzbj11/ZFyICyR5N6LbOIvQMp7ZU2zI7Ej0jIc8kiGUERXPNMfw2QqqHD1ZHtjMub3yPZILovYEYucgoQ==",
-      "dev": true,
-      "dependencies": {
-        "@typescript-eslint/utils": "^6.0.0",
-        "tslib": "^2.3.1",
-        "tsutils": "^3.21.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0",
-        "typescript": "^4.2.4 || ^5.0.0"
       }
     },
     "node_modules/eslint-plugin-jest": {
@@ -14966,12 +14950,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "dev": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "core-js": "3.35.1",
     "eslint": "8.56.0",
     "eslint-plugin-array-func": "4.0.0",
-    "eslint-plugin-deprecation": "2.0.0",
     "eslint-plugin-jest": "27.6.3",
     "eslint-plugin-jest-async": "1.0.3",
     "eslint-plugin-jest-formatting": "3.1.0",


### PR DESCRIPTION
This plugin is itself deprecated, as the check has been integrated into typescript-eslint. This plugin is also preventing ESLint from being updated to a newer version.