### PR TITLE
fix(ecau): gracefully handle failures in Bandcamp track image extraction

### DIFF
--- a/tests/test-data/__recordings__/bandcamp-provider_3598072612/extracting-images_1310741912/extracts-covers-for-subscriber-only-releases_4211089645.warc
+++ b/tests/test-data/__recordings__/bandcamp-provider_3598072612/extracting-images_1310741912/extracts-covers-for-subscriber-only-releases_4211089645.warc
@@ -1,0 +1,4661 @@
+WARC/1.1
+WARC-Filename: bandcamp provider/extracting images/extracts covers for subscriber-only releases
+WARC-Date: 2025-05-30T09:46:40.361Z
+WARC-Type: warcinfo
+WARC-Record-ID: <urn:uuid:8b1c9cef-2bb6-4414-9f6d-b6bb44c328d2>
+Content-Type: application/warc-fields
+Content-Length: 119
+
+software: warcio.js
+harVersion: 1.2
+harCreator: {"name":"Polly.JS","version":"6.0.6","comment":"persister:fs-warc"}
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:583dac05-d34a-44a1-88cb-03163bf5c6a4>
+WARC-Target-URI: https://arbee.bandcamp.com/album/des-papiers-ii
+WARC-Date: 2025-05-30T09:46:40.363Z
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:6376bb9f-b63b-42a4-89fd-20f9ec55b4bf>
+Content-Type: application/http; msgtype=request
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:4412743d0040c1c69df00b3918aa09678b4c519ba59453c0daff093cc69b035c
+Content-Length: 38
+
+GET /album/des-papiers-ii HTTP/1.1
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:583dac05-d34a-44a1-88cb-03163bf5c6a4>
+WARC-Target-URI: https://arbee.bandcamp.com/album/des-papiers-ii
+WARC-Date: 2025-05-30T09:46:40.364Z
+WARC-Type: metadata
+WARC-Record-ID: <urn:uuid:65692f33-0b6c-4259-ab13-b45b9cbd48f7>
+Content-Type: application/warc-fields
+WARC-Payload-Digest: sha256:1e9726b3d8697365bf4359d254278702554ba2e6172581f7a64528b25039163c
+WARC-Block-Digest: sha256:1e9726b3d8697365bf4359d254278702554ba2e6172581f7a64528b25039163c
+Content-Length: 424
+
+harEntryId: 3b7f7d8e202c8ea1b059e17c33bd4f49
+harEntryOrder: 0
+cache: {}
+startedDateTime: 2025-05-30T09:46:39.210Z
+time: 711
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":711,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 66
+warcRequestCookies: []
+warcResponseHeadersSize: 899
+warcResponseCookies: [{"name":"BACKENDID3","value":"flexocentral-qknz-6","path":"/","secure":true}]
+responseDecoded: false
+
+
+WARC/1.1
+WARC-Target-URI: https://arbee.bandcamp.com/album/des-papiers-ii
+WARC-Date: 2025-05-30T09:46:40.363Z
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:583dac05-d34a-44a1-88cb-03163bf5c6a4>
+Content-Type: application/http; msgtype=response
+WARC-Payload-Digest: sha256:b87e3ab26bcaf3c90fe8c97fea65474c24547f9e72a6731a0b68de04c4e85830
+WARC-Block-Digest: sha256:6a04a11da56f3b85990bd479b166ee30adbe9abfe51d9c1f70909a017674e8c1
+Content-Length: 237973
+
+HTTP/1.1 200 OK
+accept-ranges: bytes
+connection: keep-alive
+content-encoding: gzip
+content-security-policy: base-uri 'none'; object-src 'none'; report-uri https://bandcamp.com/api/cspreport/1/violation; script-src http: https: 'nonce-wTheumiB9KwnlhpIPDSBvQ==' 'report-sample' 'strict-dynamic'
+content-type: text/html; charset=UTF-8
+date: Fri, 30 May 2025 09:46:39 GMT
+link: <https://arbee.bandcamp.com/album/des-papiers-ii>;   rel="canonical"
+referrer-policy: no-referrer-when-downgrade
+server: nginx
+set-cookie: BACKENDID3=flexocentral-qknz-6; path=/; Secure
+strict-transport-security: max-age=63072000
+transfer-encoding: chunked
+vary: Accept-Encoding
+via: 1.1 varnish, 1.1 varnish
+x-cache: MISS, MISS
+x-cache-hits: 0, 0
+x-served-by: cache-rtm-ehrd2290039-RTM, cache-rtm-ehrd2290028-RTM
+x-timer: S1748598399.413034,VS0,VE450
+x-pollyjs-finalurl: https://arbee.bandcamp.com/album/des-papiers-ii
+
+    
+
+<!DOCTYPE html>
+
+
+
+<html   xmlns:og="http://opengraphprotocol.org/schema/"
+        xmlns:fb="http://www.facebook.com/2008/fbml"
+        lang="en">
+
+<head>
+    <title>Des papiers II | arbee</title>
+    
+    
+
+
+
+    <meta name="description" content="
+Des papiers II by arbee, released 30 April 2025
+
+1. Des papiers II
+
+Des papiers II.
+
+Subscriber-exclusive ambient.
+">
+    
+     
+    <link rel="shortcut icon" href="https://f4.bcbits.com/img/a1289075493_3.jpg">
+    <link rel="apple-touch-icon" href="https://f4.bcbits.com/img/a1289075493_3.jpg">
+
+
+<meta name="msapplication-TileColor" content="#603cba">
+<meta name="theme-color" content="#ffffff">
+
+    
+
+    
+
+    
+    
+        <meta name="title" content="Des papiers II, by arbee">
+        <meta property="og:title" content="Des papiers II, by arbee">
+        <meta property="og:type" content="album">
+        <meta property="og:site_name" content="arbee">
+        <meta property="og:description" content="1 track album">
+        <meta name="bc-page-properties" content="{&quot;item_type&quot;:&quot;a&quot;,&quot;item_id&quot;:948735258,&quot;tralbum_page_version&quot;:0}">
+        <meta name="robots" content="max-image-preview:large">
+
+        
+            <meta property="twitter:site" content="@bandcamp">
+        
+
+    
+    
+
+    
+    
+        
+            <meta property="twitter:card" content="summary">
+        
+
+        
+            <meta property="og:image" content="https://f4.bcbits.com/img/a1289075493_5.jpg">
+            <link rel="image_src" href="https://f4.bcbits.com/img/a1289075493_16.jpg">
+        
+
+        <meta property="og:url"   content="https://arbee.bandcamp.com/album/des-papiers-ii">
+
+        
+
+        
+            
+            
+        
+
+        
+
+        
+    
+    
+
+
+
+    
+
+    
+    
+    
+
+    
+
+    
+    
+
+    <link type="text/css" rel="stylesheet" href="https://s4.bcbits.com/client-bundle/1/trackpipe/global-3310d507cbd7464826c64ea86a6f8e75.css">
+<link type="text/css" rel="stylesheet" href="https://s4.bcbits.com/client-bundle/1/trackpipe/tralbum-828e855b799307ef427645b8fc241f90.css">
+
+    <meta id="js-crumbs-data" data-crumbs="{}">
+    
+
+    
+    <script type="application/ld+json">
+        {"albumReleaseType":"SingleRelease","@id":"https://arbee.bandcamp.com/album/des-papiers-ii","mainEntityOfPage":"https://arbee.bandcamp.com/album/des-papiers-ii","@type":"MusicAlbum","name":"Des papiers II","dateModified":"01 May 2025 01:56:42 GMT","albumRelease":[{"@type":"MusicRelease","@id":"https://arbee.bandcamp.com/album/des-papiers-ii","name":"Des papiers II","additionalProperty":[{"@type":"PropertyValue","name":"item_id","value":948735258},{"@type":"PropertyValue","name":"item_type","value":"a"},{"@type":"PropertyValue","name":"selling_band_id","value":4038363339},{"@type":"PropertyValue","name":"type_name","value":"Digital"},{"@type":"PropertyValue","name":"art_id","value":1289075493}],"description":"Includes high-quality download in MP3, FLAC and more. Paying supporters also get unlimited streaming via the free Bandcamp app.","musicReleaseFormat":"DigitalFormat","image":["https://f4.bcbits.com/img/a1289075493_10.jpg"]},{"@type":["MusicRelease","Product"],"@id":"https://arbee.bandcamp.com/subscribe","name":"subscription","additionalProperty":[{"@type":"PropertyValue","name":"item_id","value":22827},{"@type":"PropertyValue","name":"item_type","value":"i"},{"@type":"PropertyValue","name":"selling_band_id","value":4038363339},{"@type":"PropertyValue","name":"type_name","value":"Digital"},{"@type":"PropertyValue","name":"band_name","value":"arbee"},{"@type":"PropertyValue","name":"bonus_items_count","value":100},{"@type":"PropertyValue","name":"creates_music","value":true},{"@type":"PropertyValue","name":"image_ids","value":[33088798]},{"@type":"PropertyValue","name":"subscriber_only_items_count","value":22}],"offers":{"@type":"Offer","url":"https://arbee.bandcamp.com/subscribe#i22827-buy","priceCurrency":"CAD","price":3.0,"priceSpecification":{"minPrice":3.0},"additionalProperty":[{"@type":"PropertyValue","name":"cycle","value":"month"}]},"musicReleaseFormat":"DigitalFormat","image":["https://f4.bcbits.com/img/0033088798_10.jpg"]},{"@type":"MusicRelease","@id":"https://arbee.bandcamp.com/track/des-papiers-ii"}],"byArtist":{"@type":"MusicGroup","name":"arbee","@id":"https://arbee.bandcamp.com"},"publisher":{"@type":"MusicGroup","@id":"https://arbee.bandcamp.com","name":"arbee","additionalProperty":[{"@type":"PropertyValue","name":"band_id","value":4038363339},{"@type":"PropertyValue","name":"has_any_downloads","value":true},{"@type":"PropertyValue","name":"has_download_codes","value":true},{"@type":"PropertyValue","name":"image_height","value":907},{"@type":"PropertyValue","name":"image_id","value":14017},{"@type":"PropertyValue","name":"image_width","value":907}],"image":"https://f4.bcbits.com/img/0000014017_10.jpg","genre":"https://bandcamp.com/discover/electronic","description":"electronic & ambient music","mainEntityOfPage":[{"@type":"WebSite","url":"https://arbee.ca","name":"arbee.ca"},{"@type":"WebPage","url":"https://linktr.ee/arbeemonkey","name":"linktr.ee"}],"subjectOf":[{"@type":"WebPage","url":"https://arbee.bandcamp.com/music","name":"music","additionalProperty":[{"@type":"PropertyValue","name":"nav_type","value":"m"}]},{"@type":"WebPage","url":"https://arbee.bandcamp.com/merch","name":"merch","additionalProperty":[{"@type":"PropertyValue","name":"nav_type","value":"p"}]},{"@type":"WebPage","url":"https://arbee.bandcamp.com/subscribe","name":"subscribe","additionalProperty":[{"@type":"PropertyValue","name":"nav_type","value":"c"}]}],"foundingLocation":{"@type":"Place","name":"Québec"}},"numTracks":1,"track":{"@type":"ItemList","numberOfItems":1,"itemListElement":[{"@type":"ListItem","position":1,"item":{"@type":"MusicRecording","@id":"https://arbee.bandcamp.com/track/des-papiers-ii","additionalProperty":[{"@type":"PropertyValue","name":"track_id","value":3305703503},{"@type":"PropertyValue","name":"license_name","value":"all_rights_reserved"}],"name":"Des papiers II","duration":"P00H03M01S","copyrightNotice":"All Rights Reserved","mainEntityOfPage":"https://arbee.bandcamp.com/track/des-papiers-ii"}}]},"image":"https://f4.bcbits.com/img/a1289075493_10.jpg","keywords":["Electronic","ambient","drone","field recordings","noises","noisy ambient","textures","Canada"],"datePublished":"30 Apr 2025 00:00:00 GMT","description":"Des papiers II.\r\n\r\nSubscriber-exclusive ambient.","copyrightNotice":"All Rights Reserved","sponsor":[{"@type":"Person","url":"https://bandcamp.com/sharonshay","image":"https://f4.bcbits.com/img/0034637047_50.jpg","additionalProperty":[{"@type":"PropertyValue","name":"image_id","value":34637047}],"name":"sharonshay"},{"@type":"Person","url":"https://bandcamp.com/sechogs1","image":"https://f4.bcbits.com/img/0039002132_50.jpg","additionalProperty":[{"@type":"PropertyValue","name":"image_id","value":39002132}],"name":"Randall "},{"@type":"Person","url":"https://bandcamp.com/rikm","image":"https://f4.bcbits.com/img/0010008876_50.jpg","additionalProperty":[{"@type":"PropertyValue","name":"image_id","value":10008876}],"name":"rikm"},{"@type":"Person","url":"https://bandcamp.com/cinnamonskull","image":"https://f4.bcbits.com/img/0037897404_50.jpg","additionalProperty":[{"@type":"PropertyValue","name":"image_id","value":37897404}],"name":"Ur Trommler"},{"@type":"Person","url":"https://bandcamp.com/pertin-nce","image":"https://f4.bcbits.com/img/0004279367_50.jpg","additionalProperty":[{"@type":"PropertyValue","name":"image_id","value":4279367}],"name":"maxime tanguay"},{"@type":"Person","url":"https://bandcamp.com/eeem","image":"https://f4.bcbits.com/img/0000830407_50.jpg","additionalProperty":[{"@type":"PropertyValue","name":"image_id","value":830407}],"name":"Emmanuel Toledo"}],"additionalProperty":[{"@type":"PropertyValue","name":"art_id","value":1289075493},{"@type":"PropertyValue","name":"featured_track_num","value":1},{"@type":"PropertyValue","name":"license_name","value":"all_rights_reserved"},{"@type":"PropertyValue","name":"subscriber_only","value":true}],"@context":"https://schema.org"}
+    </script>
+
+
+    
+        <script type="text/javascript"
+            nonce="wTheumiB9KwnlhpIPDSBvQ=="
+            src="https://bandcamp.com/api/currency_data/1/javascript?when=1748597964"
+            data-band-currency="CAD"
+        ></script>
+    
+
+    
+<script type="text/javascript" nonce="wTheumiB9KwnlhpIPDSBvQ==">
+window.BCTracker=window.BCTracker||{preloadQueue:[],record:function(){this.preloadQueue.push(Array.prototype.slice.call(arguments))},prePageViewCallbacks:[],afterPageView:function(e){this.prePageViewCallbacks.push(e)}},window.ScrollDepthTracker=function(){this.track=function(){}},window.ScrollDepthTracker.track=function(){}
+</script>
+
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/BCCookies_1/bccookies-cd3c4e8de65a85913bb6db9b8ad7de36.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" ></script>
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/global_head-ab088fbe9ed13ec7b25d0abb51c39233.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" data-vars="{&quot;debug&quot;:false,&quot;PRODUCTION&quot;:true,&quot;siteroot&quot;:&quot;https://bandcamp.com&quot;,&quot;static_siteroot&quot;:&quot;https://s4.bcbits.com&quot;,&quot;client_logging&quot;:{&quot;enabled&quot;:true,&quot;sampleRate&quot;:null},&quot;browser&quot;:{&quot;type&quot;:&quot;gecko&quot;,&quot;make&quot;:&quot;firefox&quot;,&quot;version&quot;:[113,0],&quot;platform&quot;:&quot;mac&quot;,&quot;grade&quot;:&quot;A&quot;,&quot;platform_name&quot;:&quot;&quot;,&quot;platform_closed&quot;:false,&quot;download_difficulty&quot;:&quot;easy&quot;,&quot;media_mode&quot;:&quot;desktop&quot;,&quot;mobile_app_compatible&quot;:false},&quot;client_template_globals&quot;:{&quot;siteroot&quot;:&quot;http://bandcamp.com&quot;,&quot;siteroot_https&quot;:&quot;https://bandcamp.com&quot;,&quot;siteroot_current&quot;:&quot;https://bandcamp.com&quot;,&quot;static_siteroot&quot;:&quot;https://s4.bcbits.com&quot;,&quot;is_https&quot;:true,&quot;image_siteroot&quot;:&quot;https://f4.bcbits.com&quot;,&quot;image_siteroot_https&quot;:&quot;https://f4.bcbits.com&quot;,&quot;image_formats&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;original&quot;,&quot;resize_algo&quot;:&quot;original&quot;,&quot;file_format&quot;:null},{&quot;id&quot;:1,&quot;name&quot;:&quot;fullsize&quot;,&quot;resize_algo&quot;:&quot;scrub&quot;,&quot;file_format&quot;:&quot;original&quot;},{&quot;id&quot;:2,&quot;name&quot;:&quot;art_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:350,&quot;height&quot;:350,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:3,&quot;name&quot;:&quot;art_thumbthumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:100,&quot;height&quot;:100,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:4,&quot;name&quot;:&quot;art_embedded_metadata&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:300,&quot;height&quot;:300,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:5,&quot;name&quot;:&quot;art_embedded_metadata_large&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:6,&quot;name&quot;:&quot;art_embedded_player&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:100,&quot;height&quot;:100,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:7,&quot;name&quot;:&quot;art_embedded_player_large&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:150,&quot;height&quot;:150,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:8,&quot;name&quot;:&quot;art_tags&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:124,&quot;height&quot;:124,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:9,&quot;name&quot;:&quot;art_tags_large&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:210,&quot;height&quot;:210,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:10,&quot;name&quot;:&quot;screen&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1200,&quot;height&quot;:1200,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:11,&quot;name&quot;:&quot;art_tag_search&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:172,&quot;height&quot;:172,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:12,&quot;name&quot;:&quot;art_artist_index&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:138,&quot;height&quot;:138,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:13,&quot;name&quot;:&quot;art_solo_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:380,&quot;height&quot;:380,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:14,&quot;name&quot;:&quot;art_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:368,&quot;height&quot;:368,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:15,&quot;name&quot;:&quot;art_feed_new_release&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:135,&quot;height&quot;:135,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:16,&quot;name&quot;:&quot;art_app_large&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:70,&quot;minsize&quot;:{&quot;size&quot;:30000,&quot;format&quot;:5}},{&quot;id&quot;:20,&quot;name&quot;:&quot;bio_screen&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1024,&quot;height&quot;:1024,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:21,&quot;name&quot;:&quot;bio_thumb&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:120,&quot;height&quot;:180,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:22,&quot;name&quot;:&quot;bio_navbar&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:25,&quot;height&quot;:25,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:23,&quot;name&quot;:&quot;bio_phone&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:300,&quot;height&quot;:300,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:24,&quot;name&quot;:&quot;bio_licensing&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:300,&quot;height&quot;:300,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:25,&quot;name&quot;:&quot;bio_app&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:70},{&quot;id&quot;:26,&quot;name&quot;:&quot;bio_subscribe&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:800,&quot;height&quot;:600,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:27,&quot;name&quot;:&quot;bio_subscribe2&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:715,&quot;height&quot;:402,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:28,&quot;name&quot;:&quot;bio_featured&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:768,&quot;height&quot;:432,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:29,&quot;name&quot;:&quot;bio_autocomplete&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:100,&quot;height&quot;:75,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:31,&quot;name&quot;:&quot;package_screen&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1024,&quot;height&quot;:1024,&quot;file_format&quot;:&quot;original&quot;},{&quot;id&quot;:32,&quot;name&quot;:&quot;package_solo_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:380,&quot;height&quot;:285,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:33,&quot;name&quot;:&quot;package_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:368,&quot;height&quot;:276,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:36,&quot;name&quot;:&quot;package_page&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:400,&quot;height&quot;:300,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:37,&quot;name&quot;:&quot;package_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:168,&quot;height&quot;:126,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:38,&quot;name&quot;:&quot;package_thumb_small&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:144,&quot;height&quot;:108,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:41,&quot;name&quot;:&quot;fan_bio_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:210,&quot;height&quot;:210,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:42,&quot;name&quot;:&quot;fan_bio_thumb_small&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;height&quot;:50,&quot;width&quot;:50,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:43,&quot;name&quot;:&quot;fan_banner&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;height&quot;:100,&quot;width&quot;:99999,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:44,&quot;name&quot;:&quot;fan_banner_2x&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;height&quot;:200,&quot;width&quot;:99999,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:50,&quot;name&quot;:&quot;results_grid&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:140,&quot;height&quot;:140,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:65,&quot;name&quot;:&quot;tralbum_page_cover_art&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:70,&quot;minsize&quot;:{&quot;size&quot;:30000,&quot;format&quot;:69},&quot;anim_ok&quot;:true},{&quot;id&quot;:66,&quot;name&quot;:&quot;tralbum_page_cover_art_popup&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1200,&quot;height&quot;:1200,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:67,&quot;name&quot;:&quot;art_thumb_anim_ok&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:350,&quot;height&quot;:350,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:68,&quot;name&quot;:&quot;art_tags_large_anim_ok&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:210,&quot;height&quot;:210,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:69,&quot;name&quot;:&quot;art_embedded_metadata_large_anim_ok&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:70,&quot;name&quot;:&quot;tralbum_page_package_small&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:360,&quot;height&quot;:270,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;mozjpeg&quot;:true},{&quot;id&quot;:71,&quot;name&quot;:&quot;tralbum_page_package_large&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:720,&quot;height&quot;:540,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;mozjpeg&quot;:true},{&quot;id&quot;:100,&quot;name&quot;:&quot;custom_header_desktop&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:975,&quot;max_height&quot;:180,&quot;file_format&quot;:&quot;original&quot;,&quot;allow_transparency&quot;:true},{&quot;id&quot;:101,&quot;name&quot;:&quot;custom_header_paypal&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:750,&quot;height&quot;:90,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:120,&quot;name&quot;:&quot;custom_header_phone&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:640,&quot;max_height&quot;:124,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:130,&quot;name&quot;:&quot;design_background&quot;,&quot;resize_algo&quot;:&quot;scrub&quot;,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:140,&quot;name&quot;:&quot;subscribe_message&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:60,&quot;height&quot;:45,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:150,&quot;name&quot;:&quot;video_landscape&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:1280,&quot;height&quot;:720,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:151,&quot;name&quot;:&quot;video_portrait&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:720,&quot;height&quot;:1280,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:160,&quot;name&quot;:&quot;buy_full_email_thumb_montage&quot;,&quot;resize_algo&quot;:&quot;thumb_crop&quot;,&quot;width&quot;:60,&quot;height&quot;:100,&quot;left&quot;:40,&quot;top&quot;:0,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:161,&quot;name&quot;:&quot;buy_full_email_thumb_montage_release&quot;,&quot;resize_algo&quot;:&quot;thumb_crop&quot;,&quot;width&quot;:40,&quot;height&quot;:80,&quot;left&quot;:40,&quot;top&quot;:0,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:100},{&quot;id&quot;:165,&quot;name&quot;:&quot;ppp_email_gift_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb_composite&quot;,&quot;overlay_image&quot;:&quot;public/img/banner_email.png&quot;,&quot;x_offset&quot;:92,&quot;y_offset&quot;:0,&quot;width&quot;:210,&quot;height&quot;:210,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:100},{&quot;id&quot;:170,&quot;name&quot;:&quot;weekly_mobile_web&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:750,&quot;height&quot;:422,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:171,&quot;name&quot;:&quot;weekly_desktop&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1244,&quot;height&quot;:646,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:180,&quot;name&quot;:&quot;bcdaily_homepage_big&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1244,&quot;height&quot;:646,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:200,&quot;name&quot;:&quot;mobile_fan_banner_ios_3x&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1125,&quot;height&quot;:420,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:201,&quot;name&quot;:&quot;mobile_fan_banner_ios_2x&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:750,&quot;height&quot;:280,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:202,&quot;name&quot;:&quot;mobile_fan_banner_ios_1x&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:375,&quot;height&quot;:140,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:203,&quot;name&quot;:&quot;mobile_fan_banner_android_xxxhdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1125,&quot;height&quot;:420,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:204,&quot;name&quot;:&quot;mobile_fan_banner_android_xxhdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:960,&quot;height&quot;:360,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:205,&quot;name&quot;:&quot;mobile_fan_banner_android_xhdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:640,&quot;height&quot;:240,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:206,&quot;name&quot;:&quot;mobile_fan_banner_android_hdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:480,&quot;height&quot;:180,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:207,&quot;name&quot;:&quot;mobile_fan_banner_android_mdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:320,&quot;height&quot;:120,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:220,&quot;name&quot;:&quot;newsletter_artist_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:900,&quot;height&quot;:468,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:300,&quot;name&quot;:&quot;grayscale_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:350,&quot;height&quot;:350,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;filter&quot;:&quot;grayscale&quot;}],&quot;custom_domains_active&quot;:true,&quot;base_port_str&quot;:null,&quot;sitedomain&quot;:&quot;bandcamp.com&quot;},&quot;matches_base_domain&quot;:true,&quot;crumb&quot;:null,&quot;upload_info&quot;:null,&quot;endpoint_mobilized&quot;:true}" data-validators="{&quot;contact&quot;:{&quot;name&quot;:{&quot;req&quot;:true},&quot;email&quot;:{&quot;req&quot;:true,&quot;match&quot;:&quot;(^)([^\\s\\(\\)\&quot;&#39;/&gt;&lt;,@]+@\\w([^\\s\\(\\)\&quot;&#39;/&gt;&lt;&amp;,@]*\\w)?\\.\\w[^\\s\\(\\)\&quot;&#39;/&gt;&lt;&amp;,@]*\\w)($)&quot;,&quot;message&quot;:&quot;Invalid email address.&quot;},&quot;subject&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:300},&quot;message&quot;:{&quot;req&quot;:true,&quot;type&quot;:&quot;text&quot;,&quot;min&quot;:1,&quot;max&quot;:1999},&quot;attachment_0_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_0_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_1_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_1_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_2_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_2_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_3_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_3_data&quot;:{&quot;type&quot;:&quot;text&quot;},&quot;attachment_4_filename&quot;:{&quot;type&quot;:&quot;text&quot;,&quot;max&quot;:255},&quot;attachment_4_data&quot;:{&quot;type&quot;:&quot;text&quot;}}}" data-hide-params="[&quot;action&quot;,&quot;buy_id&quot;,&quot;no&quot;,&quot;permalink&quot;,&quot;from&quot;,&quot;pk&quot;,&quot;recipient&quot;,&quot;fan_id&quot;,&quot;showvid&quot;,&quot;label&quot;,&quot;tab&quot;,&quot;filter_band&quot;,&quot;campaign&quot;,&quot;newsletter_id&quot;,&quot;newsletter_sig&quot;,&quot;entry_type&quot;,&quot;entity_id&quot;,&quot;toast&quot;,&quot;toastref&quot;,&quot;toastband&quot;,&quot;search_page_id&quot;,&quot;search_page_no&quot;,&quot;search_rank&quot;,&quot;search_match_part&quot;,&quot;search_item_type&quot;,&quot;search_item_id&quot;,&quot;search_sig&quot;,&quot;logged_out_menubar&quot;,&quot;logged_in_menubar&quot;,&quot;logged_in_mobile_menubar&quot;,&quot;logged_out_mobile_menubar&quot;,&quot;corp_header&quot;]"></script>
+
+    
+    
+
+
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/tralbum_head-a9d32b65ead030b3357fb05ad0674e00.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" data-cart="{&quot;is_default&quot;:true,&quot;country&quot;:&quot;US&quot;,&quot;currency&quot;:&quot;USD&quot;,&quot;country_name&quot;:&quot;United States&quot;,&quot;probable_buyer_country&quot;:&quot;NL&quot;}" data-site="{&quot;supportEmail&quot;:&quot;support@arbee.bandcamp.com&quot;,&quot;is_custom_domain&quot;:null,&quot;env&quot;:&quot;prod&quot;}" data-band="{&quot;id&quot;:4038363339,&quot;name&quot;:&quot;arbee&quot;,&quot;fan_email&quot;:null,&quot;account_id&quot;:1320876912,&quot;facebook_like_enabled&quot;:1,&quot;has_discounts&quot;:true,&quot;image_id&quot;:14017}" data-embed="{&quot;tralbum_param&quot;:{&quot;name&quot;:&quot;album&quot;,&quot;value&quot;:948735258},&quot;art_id&quot;:1289075493,&quot;artist&quot;:&quot;arbee&quot;,&quot;swf_base_url&quot;:&quot;https://bandcamp.com&quot;,&quot;show_campaign&quot;:null,&quot;embed_info&quot;:{&quot;public_embeddable&quot;:false,&quot;exclusive_embeddable&quot;:false,&quot;item_public&quot;:true,&quot;no_track_preorder&quot;:false},&quot;album_title&quot;:&quot;Des papiers II&quot;,&quot;linkback&quot;:&quot;https://arbee.bandcamp.com/album/des-papiers-ii&quot;}" data-fan="{&quot;logged_in&quot;:false,&quot;name&quot;:null,&quot;image_id&quot;:null}" data-band-follow-info="{&quot;tralbum_id&quot;:948735258,&quot;tralbum_type&quot;:&quot;a&quot;}" data-tralbum-collect-info="{&quot;show_collect&quot;:null,&quot;show_wishlist_tooltip&quot;:false}" data-tralbum="{&quot;for the curious&quot;:&quot;https://bandcamp.com/help/audio_basics#steal https://bandcamp.com/terms_of_use&quot;,&quot;current&quot;:{&quot;audit&quot;:5,&quot;title&quot;:&quot;Des papiers II&quot;,&quot;new_date&quot;:&quot;01 May 2025 01:54:43 GMT&quot;,&quot;mod_date&quot;:&quot;01 May 2025 01:56:42 GMT&quot;,&quot;publish_date&quot;:&quot;01 May 2025 01:56:42 GMT&quot;,&quot;private&quot;:null,&quot;killed&quot;:null,&quot;download_pref&quot;:2,&quot;require_email&quot;:null,&quot;is_set_price&quot;:null,&quot;set_price&quot;:9.0,&quot;minimum_price&quot;:9.0,&quot;minimum_price_nonzero&quot;:9.0,&quot;require_email_0&quot;:null,&quot;artist&quot;:null,&quot;about&quot;:&quot;Des papiers II.\r\n\r\nSubscriber-exclusive ambient.&quot;,&quot;credits&quot;:null,&quot;auto_repriced&quot;:null,&quot;new_desc_format&quot;:1,&quot;band_id&quot;:4038363339,&quot;selling_band_id&quot;:4038363339,&quot;art_id&quot;:1289075493,&quot;download_desc_id&quot;:null,&quot;release_date&quot;:&quot;30 Apr 2025 00:00:00 GMT&quot;,&quot;upc&quot;:null,&quot;purchase_url&quot;:null,&quot;purchase_title&quot;:null,&quot;featured_track_id&quot;:3305703503,&quot;id&quot;:948735258,&quot;type&quot;:&quot;album&quot;},&quot;preorder_count&quot;:null,&quot;hasAudio&quot;:true,&quot;art_id&quot;:1289075493,&quot;packages&quot;:null,&quot;defaultPrice&quot;:9.0,&quot;freeDownloadPage&quot;:null,&quot;FREE&quot;:1,&quot;PAID&quot;:2,&quot;artist&quot;:&quot;arbee&quot;,&quot;item_type&quot;:&quot;album&quot;,&quot;id&quot;:948735258,&quot;last_subscription_item&quot;:null,&quot;has_discounts&quot;:false,&quot;is_bonus&quot;:false,&quot;play_cap_data&quot;:{&quot;streaming_limits_enabled&quot;:false,&quot;streaming_limit&quot;:3},&quot;is_purchased&quot;:null,&quot;items_purchased&quot;:null,&quot;is_private_stream&quot;:null,&quot;is_band_member&quot;:null,&quot;licensed_version_ids&quot;:null,&quot;package_associated_license_id&quot;:null,&quot;has_video&quot;:null,&quot;tralbum_subscriber_only&quot;:true,&quot;featured_track_id&quot;:3305703503,&quot;initial_track_num&quot;:null,&quot;is_preorder&quot;:false,&quot;album_is_preorder&quot;:false,&quot;album_release_date&quot;:&quot;30 Apr 2025 00:00:00 GMT&quot;,&quot;trackinfo&quot;:[{&quot;id&quot;:3305703503,&quot;track_id&quot;:3305703503,&quot;file&quot;:null,&quot;artist&quot;:null,&quot;title&quot;:&quot;Des papiers II&quot;,&quot;encodings_id&quot;:1048994955,&quot;license_type&quot;:1,&quot;private&quot;:null,&quot;track_num&quot;:1,&quot;album_preorder&quot;:false,&quot;unreleased_track&quot;:false,&quot;title_link&quot;:&quot;/track/des-papiers-ii&quot;,&quot;has_lyrics&quot;:false,&quot;has_info&quot;:false,&quot;streaming&quot;:1,&quot;is_downloadable&quot;:true,&quot;has_free_download&quot;:null,&quot;free_album_download&quot;:false,&quot;duration&quot;:181.519,&quot;lyrics&quot;:null,&quot;sizeof_lyrics&quot;:0,&quot;is_draft&quot;:false,&quot;video_source_type&quot;:null,&quot;video_source_id&quot;:null,&quot;video_mobile_url&quot;:null,&quot;video_poster_url&quot;:null,&quot;video_id&quot;:null,&quot;video_caption&quot;:null,&quot;video_featured&quot;:null,&quot;alt_link&quot;:null,&quot;encoding_error&quot;:null,&quot;encoding_pending&quot;:null,&quot;play_count&quot;:null,&quot;is_capped&quot;:null,&quot;track_license_id&quot;:null}],&quot;playing_from&quot;:&quot;album page&quot;,&quot;url&quot;:&quot;https://arbee.bandcamp.com/album/des-papiers-ii&quot;,&quot;use_expando_lyrics&quot;:false}" data-payment="{&quot;paymentType&quot;:null,&quot;paymentDownloadPage&quot;:null}" data-referrer-token="null"></script>
+
+    
+    
+
+    
+
+</head>
+
+
+
+
+<body class="gecko mac enable-cookie-control invertIconography has-menubar has-rec-footer tralbum-clearfix tralbum-page has-corpbanner2 " lang="en">
+
+
+
+<svg height="0" width="0" style="position:absolute;margin-left:-100%">
+    <path id="tweet" d="M16.1 3.5a9.6 9.6 0 01-1.7 6c-.6.9-1.3 1.6-2.1 2.3-.8.7-1.8 1.2-2.9 1.6-1.2.4-2.4.6-3.7.6-2.2 0-4.1-.6-5.7-1.6 2.5.2 4.1-.5 5.5-1.5-1.7 0-3-1.1-3.4-2.4.5.1 1.3 0 1.7-.1-1.5-.3-3-1.7-3-3.5.3.2.9.4 1.7.4C1.5 4.8.8 3.7.8 2.4c0-.6.2-1.4.5-1.8 1.7 2 4.4 3.6 7.6 3.7C8.3 1.4 10.6 0 12.5 0c1.1 0 2 .4 2.7 1.1.8-.1 1.6-.4 2.3-.8-.3.8-.8 1.5-1.6 1.9.7-.1 1.4-.2 2.1-.5-.5.7-1.1 1.3-1.9 1.8z"/>
+    <path id="buy-for-friend" d="M3.5 4h7c1.8-.3 2.4-1.9 2-2.9S10.7-.5 9.3.5 7 3 7 3 6.1 1.5 4.7.5s-2.8-.4-3.2.6.2 2.6 2 2.9zm6.8-3c.9-.2 1.6.1 1.3 1.1-.3 1.2-2.6 1.3-3.8 1.3 0 0 1.6-2.2 2.5-2.4zM3.8 1c1.1.4 2.4 2.4 2.4 2.4-1.3 0-3.4-.3-3.8-1.3C2 1.1 3 .8 3.8 1zM0 9h6V5H0v4zm7-4v4h7V5H7zm0 9h6v-4H7v4zm-6 0h5v-4H1v4z"/>
+    <path id="edit-profile-info" d="M10 10.5c0 .3-.2.5-.5.5h-8c-.3 0-.5-.2-.5-.5v-8c0-.3.2-.5.5-.5h3.7V1H1.5C.7 1 0 1.7 0 2.5v8c0 .8.7 1.5 1.5 1.5h8c.8 0 1.5-.7 1.5-1.5V7h-1v3.5zm2-9.1L10.5 0 6.4 4.4l-.6 2.2L8 5.7l4-4.3z"/>
+    <path id="fb-logo-share-profile" d="M3.9 12V6.3h1.8L6 4.2H4V2.9c0-.6.2-1 1-1h1.1V.1C5.8.1 5.2 0 4.4 0 2.8 0 1.8 1 1.8 2.7v1.5H0v2.1h1.8V12h2.1z"/>
+    <path id="following-checkmark" d="M4.3 10.7L0 5.8l1.5-1.3 2.8 3.1L11 0l1.5 1.3z"/>
+    <path id="follow-plus" d="M8 3H5V0H3v3H0v2h3v3h2V5h3z"/>
+    <path id="share-profile" d="M10.7.2s-.1-.1 0 0l-.4-.2h-.1L2.5 4.8.3 8.1v.1s0 .1.1.1l3.3.9h.1l5.1-6.5-3.3 7 .9 2.2.1.1s.1 0 .1-.1l.9-1.5 2.8.9.1-.1L11.8 7 10.7.2z"/>
+    <path id="search-magnifier" d="M10.1 10.4l-1.4-2C9.5 7.5 10 6.3 10 5c0-2.8-2.2-5-5-5S0 2.2 0 5s2.2 5 5 5c.7 0 1.4-.1 2-.4l1.5 2c.3.4 1 .5 1.4.2.4-.3.5-.9.2-1.4zM5 9C2.8 9 1 7.2 1 5s1.8-4 4-4 4 1.8 4 4-1.8 4-4 4z"/>
+    <path id="close-search-results" d="M8 .7L7.3 0 4 3.3.7 0 0 .7 3.3 4 0 7.3l.7.7L4 4.7 7.3 8l.7-.7L4.7 4z"/>
+    <path id="camera-icon" d="M26 2h-4a2 2 0 00-2-2H8a2 2 0 00-2 2H2a2 2 0 00-2 2v14a2 2 0 002 2h24a2 2 0 002-2V4a2 2 0 00-2-2zM14 17a6 6 0 116-6 6 6 0 01-6 6zm1-10h-2v3h-3v2h3v3h2v-3h3v-2h-3z"/>
+    <g id="search-spinner">
+        <circle class="st1" cx="7" cy="1.5" r="1.5"/>
+        <circle class="st2" transform="rotate(-45 10.89 3.11)" cx="10.9" cy="3.1" r="1.5"/>
+        <circle class="st3" cx="12.5" cy="7" r="1.5"/>
+        <circle class="st4" transform="rotate(-45 10.89 10.89)" cx="10.9" cy="10.9" r="1.5"/>
+        <circle class="st5" cx="7" cy="12.5" r="1.5"/>
+        <circle class="st6" transform="rotate(-45 3.11 10.89)" cx="3.1" cy="10.9" r="1.5"/>
+        <circle class="st8" transform="rotate(-45 3.11 3.11)" cx="3.1" cy="3.1" r="1.5"/>
+        <circle class="st7" cx="1.5" cy="7" r="1.5"/>
+    </g>
+    <path id="mobile-web-collection-arrow" d="M20.3 17.3L3 0 .3 2.7 17.7 20 .3 37.3 3 40l17.3-17.3L23 20z"/>
+    <path id="homepage-mobile-arrow" d="M12.9 11L2.1.1 0 2.2l10.8 10.9L0 24l2.1 2.1 10.8-10.9 2.1-2.1z"/>
+    <path id="collect-control-wishlist" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1zm-4-7.1c1.8 1.6 3.2 3.1 4 4 .8-.9 2.2-2.4 3.9-4 3.1-2.8 4.7-5.2 4.7-7.1 0-1-.4-1.9-1.3-2.7-1-.8-1.9-1.2-2.9-1-2 .3-3.6 2.7-3.6 2.7l-.9 1.4-.8-1.5S8.3 2.3 6.3 1.9c-1-.2-2 .2-3.1 1.1-.9.9-1.3 1.9-1.2 2.9 0 2 1.6 4.3 4.5 7z"/>
+    <path id="collect-control-purchased" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1z"/>
+    <path id="collect-control-wishlisted" d="M10.5 20l-.8-.9s-1.9-2.3-4.6-4.7C1.8 11.2.1 8.5 0 6c0-1.6.6-3 1.8-4.3C3.4.3 5-.2 6.6.1c1.8.3 3.1 1.6 3.9 2.5.9-1 2.3-2.2 4.1-2.5 1.6-.2 3 .3 4.5 1.5 1.3 1.2 2 2.6 2 4.1 0 2.5-1.7 5.3-5.3 8.6a44.6 44.6 0 00-4.4 4.7l-.9 1z"/>
+    <path id="facebook-like" d="M2 0h12c1.15 0 2 .85 2 2v12c0 1.15-.85 2-2 2h-3.49V9.83h2.06l.34-2.52h-2.4V5.83c0-.34.12-.69.23-.8.12-.23.46-.34.92-.34h1.25V2.5c-.45-.11-1.02-.11-1.82-.11-.92 0-1.72.23-2.29.8-.57.57-.8 1.37-.8 2.4v1.83H5.94v2.4H8V16H2c-1.15 0-2-.85-2-2V2C0 .85.85 0 2 0z"/>
+    <path id="format-dropdown" d="M10 0L5 6 0 0z"/>
+    <path id="direct-download" d="M11.7 7.3c-.4-.4-1-.4-1.4 0L7 10.6V1c0-.5-.5-1-1-1S5 .5 5 1v9.6L1.7 7.3c-.4-.4-1-.4-1.4 0s-.4 1 0 1.4l5 5c.2.2.4.3.7.3.4 0 .5-.1.7-.3l5-5c.4-.4.4-1 0-1.4zM10 15H2c-.5 0-1 .5-1 1s.5 1 1 1h8c.5 0 1-.5 1-1s-.5-1-1-1z"/>
+    <path id="mobile-gift-ribbon" class="st0" d="M46.3 0C37.4 0 31.1 8.3 28 13.5 24.9 8.3 18.6 0 9.7 0 4.1 0 0 3.5 0 8.2 0 16.6 12.2 22 27.7 22 43.9 22 56 15 56 8.3c0-1.3-.3-2.6-1-3.8C53.5 1.7 50.2 0 46.3 0zM9.6 12.8c-3.1-1.6-3.9-3.1-3.9-4.6 0-1.5 1.5-3.1 4-3.1 6 0 10.8 6.6 13.4 10.9-6.9-.5-11.1-2-13.5-3.2zm37.3-.3c-2.8 1.6-7.4 3-14 3.4C35.5 11.6 40.1 5 46.1 5c2.1 0 4 .9 4 3 0 1.9-1.6 3.6-3.2 4.5z"/>
+    <path id="grab-app" d="M20.8 25c-.8-.8-2-.8-2.8 0-.8.8-.8 2 0 2.8l7.2 7.2H2a2 2 0 00-2 2c0 1.1.9 2 2 2h23.2L18 46.2c-.8.8-.8 2 0 2.8.8.8 2 .8 2.8 0l10.6-10.6c.3-.3.6-.8.6-1.4 0-.6-.3-1.1-.6-1.4L20.8 25zM77.6 0h-26C46 0 41 4 41 9.5v56C41 71 46 76 51.6 76h26c5.5 0 9.4-5 9.4-10.5v-56C87 4 83.1 0 77.6 0zM84 65.5c0 3.9-2.6 7.5-6.4 7.5h-26c-3.9 0-7.6-3.6-7.6-7.5V56h40v9.5zM84 53H44V17h40v36zm0-39H44V9.5C44 5.6 47.7 3 51.6 3h26C81.4 3 84 5.6 84 9.5V14zM64 67c1.7 0 3-1.3 3-3s-1.3-3-3-3-3 1.3-3 3 1.4 3 3 3z"/>
+    <path id="play-app" d="M1 60c-.2 0-.3 0-.5-.1-.3-.2-.5-.5-.5-.9V1C0 .6.2.3.5.1c.4-.1.8-.1 1.1.1l42 29c.3.2.4.5.4.8s-.2.6-.4.8l-42 29c-.2.2-.4.2-.6.2zM2 2.9v54.2L41.3 30 2 2.9z"/>
+    <path id="play-app-2" d="M18.55 16L2.97 5.61V26.4L18.55 16zM0 32V0l24 16L0 32z"/>
+    <g id="grab-app-opensignup" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="collection" transform="translate(-67 -505)" fill="#FFF">
+            <g id="mweb-phone-icon-outline" transform="translate(67 505)">
+                <path d="M21.16 3.99v28.02a3 3 0 003 2.99h13.99a3 3 0 003-2.99V3.99a3 3 0 00-3-2.99H24.17a3 3 0 00-3.01 2.99zm-1 0a4 4 0 014-3.99h13.99a4 4 0 014 3.99v28.02a4 4 0 01-4 3.99H24.17a4 4 0 01-4.01-3.99V3.99z" id="Rectangle-1270"/>
+                <rect id="Rectangle-1271" x="29.41" y="29.73" width="2.5" height="2.5" rx="1.25"/>
+                <path d="M20.66 8.23h21v-1h-21v1zm0 19h21v-1h-21v1z" id="Combined-Shape"/>
+                <path d="M.29 18.44c0 .36.31.67.68.67h11.62L8.86 23.3a.72.72 0 000 .99l.36.41c.26.26.68.26.94 0l5.89-6.05a.72.72 0 000-1L9.96 11.3a.66.66 0 00-.94 0l-.36.41a.72.72 0 000 1l3.9 4.43H.96a.69.69 0 00-.67.67v.63z" id="→"/>
+            </g>
+        </g>
+    </g>
+    <g id="has-app">
+        <path class="has-app-phone" d="M18 56a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2zM29 0H7C3.1 0 0 3.1 0 7v48c0 3.9 3.1 7 7 7h22c3.9 0 7-3.1 7-7V7c0-3.9-3.1-7-7-7zm5 55c0 2.8-2.2 5-5 5H7c-2.8 0-5-2.2-5-5v-6h32v6zm0-8H2V12h32v35zm0-37H2V7c0-2.8 2.2-5 5-5h22c2.8 0 5 2.2 5 5v3z"/>
+        <path class="has-app-confirm" d="M18 18c-6.4 0-11.5 5.1-11.5 11.5S11.6 41 18 41s11.5-5.1 11.5-11.5S24.4 18 18 18zm5.3 9.6l-5.8 5.8c-.3.3-.7.4-1.1.4-.4 0-.8-.1-1.1-.4l-2.6-2.6c-.6-.6-.6-1.5 0-2.1s1.5-.6 2.1 0l1.6 1.6 4.8-4.8c.6-.6 1.5-.6 2.1 0 .6.6.6 1.6 0 2.1z"/>
+    </g>
+    <g id="no-app">
+        <path class="no-app-phone" d="M18 56a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2zM29 0H7C3.1 0 0 3.1 0 7v48c0 3.9 3.1 7 7 7h22c3.9 0 7-3.1 7-7V7c0-3.9-3.1-7-7-7zm5 55c0 2.8-2.2 5-5 5H7c-2.8 0-5-2.2-5-5v-6h32v6zm0-8H2V12h32v35zm0-37H2V7c0-2.8 2.2-5 5-5h22c2.8 0 5 2.2 5 5v3z"/>
+        <path class="no-app-bc-logo" d="M14 23L7 36h15l7-13z"/>
+    </g>
+    <g id="signup-promo-icon">
+        <path id="signup-phone-background" d="M25 52H5c-2.8 0-5-2.2-5-5V5c0-2.8 2.2-5 5-5h20c2.8 0 5 2.2 5 5v42c0 2.8-2.2 5-5 5z"/>
+        <g id="signup-promo-phone">
+            <path class="signup-phone-icon" d="M25 0H5C2.2 0 0 2.2 0 5v42c0 2.8 2.2 5 5 5h20c2.8 0 5-2.2 5-5V5c0-2.8-2.2-5-5-5zm3 47c0 1.7-1.3 3-3 3H5c-1.7 0-3-1.3-3-3v-6h26v6zm0-8H2V10h26v29zm0-31H2V5c0-1.7 1.3-3 3-3h20c1.7 0 3 1.3 3 3v3zM15 47a2 2 0 002-2c0-1.1-.9-2-2-2s-2 .9-2 2 .9 2 2 2z"/>
+            <path class="signup-bc-logo" d="M11.6 19L5.7 30h12.7l5.9-11z"/>
+        </g>
+    </g>
+    <path id="format-dropdown-selected" d="M8.6.3C8.2-.1 7.5-.1 7 .3L3.4 4 2 2.5c-.4-.4-1.2-.4-1.6 0-.4.4-.4 1.2 0 1.6l2.2 2.2c.2.2.5.3.8.3.3 0 .6-.1.8-.3L8.6 2c.5-.5.5-1.2 0-1.7z"/>
+    <defs>
+        <linearGradient id="ribbon-gradient" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stop-color="#00BAEF"/>
+            <stop offset="90%" stop-color="#1DA0C3"/>
+        </linearGradient>
+    </defs>
+    <path id="rarr-ico" d="M5 5L0 9l2 1 6-5-6-5-2 1 5 4z"/>
+    <path id="larr-ico" d="M5 5L0 9l2 1 6-5-6-5-2 1 5 4z" transform="rotate(-180 4 5)"/>
+    <path d="M2.57 0L.44 2.13 7.31 9 .43 15.87 2.56 18l9-9z" transform="rotate(-180 7.5 9)" id="larr-onboarding-ico"/>
+    <g id="rarr-onboarding-ico" transform="translate(3)">
+        <path id="Fill-2" d="M2.57 0L.44 2.13 7.31 9 .43 15.87 2.56 18l9-9z"/>
+    </g>
+    <path d="M0 3h3v3H0V3zm6 0l2-1-2-2-1.5 2.3L3 0 1 2l2 1h1v3h5V3H6zm-5 7h2V7H1v3zm3 0h4V7H4v3z" id="gift-card-icon"/>
+    <path id="not-shipped" d="M7.9 0L4.75 3.16 1.58 0 0 1.58l3.16 3.17L0 7.9l1.58 1.58 3.16-3.16 3.17 3.16 1.58-1.58-3.16-3.16 3.16-3.17z"/>
+    <path id="checkmark-shipped" d="M4.66 6.5L1.38 3.37 0 4.8l3.28 3.14 1.18 1.12.26.26 7.6-7.95L10.89 0z"/>
+    <path fill-rule="evenodd" d="M11.82 21.35a60.6 60.6 0 011.25 1.4 42.86 42.86 0 011.21-1.4 56.68 56.68 0 014.18-4.24c5.95-5.4 8.04-9.93 4.2-13.42-2.69-2.35-5.25-1.9-7.63.34a11.2 11.2 0 00-1.62 1.92l-.46.73-.4-.75a10.42 10.42 0 00-1.5-1.97c-2.28-2.32-4.85-2.78-7.72-.3-3.62 3.7-1.54 8.23 4.22 13.45a69.17 69.17 0 014.27 4.24zm1.21-16.6c.38-.5.82-.99 1.31-1.45 2.72-2.55 5.84-3.1 8.99-.35 4.49 4.07 2.15 9.14-4.2 14.9a55.69 55.69 0 00-5.65 5.99l-.38.49-.4-.48c-.07-.1-.21-.26-.42-.5a68.18 68.18 0 00-5.4-5.5C.74 12.28-1.57 7.24 2.64 2.94 6 .04 9.14.6 11.75 3.26A11.4 11.4 0 0113 4.79l.03-.04z" id="menubar-collection-icon"/>
+    <path fill-rule="evenodd" d="M14.4.87a1 1 0 011.77.77l-1.1 7.84h6.46a1 1 0 01.74 1.68L9.24 25.2a1 1 0 01-1.72-.85L9 15.56H4.5a1 1 0 01-.77-1.63L14.4.87zm.78.63L4.5 14.57H9a1 1 0 01.98 1.16l-1.47 8.8 13.02-14.05h-6.47a1 1 0 01-.99-1.14l1.11-7.84z" id="menubar-feed-icon"/>
+    <path d="M21.38 19.44a.13.13 0 01-.12.07H1.13a.12.12 0 01-.11-.07.33.33 0 01-.03-.09l3.27-4.15c.37-.59.57-1.27.57-1.97V7.67C4.83 4.09 7.6 1.1 11 1h.2c1.66 0 3.23.63 4.43 1.8a6.33 6.33 0 011.94 4.58v5.85c0 .7.2 1.38.6 2.01l3.2 4.05c.03.06.02.11 0 .15m-7.45 1.32a2.73 2.73 0 01-5.46 0c0-.09.03-.17.03-.25h5.4c.01.08.03.16.03.25m8.27-2.04L19 14.67a2.66 2.66 0 01-.42-1.44V7.38A7.36 7.36 0 0010.98 0C7.03.11 3.83 3.55 3.83 7.66v5.56c0 .51-.15 1-.39 1.4L.17 18.78c-.22.36-.23.79-.02 1.15.2.36.57.58.98.58H7.5c0 .08-.03.16-.03.25a3.73 3.73 0 007.46 0c0-.09-.02-.17-.03-.25h6.36a1.14 1.14 0 00.94-1.78" id="menubar-messages-icon" fill-rule="evenodd"/>
+    <path fill-rule="evenodd" d="M11.43 19.7a9.02 9.02 0 008.93-9.1c0-5.03-4-9.1-8.93-9.1a9.02 9.02 0 00-8.93 9.1c0 5.03 4 9.1 8.93 9.1zm6.95-1.9l6 6.87c.44.5-.32 1.16-.76.66l-5.98-6.85a9.78 9.78 0 01-6.21 2.22c-5.49 0-9.93-4.52-9.93-10.1S5.94.5 11.43.5c5.48 0 9.93 4.52 9.93 10.1 0 2.82-1.14 5.37-2.98 7.2z" id="menubar-search-icon"/>
+    <path d="M10.7 10.47l3.74 4.2c.44.5-.3 1.16-.75.66l-3.73-4.2c-.44-.5.3-1.16.75-.66zM6.6 11.7a5.1 5.1 0 100-10.2 5.1 5.1 0 000 10.2zm0 1A6.1 6.1 0 116.6.5a6.1 6.1 0 010 12.2z" id="menubar-search-input-icon"/>
+    <g id="menubar-cart-icon" fill-rule="evenodd">
+        <path d="M21.5 25a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"/>
+        <circle cx="8.5" cy="23.5" r="1.5" opacity=".9"/>
+        <path fill-rule="nonzero" d="M4.57 2H.5a.5.5 0 010-1h4.48a.5.5 0 01.5.4l.5 2.7 18.52.18c.31 0 .54.28.5.58l-2.28 13.72a.5.5 0 01-.49.42H8.16a.5.5 0 01-.49-.4L4.57 2zm1.6 3.1L8.57 18h13.24l2.1-12.73L6.17 5.1z"/>
+    </g>
+    <g id="menubar-phone-menu-icon">
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 6.25H3V4.75H21V6.25Z" fill="#222222"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 12.75H3V11.25H21V12.75Z" fill="#222222"/>
+        <path fill-rule="evenodd" clip-rule="evenodd" d="M21 19.75L3 19.75V18.25H12L21 18.25V19.75Z" fill="#222222"/>
+    </g>
+    <g id="bandcamp-logo-color-bcaqua">
+        <path d="M26.62 0h2.42v5.8h.04a3.96 3.96 0 013.28-1.78c3.46 0 5.14 2.73 5.14 6.05C37.5 13.12 36 16 32.76 16c-1.49 0-3.08-.37-3.8-1.87h-.05v1.57h-2.3V0m5.43 6c-2.04 0-3.08 1.6-3.08 4.02 0 2.29 1.12 4 3.08 4 2.2 0 3.04-2.02 3.04-4 0-2.06-1.05-4.02-3.04-4.02" id="b" fill="#333"/>
+        <path d="M56.26 4.05c-1.44 0-2.7.77-3.42 2.03l-.04-.05V4.36h-2.3v9.68l-1.61.01c-.45 0-.58-.24-.58-.85V7.35c0-2.4-2.25-3.3-4.4-3.3-2.42 0-4.82.86-4.99 3.78h2.42c.11-1.23 1.07-1.8 2.43-1.8.97 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.87 1.38.4 0 1.17-.15 4.96-.28v-.03h.02v-6.7c0-1.67 1.04-2.99 2.65-2.99 1.42 0 2.1.77 2.15 2.55v7.14h2.42v-7.8c0-2.55-1.5-3.87-3.88-3.87zM45.9 11.9c0 1.58-1.66 2.15-2.72 2.15-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87z" id="an" fill="#333"/>
+        <path d="M72.62 15.7h-2.29v-1.54h-.04c-.64 1.3-2.02 1.84-3.4 1.84-3.47 0-5.14-2.66-5.14-6.06 0-4.12 2.35-5.92 4.76-5.92 1.38 0 2.9.53 3.65 1.78h.04V0h2.43v15.7m-5.42-1.68c2.16 0 3.08-2.04 3.08-4.02 0-2.5-1.17-4-3.04-4-2.27 0-3.08 2.09-3.08 4.13 0 1.96.93 3.9 3.04 3.9" id="d" fill="#333"/>
+        <path d="M82.25 8.16c-.19-1.38-1.17-2.13-2.5-2.13-1.26 0-3.02.68-3.02 4.13 0 1.9.8 3.9 2.9 3.9 1.41 0 2.39-.97 2.62-2.6h2.42c-.44 2.95-2.2 4.57-5.03 4.57-3.44 0-5.34-2.53-5.34-5.87 0-3.43 1.81-6.1 5.42-6.1 2.55 0 4.72 1.31 4.95 4.1h-2.41" id="c" fill="#333"/>
+        <path d="M106.44 5.94c-.5-1.3-1.75-1.89-3.09-1.89-1.74 0-2.65.77-3.37 1.9l-.07-1.59h-2.3v9.68l-1.61.01c-.45 0-.57-.24-.57-.85V7.35c0-2.4-2.26-3.3-4.4-3.3-2.42 0-4.83.86-5 3.78h2.43c.1-1.23 1.06-1.8 2.42-1.8.98 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.88 1.38.4 0 1.16-.15 4.92-.28l.05-6.77c0-1.9 1.15-2.95 2.4-2.95 1.47 0 1.93.84 1.93 2.4v7.3h2.43V9.05c0-1.9.7-3.03 2.33-3.03 1.9 0 2 1.25 2 3.06v6.63h2.42V7.88c0-2.77-1.36-3.83-3.67-3.83-1.6 0-2.64.73-3.44 1.9zm-16.15 8.11c-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87c0 1.58-1.66 2.15-2.72 2.15z" id="am" fill="#333"/>
+        <path d="M118.04 4.36V5.9h.04c.68-1.3 2-1.85 3.4-1.85 3.46 0 5.14 2.73 5.14 6.05 0 3.05-1.48 5.93-4.74 5.93-1.4 0-2.9-.53-3.67-1.78h-.05v5.67h-2.42V4.36h2.3zm.04 5.7c0 2.28 1.13 4 3.08 4 2.21 0 3.04-2.03 3.04-4 0-2.07-1.04-4.03-3.04-4.03-2.04 0-3.08 1.6-3.08 4.02z" id="p" fill="#333"/>
+        <path id="rhomboid" fill="#1DA0C3" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"/>
+    </g>
+    <g id="bandcamp-logo-color-white" fill="#FFF">
+        <path d="M26.62 0h2.42v5.8h.04a3.96 3.96 0 013.28-1.78c3.46 0 5.14 2.73 5.14 6.05C37.5 13.12 36 16 32.76 16c-1.49 0-3.08-.37-3.8-1.87h-.05v1.57h-2.3V0m5.43 6c-2.04 0-3.08 1.6-3.08 4.02 0 2.29 1.12 4 3.08 4 2.2 0 3.04-2.02 3.04-4 0-2.06-1.05-4.02-3.04-4.02" id="b"/>
+        <path d="M56.26 4.05c-1.44 0-2.7.77-3.42 2.03l-.04-.05V4.36h-2.3v9.68l-1.61.01c-.45 0-.58-.24-.58-.85V7.35c0-2.4-2.25-3.3-4.4-3.3-2.42 0-4.82.86-4.99 3.78h2.42c.11-1.23 1.07-1.8 2.43-1.8.97 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.87 1.38.4 0 1.17-.15 4.96-.28v-.03h.02v-6.7c0-1.67 1.04-2.99 2.65-2.99 1.42 0 2.1.77 2.15 2.55v7.14h2.42v-7.8c0-2.55-1.5-3.87-3.88-3.87zM45.9 11.9c0 1.58-1.66 2.15-2.72 2.15-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87z" id="an"/>
+        <path d="M72.62 15.7h-2.29v-1.54h-.04c-.64 1.3-2.02 1.84-3.4 1.84-3.47 0-5.14-2.66-5.14-6.06 0-4.12 2.35-5.92 4.76-5.92 1.38 0 2.9.53 3.65 1.78h.04V0h2.43v15.7m-5.42-1.68c2.16 0 3.08-2.04 3.08-4.02 0-2.5-1.17-4-3.04-4-2.27 0-3.08 2.09-3.08 4.13 0 1.96.93 3.9 3.04 3.9" id="d"/>
+        <path d="M82.25 8.16c-.19-1.38-1.17-2.13-2.5-2.13-1.26 0-3.02.68-3.02 4.13 0 1.9.8 3.9 2.9 3.9 1.41 0 2.39-.97 2.62-2.6h2.42c-.44 2.95-2.2 4.57-5.03 4.57-3.44 0-5.34-2.53-5.34-5.87 0-3.43 1.81-6.1 5.42-6.1 2.55 0 4.72 1.31 4.95 4.1h-2.41" id="c"/>
+        <path d="M106.44 5.94c-.5-1.3-1.75-1.89-3.09-1.89-1.74 0-2.65.77-3.37 1.9l-.07-1.59h-2.3v9.68l-1.61.01c-.45 0-.57-.24-.57-.85V7.35c0-2.4-2.26-3.3-4.4-3.3-2.42 0-4.83.86-5 3.78h2.43c.1-1.23 1.06-1.8 2.42-1.8.98 0 2.27.24 2.27 1.54 0 1.47-1.55 1.27-3.3 1.6-2.03.25-4.22.7-4.22 3.54 0 2.22 1.78 3.32 3.76 3.32 1.3 0 2.85-.42 3.8-1.38.2 1.03.9 1.38 1.88 1.38.4 0 1.16-.15 4.92-.28l.05-6.77c0-1.9 1.15-2.95 2.4-2.95 1.47 0 1.93.84 1.93 2.4v7.3h2.43V9.05c0-1.9.7-3.03 2.33-3.03 1.9 0 2 1.25 2 3.06v6.63h2.42V7.88c0-2.77-1.36-3.83-3.67-3.83-1.6 0-2.64.73-3.44 1.9zm-16.15 8.11c-.85 0-2.24-.33-2.24-1.45 0-1.32.94-1.71 1.98-1.89 1.06-.2 2.23-.17 2.98-.68v1.87c0 1.58-1.66 2.15-2.72 2.15z" id="am"/>
+        <path d="M118.04 4.36V5.9h.04c.68-1.3 2-1.85 3.4-1.85 3.46 0 5.14 2.73 5.14 6.05 0 3.05-1.48 5.93-4.74 5.93-1.4 0-2.9-.53-3.67-1.78h-.05v5.67h-2.42V4.36h2.3zm.04 5.7c0 2.28 1.13 4 3.08 4 2.21 0 3.04-2.03 3.04-4 0-2.07-1.04-4.03-3.04-4.03-2.04 0-3.08 1.6-3.08 4.02z" id="p"/>
+        <path id="rhomboid" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"/>
+    </g>
+    <g id="bandcamp-rhomboid-white">
+        <path id="rhomboid" fill="#FFF" d="M0 15.63L8.47 0H26.6l-8.47 15.63z"/>
+    </g>
+    <g id="mobile-cart-up">
+        <path fill="#fff" stroke="#eee" d="M5 12L16 1h0l11 11"/>
+        <path fill="none" id="blocking" stroke="#fff" stroke-width="2" d="M4.5 12H27"/>
+    </g>
+    <defs>
+        <linearGradient x1="50%" y1="100%" x2="50%" y2="0%" id="fanAppGradient">
+            <stop stop-color="#00BAEF" offset="0%"/>
+            <stop stop-color="#1DA0C3" offset="100%"/>
+        </linearGradient>
+    </defs>
+    <g id="fan-app-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="mobileweb-fanartist-02" transform="translate(-86 -385)">
+            <g id="Group">
+                <g id="menu" transform="translate(58 39)">
+                    <g id="fan-app-icon" transform="translate(28 346)">
+                        <rect id="bg" fill="#FFF" x="0" y="0" width="23" height="23" rx="3"/>
+                        <path id="tent" fill="url(#fanAppGradient)" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <g id="artist-app-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="mobileweb-fanartist-02" transform="translate(-86 -334)">
+            <g id="Group">
+                <g id="menu" transform="translate(58 39)">
+                    <g id="artist-app-icon" transform="translate(28 295)">
+                        <rect id="bg" fill="#4999AD" x="0" y="0" width="23" height="23" rx="3"/>
+                        <path id="tent" fill="#FFF" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"/>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+    <path id="embed-icon" d="M16.9 2.3L22 6.97l-5.1 4.68c-.43.43-1 .43-1.43 0-.43-.43-.4-1.13.02-1.57l3.42-3.1-3.42-3.12a1.12 1.12 0 01-.02-1.56c.43-.43 1-.43 1.43 0zm-6.48 10.76c-.14.63-.62.98-1.2.87-.58-.12-.93-.72-.8-1.35L11.47.88c.14-.62.62-.97 1.2-.86.58.12.93.72.8 1.35l-2.8 10.77-.24.92zM5.1 2.3c.43-.43 1-.43 1.43 0 .43.43.43 1.13 0 1.56L3.1 6.97l3.44 3.11c.43.44.43 1.14 0 1.57-.42.43-1 .43-1.43 0L0 6.97 5.1 2.3z"/>
+    <path id="email-link" d="M0 2C0 .9.9 0 2 0h14a2 2 0 012 2v8a2 2 0 01-2 2H2a2 2 0 01-2-2V2zm16.06 9l.94-.9-4.7-4.55L17 1.9 16.06 1 9.24 6.47h-.48L1.94 1 1 1.9l4.7 3.65L1 10.09l.94.91 4.7-4.55 2.12 1.82h.48l2.11-1.82 4.7 4.55z"/>
+    <path id="reddit-share" d="M24 11.78a2.65 2.65 0 00-4.5-1.9 13.7 13.7 0 00-6.97-2.05l1.49-4.66 4.01.94v.05a2.17 2.17 0 004.34 0 2.17 2.17 0 00-4.2-.78l-4.32-1.02a.37.37 0 00-.44.25l-1.66 5.21c-2.83.03-5.4.8-7.3 2.03a2.64 2.64 0 10-3.13 4.2c-.06.28-.09.57-.09.86 0 3.9 4.8 7.09 10.72 7.09s10.72-3.18 10.72-7.1c0-.27-.03-.54-.08-.8A2.63 2.63 0 0024 11.78zM6.78 13.6a1.58 1.58 0 013.16 0 1.58 1.58 0 01-3.16 0zm9.06 4.66c-.8.8-2.05 1.18-3.83 1.18H12c-1.78 0-3.03-.38-3.83-1.18a.37.37 0 010-.52.37.37 0 01.53 0c.65.65 1.73.96 3.3.96H12c1.57 0 2.65-.31 3.3-.96a.37.37 0 01.53 0c.14.14.14.38 0 .52zm-.2-3.1c-.86 0-1.57-.7-1.57-1.57a1.58 1.58 0 013.16 0c0 .87-.71 1.58-1.58 1.58z"/>
+    <path id="copy-icon" d="M16.95 7.05a1 1 0 010 1.41l-8.48 8.49a1 1 0 11-1.42-1.41l8.49-8.49a1 1 0 011.4 0zm-5.8 10.04A4.2 4.2 0 0110 19.2l-1.66 1.65c-1.56 1.56-3.99 1.67-5.41.24-1.43-1.43-1.33-3.86.23-5.42L4.82 14c.6-.6 1.33-.98 2.09-1.14l1.93-1.94c-1.82-.3-3.83.3-5.31 1.79l-1.66 1.66c-2.35 2.34-2.5 5.98-.36 8.12 2.15 2.15 5.79 1.99 8.12-.35l1.66-1.66a6.14 6.14 0 001.79-5.32l-1.94 1.93zm3.22-15.23L12.7 3.52a6.14 6.14 0 00-1.79 5.32l1.94-1.93c.16-.76.54-1.49 1.14-2.1l1.66-1.65c1.56-1.56 3.99-1.66 5.42-.24 1.43 1.43 1.32 3.86-.24 5.42L19.18 10c-.6.6-1.33.98-2.08 1.14l-1.94 1.94c1.82.3 3.83-.3 5.32-1.78l1.66-1.67c2.34-2.34 2.5-5.97.35-8.12-2.14-2.14-5.78-1.98-8.12.35z"/>
+    <path id="share-icon" d="M6 17A15.24 15.24 0 0117 5.33V2l7 6.64-7 6.7V12s-6.17-.17-11 5zm12 .14V20H2V8h6.6a17 17 0 012.34-2H0v16h20v-6.77l-2 1.91z"/>
+<!--hubs-->
+    <g transform="translate(-1036 -601)" fill-rule="nonzero" stroke="#323232" id="hub-page-next" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 602.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 624l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape"/>
+    </g>
+    <g transform="translate(-1036 -655)" fill-rule="nonzero" stroke="#323232" id="hub-page-prev" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 656.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 678l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape" transform="matrix(-1 0 0 1 2100 0)"/>
+    </g>
+    <g transform="translate(-1036 -601)" fill-rule="nonzero" stroke="#FFF" id="hub-page-next-light" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 602.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 624l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape"/>
+    </g>
+    <g transform="translate(-1036 -655)" fill-rule="nonzero" stroke="#FFF" id="hub-page-prev-light" stroke-width="1" fill="none" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M1052.17 656.15l11.62 10.63-11.62-10.63zm11.83 10.88L1052 678l12-10.97zm-.32-.13l-27.18.13 27.18-.13z" id="Combined-Shape" transform="matrix(-1 0 0 1 2100 0)"/>
+    </g>
+    <g id="material-close">
+        <path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/>
+        <path d="M0 0h24v24H0z" fill="none"/>
+    </g>
+    <g id="material-add">
+        <path d="M0 0h24v24H0z" fill="none"/>
+        <path d="M13 7h-2v4H7v2h4v4h2v-4h4v-2h-4V7zm-1-5C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8z"/>
+    </g>
+    <g id="material-arrow-fwd">
+        <path d="M0 0h24v24H0z" fill="none"/>
+        <path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8z"/>
+    </g>
+    <g id="material-done">
+        <path fill="none" d="M0 0h24v24H0z"/>
+        <path d="M9 16.2L4.8 12l-1.4 1.4L9 19 21 7l-1.4-1.4L9 16.2z"/>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"></svg>-->
+    <g id="material-queue">
+        <path d="M0 0h24v24H0z" fill="none"/>
+        <path d="M15 6H3v2h12V6zm0 4H3v2h12v-2zM3 16h8v-2H3v2zM17 6v8.18A3 3 0 1019 17V8h3V6h-5z"/>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"></svg>-->
+    <g id="material-vol-up">
+        <path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3A4.5 4.5 0 0014 7.97v8.05A4.47 4.47 0 0016.5 12zM14 3.23v2.06a7 7 0 010 13.42v2.06a9 9 0 000-17.54z" id="Shape" fill="#333" fill-rule="nonzero"/>
+    </g>
+    <path fill="#333" d="M3 9v6h4l5 5V4L7 9z" id="material-vol-mute"/>
+    <g id="material-unlock">
+        <path d="M0 0h24v24H0z" fill="none"/>
+        <path d="M12 17c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm6-9h-1V6A5 5 0 007 6h1.9a3.1 3.1 0 016.2 0v2H6a2 2 0 00-2 2v10c0 1.1.9 2 2 2h12a2 2 0 002-2V10a2 2 0 00-2-2zm0 12H6V10h12v10z"/>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 128 128" > <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-heart"></use> </svg>-->
+    <path d="M25.75 36.06C10.4 51.72 18.82 70.11 41.2 90.41a249.17 249.17 0 0115.33 15.21c1.63 1.77 3.09 3.4 4.34 4.84.76.86 1.27 1.48 1.54 1.8l1.44 1.74 1.4-1.8 1.46-1.79A201.31 201.31 0 0185.85 90.4c23.11-21 31.63-39.47 15.27-54.3-11.46-10.04-22.82-8-32.73 1.29a44.91 44.91 0 00-4.78 5.28l-.1.13-.09-.13a41.46 41.46 0 00-4.48-5.45C53.8 32 48.12 29 42.04 29c-5.19 0-10.65 2.19-16.29 7.06z" id="material-heart"/>
+<!--<svg width="16px" height="15px" viewBox="0 0 16 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="material-comment">
+        <path id="ic-comment" d="M14.93 0c.59 0 1.06.48 1.07 1.08v8.57c0 .59-.48 1.06-1.07 1.06H8V15l-4.27-4.29H1.07c-.59 0-1.06-.47-1.07-1.06V1.08C0 .48.48 0 1.07 0h13.86zM1.5 1.5V9.2h2.86l2.14 2.16V9.2h8V1.5h-13z"/>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-keyboard-up"></use></svg>-->
+    <g id="material-keyboard-up">
+        <path d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"/>
+        <path d="M0 0h24v24H0z" fill="none"/>
+    </g>
+<!--<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-keyboard-down"></use></svg>-->
+    <g id="material-keyboard-down">
+        <path d="M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z"/>
+        <path fill="none" d="M0 0h24v24H0V0z"/>
+    </g>
+    <defs>
+        <linearGradient id="pledge-processing-mask" x1="50%" x2="50%" y1="0%" y2="100%">
+            <stop offset="0%" stop-color="#F8E71C"/>
+            <stop offset="100%" stop-color="#4E8E25"/>
+        </linearGradient>
+    </defs>
+    <path d="M50.17 100.08l5.33 4.51c.49.69-.73 1.95-1.5 1.5l-8-7 8-7c.77-.44 1.99.82 1.5 1.5l-5.3 4.49a45 45 0 001.06-89.93l2.12-1.85a47 47 0 01-3.21 93.78zM45.46 6.12L40.1 1.59c-.48-.68.73-1.94 1.5-1.5l8 7-8 7c-.77.45-1.98-.81-1.5-1.5l5.29-4.47a45 45 0 00-1.03 89.9l-2.1 1.84a47 47 0 013.19-93.74zm1.14 71.27v-5.4a22.16 22.16 0 01-12.75-5.57l2.43-3.24c3.24 2.92 6.43 4.7 10.48 5.13v-13.5c-8-1.89-11.5-4.86-11.5-10.47v-.11c0-5.56 4.7-9.61 11.34-9.94v-3.13h3.45v3.24c4.05.38 7.18 1.9 10.32 4.32l-2.33 3.24c-2.59-2.21-5.29-3.4-8.15-3.89v13.29c8.2 1.89 11.66 5.02 11.66 10.47v.11c0 5.78-4.7 9.72-11.5 10.15v5.3H46.6zm.16-26.79V37.91c-4.54.16-7.35 2.76-7.35 6.05v.1c0 3.03 1.4 5.03 7.35 6.54zm3.13 17.88c4.59-.22 7.5-2.76 7.5-6.27v-.1c0-3.2-1.5-5.08-7.5-6.54v12.9z" transform="translate(0 .9)" id="pledge-processing"/>
+<!--common icons-->
+    <g id="help" fill="none" fill-rule="evenodd">
+        <rect width="15" height="15" fill="#B8B8B8" rx="7.5"/>
+        <path fill="#FFF" d="M6.57 9.8h1.72v1.7H6.57V9.8zM4.79 6.19c.01-.4.08-.76.2-1.1.14-.32.32-.6.55-.85.23-.24.5-.43.83-.57a3.45 3.45 0 012.4.01c.35.15.63.32.84.54a1.93 1.93 0 01.6 1.37 2.14 2.14 0 01-.93 1.86l-.47.35c-.15.11-.28.24-.4.39-.1.14-.18.33-.2.55v.42H6.7v-.5a2.25 2.25 0 01.54-1.34c.13-.15.27-.28.42-.39.14-.1.28-.22.4-.33.13-.1.23-.23.3-.36a.9.9 0 00.1-.5c0-.33-.07-.58-.24-.74a.94.94 0 00-.69-.24c-.2 0-.36.03-.5.11-.15.08-.27.18-.36.3-.1.14-.16.29-.2.46-.05.17-.07.36-.07.56H4.8z"/>
+    </g>
+    <g id="ic-add-video">
+        <path d="M88 32a8 8 0 018 8v19l24-24v69L96 80v16a8 8 0 01-8 8H16a8 8 0 01-8-8V40a8 8 0 018-8h72zM56 52h-8v12H36v8h12v12h8V72h12v-8H56V52z" id="ic-add-video"/>
+    </g>
+    <g id="ic-add-photo">
+        <path d="M104 8H88a8 8 0 00-8-8H32a8 8 0 00-8 8H8a8 8 0 00-8 8v56a8 8 0 008 8h96a8 8 0 008-8V16a8 8 0 00-8-8zM56 68a24 24 0 110-48 24 24 0 010 48zm4-40h-8v12H40v8h12v12h8V48h12v-8H60V28z" id="ic-add-photo"/>
+    </g>
+    <path fill="#1DA0C3" fill-rule="evenodd" d="M8.86 8.26H0L4.14.62H13L8.86 8.26" id="bc-logo-tent"/>
+<!--<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="contextual-dots" stroke="none" fill="none" fill-rule="evenodd">
+        <g transform="translate(7 17)" fill="#818285">
+            <circle cx="3" cy="3" r="3"/>
+            <circle cx="13" cy="3" r="3"/>
+            <circle cx="23" cy="3" r="3"/>
+        </g>
+        <path d="M0 0h40v40H0z"/>
+    </g>
+<!--<svg width="128px" height="128px" viewBox="0 0 128 128" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">-->
+    <g id="report-flag-icon">
+        <path fill="none" d="M0 0h128v128H0z"/>
+        <path d="M34.56 20v95.7h-7.9V20h7.9zm7.78 5.01s9.54-10 19.34 0c21.28 21.72 40.61-.65 40.61-.65v46.58s-19.33 22.37-40.61.65c-9.8-10-19.34 0-19.34 0z"/>
+    </g>
+
+
+    <!-- <svg id="icon-allow-comment" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="allow-comment-icon">
+        <polygon points="15.981 3 6.573 13.501 2.708 9.635 2 10.342 6.614 14.956 16.726 3.668"></polygon>
+    </g>
+
+    <!-- <svg class="live-calendar-icon" viewBox="0 0 12 11"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#live-calendar-icon"></use></svg> -->
+    <g id="live-calendar-icon" fill="none" fill-rule="evenodd">
+        <g id="live-calendar-icon-stroke" transform="translate(-1033 -482)" stroke-width=".9">
+            <g id="component/event-card/4-col" transform="translate(744 209.5)">
+                <g id="Group" transform="translate(289 272)">
+                    <rect id="Rectangle" x=".45" y="2.65" width="10.73" height="8.36" rx="1.8"/>
+                    <path id="Path" d="M2.91.66v3.08M8.72.66v3.08"/>
+                    <path id="Path-4" d="M.83 5.67h10.8"/>
+                </g>
+            </g>
+        </g>
+    </g>
+
+    <!-- <svg class="live-clock-icon" viewBox="0 0 12 11"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#live-clock-icon"></use></svg> -->
+    <g id="live-clock-icon" fill="none" fill-rule="evenodd">
+        <g id="live-clock-icon-stroke" transform="translate(-1033 -499)" >
+            <g id="component/event-card/4-col" transform="translate(744 209.5)">
+                <g id="icon/clock" transform="translate(289 289)">
+                    <circle id="Oval" cx="6" cy="6.5" r="5.5"/>
+                    <path id="Path-5" d="M6 2.53V7h3.03"/>
+                </g>
+            </g>
+        </g>
+    </g>
+
+
+
+    <!-- <svg id="icon-ban" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="ban-user-icon">
+        <path d="M8.0002,0.0002 C3.5822,0.0002 0.0002,3.5822 0.0002,8.0002 C0.0002,12.4182 3.5822,16.0002 8.0002,16.0002 C12.4182,16.0002 16.0002,12.4182 16.0002,8.0002 C16.0002,3.5822 12.4182,0.0002 8.0002,0.0002 L8.0002,0.0002 Z M8.0002,1.0002 C11.8602,1.0002 15.0002,4.1402 15.0002,8.0002 C15.0002,11.8592 11.8602,15.0002 8.0002,15.0002 C4.1402,15.0002 1.0002,11.8592 1.0002,8.0002 C1.0002,4.1402 4.1402,1.0002 8.0002,1.0002 L8.0002,1.0002 Z M8.7072,8.0002 L11.6472,10.9402 L10.9402,11.6472 L8.0002,8.7072 L5.0592,11.6472 L4.3522,10.9402 L7.2922,8.0002 L4.3522,5.0592 L5.0592,4.3522 L8.0002,7.2932 L10.9402,4.3522 L11.6472,5.0592 L8.7072,8.0002 Z"></path>
+    </g>
+
+
+    <!-- <svg id="icon-delete-comment" fill-rule="evenodd" width="18px" height="18px" viewBox="0 0 18 18" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"></svg> -->
+    <g id="delete-comment-icon" fill-rule="evenodd">
+        <path d="M10.5,14.518 L11.5,14.518 L11.5,5.37 L10.5,5.37 L10.5,14.518 Z M6.5,14.518 L7.5,14.518 L7.5,5.37 L6.5,5.37 L6.5,14.518 Z M4.017,16.002 L14.017,16.002 L14.017,3.887 L4.017,3.887 L4.017,16.002 Z M6.464,2.887 L11.536,2.887 L11.536,2 L6.464,2 L6.464,2.887 Z M14.001,2.887 L12.536,2.887 L12.536,1 L5.464,1 L5.464,2.887 L3.999,2.887 L1,2.887 L1,3.887 L3,3.887 L3,15.989 C3,16.541 3.447,16.988 3.999,16.988 L14.001,16.988 C14.553,16.988 15,16.541 15,15.989 L15,3.887 L17,3.887 L17,2.887 L14.001,2.887 Z"></path>
+    </g>
+
+    <!-- <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"></svg> -->
+    <g id="ic-edit">
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path d="m12.02 6.27 1.06-1.07a.56.56 0 0 0 .17-.41c0-.16-.06-.3-.17-.41l-1.36-1.36a.56.56 0 0 0-.4-.17c-.17 0-.31.06-.42.17L9.83 4.08l2.19 2.19zm-7.09 7.08L11.4 6.9 9.2 4.7l-6.45 6.46v2.18h2.18z"/>
+        </svg>
+    </g>
+
+    <!-- <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-tooltip">
+        <path d="M8 15.06a6.55 6.55 0 0 0 5.74-3.28c.61-1.04.92-2.16.92-3.38a6.55 6.55 0 0 0-3.28-5.74A6.55 6.55 0 0 0 8 1.74c-1.2 0-2.33.3-3.36.92-1 .58-1.8 1.38-2.38 2.38a6.52 6.52 0 0 0-.92 3.36c0 1.2.3 2.33.92 3.36A6.55 6.55 0 0 0 8 15.06zm0-1.32a5.2 5.2 0 0 1-2.69-.73 5.18 5.18 0 0 1-1.92-1.92 5.2 5.2 0 0 1 0-5.38A5.18 5.18 0 0 1 5.31 3.8a5.2 5.2 0 0 1 5.38 0c.8.47 1.45 1.11 1.92 1.92a5.2 5.2 0 0 1 0 5.38A5.18 5.18 0 0 1 10.69 13a5.2 5.2 0 0 1-2.69.73zm.66-3.34c0-.33.1-.64.32-.93.11-.16.34-.38.67-.68.33-.3.56-.53.69-.73.2-.3.32-.64.32-1A2.72 2.72 0 0 0 8 4.4a2.72 2.72 0 0 0-2.66 2.66h1.32c0-.37.13-.68.4-.93.26-.26.58-.39.94-.39s.68.13.94.39c.27.25.4.56.4.93 0 .24-.07.46-.2.65-.1.14-.27.3-.5.48l-.6.48a2.19 2.19 0 0 0-.7 1.73h1.32zm0 2v-1.34H7.34v1.34h1.32z" fill="#999"/>
+    </g>
+
+    <!-- <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-camera-small">
+        <path d="M9.21 5.93H7.57v1.65h-.93V5.93H5V5h1.64V3.36h.93V5h1.64v.93zm-2.13 3.1A3.57 3.57 0 0 1 3.53 5.5c0-1.94 1.6-3.54 3.55-3.54 1.93 0 3.54 1.6 3.54 3.54s-1.6 3.54-3.54 3.54zm6.2-7.86h-2.75C10.53.53 10 0 9.36 0H4.68C4.03 0 3.5.53 3.5 1.17H.76a.77.77 0 0 0-.76.76v7.43c0 .4.35.76.76.76h12.46c.4 0 .76-.35.76-.76V1.93c.11-.41-.24-.76-.7-.76z"/>
+    </g>
+
+    <!-- <svg width="326" height="324" xmlns="http://www.w3.org/2000/svg"> -->
+    <g id="ic-spinny">
+        <g transform="translate(0 2)" opacity=".99" fill="none" fill-rule="evenodd">
+            <circle fill="#A4A4A5" cx="161" cy="287" r="35"/>
+            <circle fill="#606463" cx="161" cy="35" r="35"/>
+            <circle fill="#D2D2D1" transform="rotate(90 35 161)" cx="35" cy="161" r="35"/>
+            <circle fill="#7C7F7E" transform="rotate(90 287 161)" cx="287" cy="161" r="35"/>
+            <circle fill="#BBBAB9" transform="rotate(45 71.9 250.1)" cx="71.9" cy="250.1" r="35"/>
+            <circle fill="#717474" transform="rotate(45 250.1 71.9)" cx="250.1" cy="71.9" r="35"/>
+            <circle fill="#DCDCDC" transform="rotate(135 71.9 71.9)" cx="71.9" cy="71.9" r="35"/>
+            <circle fill="#8D8F8F" transform="rotate(135 250.1 250.1)" cx="250.1" cy="250.1" r="35"/>
+        </g>
+    </g>
+    <!-- <svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg> -->
+    <path id="discover-arrow" d="M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6-1.41-1.41z"/>
+    <g id="fan-app-icon" fill="none" fill-rule="evenodd">
+        <rect fill="#FFF" width="23" height="23" rx="3"/>
+        <path fill="url(#fanAppGradient)" d="M4 15.9l4.78-8.8h10.21l-4.77 8.8z"/>
+    </g>
+
+    <!-- <svg width="22px" height="15px" viewBox="0 0 22 15" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"> -->
+    <g id="view-eyeball-icon" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="adminControls---OFF-AIR-Copy" transform="translate(-823.000000, -743.000000)">
+            <g id="component/video/sound-check" transform="translate(134.000000, 222.000000)">
+                <g id="Group" transform="translate(689.000000, 521.000000)">
+                    <g transform="translate(0.000000, 0.000000)" id="Oval">
+                        <circle fill="currentColor" cx="11" cy="7.28" r="3"></circle>
+                        <path d="M11,1 C15.6667595,1 19.5502286,5.64619254 20.7714147,7.28017631 C19.5496534,8.91449561 15.6664139,13.56 11,13.56 C6.33324048,13.56 2.44977141,8.91380746 1.22858526,7.27982369 C2.45034662,5.64550439 6.33358609,1 11,1 Z" stroke="currentColor" stroke-width="2"></path>
+                    </g>
+                </g>
+            </g>
+        </g>
+    </g>
+
+    <path id="check" fill="none" stroke-width="1.5" d="M1.5 6.5l4 5 8-11" />
+    <g id="two-person-silhouette">
+        <path d='M12.81 8.64c-.244-.359-.808-.605-1.858-.986-1.046-.38-1.38-.701-1.38-1.388 0-.412.32-.277.46-1.032.058-.313.34-.005.394-.72 0-.285-.154-.357-.154-.357s.078-.42.109-.745c.037-.404-.042-1.579-1.494-1.579S6.971 3.008 7.01 3.413c.03.323.108.744.108.744s-.154.072-.154.357c.054.715.336.407.394.72.14.755.46.62.46 1.032 0 .467-.156.765-.583 1.027 2.284.995 2.24 1.2 2.24 2.09V11H13s-.028-2.12-.19-2.36zm-6.046-.7c-1.308-.518-1.726-.954-1.726-1.888 0-.56.399-.378.574-1.404.072-.426.426-.007.493-.98 0-.387-.192-.484-.192-.484s.098-.573.136-1.014C6.097 1.62 5.676 0 3.859 0 2.044 0 1.782 1.62 1.83 2.17c.039.441.136 1.014.136 1.014s-.192.097-.192.484c.067.973.42.554.493.98.175 1.026.575.843.575 1.404 0 .934-.418 1.37-1.727 1.887C.717 8.097 0 8.213 0 8.8V11h8.821V9.35c0-.536-.745-.892-2.057-1.41z' />
+    </g>
+
+    
+    <path id="read-more-arr" d="M10.815,3.12018899 C10.809,3.11518899 6.58,0.0611889922 6.58,0.0611889922 C6.427,-0.0388110078 6.221,-0.0138110078 6.097,0.124188992 C5.973,0.260188992 5.967,0.467188992 6.083,0.610188992 L7.863,3.00018899 L0.5,3.00018899 C0.224,3.00018899 0,3.22418899 0,3.50018899 C0,3.77618899 0.224,4.00018899 0.5,4.00018899 L7.863,4.00018899 L6.083,6.39018899 C5.967,6.53318899 5.973,6.74018899 6.097,6.87618899 C6.221,7.01418899 6.427,7.03918899 6.58,6.93918899 L10.802,3.89918899 C10.926,3.78818899 11,3.65518899 11,3.50018899 C11,3.34518899 10.926,3.21218899 10.815,3.12018899 Z"></path>
+    <path id="close-weekly-archive" d="M7.4,6l2.8-2.8c0.4-0.4,0.4-1,0-1.4c-0.4-0.4-1-0.4-1.4,0L6,4.6L3.2,1.8c-0.4-0.4-1-0.4-1.4,0 c-0.4,0.4-0.4,1,0,1.4L4.6,6L1.8,8.8c-0.4,0.4-0.4,1,0,1.4c0.4,0.4,1,0.4,1.4,0L6,7.4l2.8,2.8c0.4,0.4,1,0.4,1.4,0 c0.4-0.4,0.4-1,0-1.4L7.4,6z"></path>
+    <path id="nn-view-album" d="M1.43682992,0L0 1.44492059 9.03679561 10.0650366 0.00617548675 18.5439879 1.43065443 20 12 10.0771364z"></path>
+    <path id="nn-own-this" d="M18.1085095,1.66536531 C16.7611171,0.429117108 15.3262573,-0.0849663045 13.8432411,0.146575233 C12.1400821,0.40973698 10.7946553,1.62150502 9.97698178,2.57215133 C9.22220618,1.60722493 7.97112632,0.38423681 6.31317524,0.0741547518 C4.77610618,-0.210427137 3.24493381,0.32099639 1.70786476,1.71942567 C0.531476234,2.97709402 -0.0414849278,4.41734358 0.00274020481,6.00039409 C0.0725176362,8.52287084 1.68722637,11.252409 4.93728222,14.3481295 L4.93728222,14.3491495 C7.46106312,16.7492254 9.23596511,18.9850803 9.25365516,19.0075204 L10.0379142,19.999987 L10.791707,18.9840603 C10.8084143,18.9616201 12.4820898,16.7186252 14.973439,14.3450695 C18.3561702,11.1198081 20.0013452,8.32804954 20.0003624,5.81169284 C20.0003624,4.25516251 19.3674516,2.86489328 18.1085095,1.66536531"></path>
+    <path id="nn-wishlisted" d="M18.1081467,1.66537829 C16.7607543,0.429130081 15.3258944,-0.0849533313 13.8428783,0.146588206 C12.1397193,0.409749953 10.7942925,1.621518 9.97661895,2.57216431 C9.22184336,1.6072379 7.97076349,0.384249783 6.31281241,0.074167725 C4.77574336,-0.210414164 3.24457099,0.321009364 1.70750194,1.71943865 C0.531113412,2.977107 -0.0418477507,4.41735656 0.00237738193,6.00040707 C0.0721548134,8.52288381 1.68686354,11.2524219 4.9369194,14.3481425 L4.9369194,14.3491625 C7.4607003,16.7492384 9.23560229,18.9850933 9.25329234,19.0075334 L10.0375514,20 L10.7913442,18.9840733 C10.8080514,18.9616331 12.481727,16.7186382 14.9730762,14.3450825 C18.3558074,11.1198211 20.0009823,8.32806252 19.9999996,5.81170581 C19.9999996,4.25517548 19.3670888,2.86490625 18.1081467,1.66537829"></path>
+    <path id="nn-add-wishlist" d="M6.26532856,12.8438659 C7.90059563,14.4003455 9.21450913,15.8670674 9.99381609,16.7758637 C10.7485547,15.8548277 12.0251244,14.3840259 13.643685,12.8428459 C16.5574872,10.0634181 18.0355171,7.69911951 18.0345343,5.81216853 C18.0345343,4.83707385 17.6286658,3.97621622 16.793343,3.18165685 C15.9010218,2.36261813 15.0195107,2.02806682 14.1311204,2.16474327 C12.2285501,2.45747566 10.7858986,4.80953457 10.7711576,4.83299396 L9.87981911,6.33643491 L9.07004744,4.78403523 C9.05923738,4.76261579 7.80428783,2.42075662 5.95675052,2.08110544 C5.03494733,1.91178984 4.06302478,2.28714009 3.05965478,3.19797643 C2.31474346,3.99967561 1.93835687,4.91561181 1.96685611,5.94170516 C2.02090641,7.85619543 3.46650608,10.1786751 6.26532856,12.8448859 L6.26532856,12.8438659 Z M10.0370563,20 L9.2528357,19.0075658 C9.23514652,18.9851264 7.46033142,16.7493444 4.93667407,14.3483268 L4.93667407,14.3473068 C1.68677732,11.2516872 0.0731303674,8.52223813 0.00237361922,6.00086363 C-0.0418493484,4.41786474 0.532066498,2.97766215 1.7074147,1.72003482 C3.24440851,0.320631169 4.77452319,-0.209755055 6.31249973,0.07379758 C7.96938691,0.384889499 9.22138826,1.60681776 9.97612691,2.5717127 C10.7927777,1.62211736 12.1391214,0.409368864 13.842197,0.147235672 C15.3221923,-0.0822583664 16.7599301,0.42874836 18.1082393,1.66597622 C19.3671198,2.86444509 19.9990168,4.25568896 19.9999996,5.81216853 C20.0009823,8.32742319 18.3558879,11.1190907 14.9723395,14.3452669 C12.4811123,16.7177253 10.8085014,18.960647 10.7908122,18.9841064 L10.0370563,20 Z"></path>
+    <path id="bc-daily-expand" d="M9,4H6V1c0-0.6-0.4-1-1-1S4,0.4,4,1v3H1C0.4,4,0,4.4,0,5c0,0.6,0.4,1,1,1h3v3c0,0.6,0.4,1,1,1 s1-0.4,1-1V6h3c0.6,0,1-0.4,1-1C10,4.4,9.6,4,9,4z"></path>
+    
+</svg>
+
+
+
+    <div id="pagedata" data-blob="{&quot;recaptcha_public_key&quot;:&quot;6LfhSPgSAAAAAPwto_qzHuwSmjgfrkg35xXXu_8K&quot;,&quot;invisible_recaptcha_public_key&quot;:&quot;6Ld7hz4UAAAAANlndw60vAheGUwN0Mb-qeWD_LHr&quot;,&quot;templglobals&quot;:{&quot;endpoint_mobilized&quot;:true,&quot;is_phone&quot;:false},&quot;localize_page&quot;:true,&quot;locale&quot;:&quot;en&quot;,&quot;languages&quot;:{&quot;en&quot;:&quot;English&quot;,&quot;de&quot;:&quot;Deutsch&quot;,&quot;es&quot;:&quot;Español&quot;,&quot;fr&quot;:&quot;Français&quot;,&quot;pt&quot;:&quot;Português&quot;,&quot;ja&quot;:&quot;日本語&quot;},&quot;help_center_url&quot;:&quot;https://get.bandcamp.help/hc/en-us&quot;,&quot;env&quot;:&quot;prod&quot;,&quot;user_territory&quot;:null,&quot;tralbum_is_promo&quot;:null,&quot;embed_info&quot;:{&quot;public_embeddable&quot;:false,&quot;exclusive_embeddable&quot;:false,&quot;item_public&quot;:true,&quot;no_track_preorder&quot;:false},&quot;fan_follows_label&quot;:null,&quot;login_bounce_url&quot;:&quot;https://bandcamp.com/login?bounce=https%3A%2F%2Farbee.bandcamp.com%2Falbum%2Fdes-papiers-ii&amp;sig=540545146488720f840e7aed7f6b462d&quot;,&quot;artist_service_url&quot;:&quot;https://arbee.bandcamp.com/subscribe&quot;,&quot;cfg&quot;:{&quot;mobile_app&quot;:true,&quot;gifting&quot;:true,&quot;physical_gifting&quot;:true,&quot;physical_gifting_zip_regex&quot;:true,&quot;tralbum_login&quot;:true,&quot;no_flash_uploads&quot;:true,&quot;artist_subscriptions&quot;:true,&quot;video_sharing&quot;:true,&quot;open_signup&quot;:true,&quot;stream_buffer_duration_stats&quot;:true,&quot;fan_page_2017&quot;:true,&quot;header_rework_2018&quot;:true,&quot;band_navbar_update_2023&quot;:true,&quot;dsa_buy_dialog&quot;:true,&quot;single_sign_up&quot;:true,&quot;fan_signup_use_captcha&quot;:true,&quot;login_use_captcha&quot;:true,&quot;mobile_onboarding&quot;:true,&quot;gift_cards&quot;:true,&quot;menubar_autocomplete_enabled&quot;:true,&quot;use_elasticsearch_backed_search&quot;:true,&quot;new_search_api_service&quot;:true,&quot;search_tracking&quot;:true,&quot;order_history&quot;:true,&quot;search_discovery_one_filter_desktop_only&quot;:true,&quot;search_discovery_one_filter_rollout&quot;:true,&quot;community&quot;:true},&quot;media_mode_test&quot;:false,&quot;lo_querystr&quot;:&quot;?action_sig=55414c1ec6b8b052199cac9c67303048&amp;action_url=https%3A%2F%2Farbee.bandcamp.com%2Falbum%2Fdes-papiers-ii&amp;band_id=4038363339&amp;item_id=948735258&amp;item_type=album&quot;,&quot;ip_location_country_code&quot;:&quot;NL&quot;,&quot;fan_location_country&quot;:null,&quot;show_buy_full_disco&quot;:null,&quot;live_event_tickets&quot;:{},&quot;buyer_location&quot;:{&quot;country_code&quot;:&quot;NL&quot;,&quot;is_eu&quot;:true},&quot;signup_params&quot;:{&quot;save_card&quot;:false,&quot;mailing_list_info&quot;:{&quot;email_address&quot;:null},&quot;genres&quot;:[{&quot;id&quot;:10,&quot;name&quot;:&quot;electronic&quot;,&quot;norm_name&quot;:&quot;electronic&quot;,&quot;value&quot;:&quot;electronic&quot;},{&quot;id&quot;:23,&quot;name&quot;:&quot;rock&quot;,&quot;norm_name&quot;:&quot;rock&quot;,&quot;value&quot;:&quot;rock&quot;},{&quot;id&quot;:18,&quot;name&quot;:&quot;metal&quot;,&quot;norm_name&quot;:&quot;metal&quot;,&quot;value&quot;:&quot;metal&quot;},{&quot;id&quot;:2,&quot;name&quot;:&quot;alternative&quot;,&quot;norm_name&quot;:&quot;alternative&quot;,&quot;value&quot;:&quot;alternative&quot;},{&quot;id&quot;:14,&quot;name&quot;:&quot;hip-hop/rap&quot;,&quot;norm_name&quot;:&quot;hip-hop-rap&quot;,&quot;value&quot;:&quot;hip-hop-rap&quot;},{&quot;id&quot;:11,&quot;name&quot;:&quot;experimental&quot;,&quot;norm_name&quot;:&quot;experimental&quot;,&quot;value&quot;:&quot;experimental&quot;},{&quot;id&quot;:20,&quot;name&quot;:&quot;punk&quot;,&quot;norm_name&quot;:&quot;punk&quot;,&quot;value&quot;:&quot;punk&quot;},{&quot;id&quot;:12,&quot;name&quot;:&quot;folk&quot;,&quot;norm_name&quot;:&quot;folk&quot;,&quot;value&quot;:&quot;folk&quot;},{&quot;id&quot;:19,&quot;name&quot;:&quot;pop&quot;,&quot;norm_name&quot;:&quot;pop&quot;,&quot;value&quot;:&quot;pop&quot;},{&quot;id&quot;:3,&quot;name&quot;:&quot;ambient&quot;,&quot;norm_name&quot;:&quot;ambient&quot;,&quot;value&quot;:&quot;ambient&quot;},{&quot;id&quot;:24,&quot;name&quot;:&quot;soundtrack&quot;,&quot;norm_name&quot;:&quot;soundtrack&quot;,&quot;value&quot;:&quot;soundtrack&quot;},{&quot;id&quot;:26,&quot;name&quot;:&quot;world&quot;,&quot;norm_name&quot;:&quot;world&quot;,&quot;value&quot;:&quot;world&quot;},{&quot;id&quot;:15,&quot;name&quot;:&quot;jazz&quot;,&quot;norm_name&quot;:&quot;jazz&quot;,&quot;value&quot;:&quot;jazz&quot;},{&quot;id&quot;:1,&quot;name&quot;:&quot;acoustic&quot;,&quot;norm_name&quot;:&quot;acoustic&quot;,&quot;value&quot;:&quot;acoustic&quot;},{&quot;id&quot;:13,&quot;name&quot;:&quot;funk&quot;,&quot;norm_name&quot;:&quot;funk&quot;,&quot;value&quot;:&quot;funk&quot;},{&quot;id&quot;:21,&quot;name&quot;:&quot;r&amp;b/soul&quot;,&quot;norm_name&quot;:&quot;r-b-soul&quot;,&quot;value&quot;:&quot;r-b-soul&quot;},{&quot;id&quot;:9,&quot;name&quot;:&quot;devotional&quot;,&quot;norm_name&quot;:&quot;devotional&quot;,&quot;value&quot;:&quot;devotional&quot;},{&quot;id&quot;:5,&quot;name&quot;:&quot;classical&quot;,&quot;norm_name&quot;:&quot;classical&quot;,&quot;value&quot;:&quot;classical&quot;},{&quot;id&quot;:22,&quot;name&quot;:&quot;reggae&quot;,&quot;norm_name&quot;:&quot;reggae&quot;,&quot;value&quot;:&quot;reggae&quot;},{&quot;id&quot;:27,&quot;name&quot;:&quot;podcasts&quot;,&quot;norm_name&quot;:&quot;podcasts&quot;,&quot;value&quot;:&quot;podcasts&quot;},{&quot;id&quot;:7,&quot;name&quot;:&quot;country&quot;,&quot;norm_name&quot;:&quot;country&quot;,&quot;value&quot;:&quot;country&quot;},{&quot;id&quot;:25,&quot;name&quot;:&quot;spoken word&quot;,&quot;norm_name&quot;:&quot;spoken-word&quot;,&quot;value&quot;:&quot;spoken-word&quot;},{&quot;id&quot;:6,&quot;name&quot;:&quot;comedy&quot;,&quot;norm_name&quot;:&quot;comedy&quot;,&quot;value&quot;:&quot;comedy&quot;},{&quot;id&quot;:4,&quot;name&quot;:&quot;blues&quot;,&quot;norm_name&quot;:&quot;blues&quot;,&quot;value&quot;:&quot;blues&quot;},{&quot;id&quot;:28,&quot;name&quot;:&quot;audiobooks&quot;,&quot;norm_name&quot;:&quot;audiobooks&quot;,&quot;value&quot;:&quot;audiobooks&quot;},{&quot;id&quot;:17,&quot;name&quot;:&quot;latin&quot;,&quot;norm_name&quot;:&quot;latin&quot;,&quot;value&quot;:&quot;latin&quot;}],&quot;subgenres&quot;:{&quot;acoustic&quot;:[{&quot;name&quot;:&quot;folk&quot;,&quot;value&quot;:&quot;folk&quot;,&quot;norm_name&quot;:&quot;folk&quot;},{&quot;name&quot;:&quot;singer-songwriter&quot;,&quot;value&quot;:&quot;singer-songwriter&quot;,&quot;norm_name&quot;:&quot;singer-songwriter&quot;},{&quot;name&quot;:&quot;rock&quot;,&quot;value&quot;:&quot;rock&quot;,&quot;norm_name&quot;:&quot;rock&quot;},{&quot;name&quot;:&quot;pop&quot;,&quot;value&quot;:&quot;pop&quot;,&quot;norm_name&quot;:&quot;pop&quot;},{&quot;name&quot;:&quot;guitar&quot;,&quot;value&quot;:&quot;guitar&quot;,&quot;norm_name&quot;:&quot;guitar&quot;},{&quot;name&quot;:&quot;americana&quot;,&quot;value&quot;:&quot;americana&quot;,&quot;norm_name&quot;:&quot;americana&quot;},{&quot;name&quot;:&quot;electro-acoustic&quot;,&quot;value&quot;:&quot;electro-acoustic&quot;,&quot;norm_name&quot;:&quot;electro-acoustic&quot;},{&quot;name&quot;:&quot;instrumental&quot;,&quot;value&quot;:&quot;instrumental&quot;,&quot;norm_name&quot;:&quot;instrumental&quot;},{&quot;name&quot;:&quot;piano&quot;,&quot;value&quot;:&quot;piano&quot;,&quot;norm_name&quot;:&quot;piano&quot;},{&quot;name&quot;:&quot;bluegrass&quot;,&quot;value&quot;:&quot;bluegrass&quot;,&quot;norm_name&quot;:&quot;bluegrass&quot;},{&quot;name&quot;:&quot;roots&quot;,&quot;value&quot;:&quot;roots&quot;,&quot;norm_name&quot;:&quot;roots&quot;}],&quot;alternative&quot;:[{&quot;name&quot;:&quot;indie rock&quot;,&quot;value&quot;:&quot;indie-rock&quot;,&quot;norm_name&quot;:&quot;indie-rock&quot;},{&quot;name&quot;:&quot;industrial&quot;,&quot;value&quot;:&quot;industrial&quot;,&quot;norm_name&quot;:&quot;industrial&quot;},{&quot;name&quot;:&quot;shoegaze&quot;,&quot;value&quot;:&quot;shoegaze&quot;,&quot;norm_name&quot;:&quot;shoegaze&quot;},{&quot;name&quot;:&quot;grunge&quot;,&quot;value&quot;:&quot;grunge&quot;,&quot;norm_name&quot;:&quot;grunge&quot;},{&quot;name&quot;:&quot;goth&quot;,&quot;value&quot;:&quot;goth&quot;,&quot;norm_name&quot;:&quot;goth&quot;},{&quot;name&quot;:&quot;dream pop&quot;,&quot;value&quot;:&quot;dream-pop&quot;,&quot;norm_name&quot;:&quot;dream-pop&quot;},{&quot;name&quot;:&quot;emo&quot;,&quot;value&quot;:&quot;emo&quot;,&quot;norm_name&quot;:&quot;emo&quot;},{&quot;name&quot;:&quot;math rock&quot;,&quot;value&quot;:&quot;math-rock&quot;,&quot;norm_name&quot;:&quot;math-rock&quot;},{&quot;name&quot;:&quot;britpop&quot;,&quot;value&quot;:&quot;britpop&quot;,&quot;norm_name&quot;:&quot;britpop&quot;},{&quot;name&quot;:&quot;jangle pop&quot;,&quot;value&quot;:&quot;jangle-pop&quot;,&quot;norm_name&quot;:&quot;jangle-pop&quot;}],&quot;ambient&quot;:[{&quot;name&quot;:&quot;chill-out&quot;,&quot;value&quot;:&quot;chill-out&quot;,&quot;norm_name&quot;:&quot;chill-out&quot;},{&quot;name&quot;:&quot;drone&quot;,&quot;value&quot;:&quot;drone&quot;,&quot;norm_name&quot;:&quot;drone&quot;},{&quot;name&quot;:&quot;dark ambient&quot;,&quot;value&quot;:&quot;dark-ambient&quot;,&quot;norm_name&quot;:&quot;dark-ambient&quot;},{&quot;name&quot;:&quot;electronic&quot;,&quot;value&quot;:&quot;electronic&quot;,&quot;norm_name&quot;:&quot;electronic&quot;},{&quot;name&quot;:&quot;soundscapes&quot;,&quot;value&quot;:&quot;soundscapes&quot;,&quot;norm_name&quot;:&quot;soundscapes&quot;},{&quot;name&quot;:&quot;field recordings&quot;,&quot;value&quot;:&quot;field-recordings&quot;,&quot;norm_name&quot;:&quot;field-recordings&quot;},{&quot;name&quot;:&quot;atmospheric&quot;,&quot;value&quot;:&quot;atmospheric&quot;,&quot;norm_name&quot;:&quot;atmospheric&quot;},{&quot;name&quot;:&quot;meditation&quot;,&quot;value&quot;:&quot;meditation&quot;,&quot;norm_name&quot;:&quot;meditation&quot;},{&quot;name&quot;:&quot;noise&quot;,&quot;value&quot;:&quot;noise&quot;,&quot;norm_name&quot;:&quot;noise&quot;},{&quot;name&quot;:&quot;new age&quot;,&quot;value&quot;:&quot;new-age&quot;,&quot;norm_name&quot;:&quot;new-age&quot;},{&quot;name&quot;:&quot;idm&quot;,&quot;value&quot;:&quot;idm&quot;,&quot;norm_name&quot;:&quot;idm&quot;},{&quot;name&quot;:&quot;industrial&quot;,&quot;value&quot;:&quot;industrial&quot;,&quot;norm_name&quot;:&quot;industrial&quot;}],&quot;blues&quot;:[{&quot;name&quot;:&quot;rhythm &amp; blues&quot;,&quot;value&quot;:&quot;rhythm-blues&quot;,&quot;norm_name&quot;:&quot;rhythm-blues&quot;},{&quot;name&quot;:&quot;blues rock&quot;,&quot;value&quot;:&quot;blues-rock&quot;,&quot;norm_name&quot;:&quot;blues-rock&quot;},{&quot;name&quot;:&quot;country blues&quot;,&quot;value&quot;:&quot;country-blues&quot;,&quot;norm_name&quot;:&quot;country-blues&quot;},{&quot;name&quot;:&quot;boogie-woogie&quot;,&quot;value&quot;:&quot;boogie-woogie&quot;,&quot;norm_name&quot;:&quot;boogie-woogie&quot;},{&quot;name&quot;:&quot;delta blues&quot;,&quot;value&quot;:&quot;delta-blues&quot;,&quot;norm_name&quot;:&quot;delta-blues&quot;},{&quot;name&quot;:&quot;americana&quot;,&quot;value&quot;:&quot;americana&quot;,&quot;norm_name&quot;:&quot;americana&quot;},{&quot;name&quot;:&quot;electric blues&quot;,&quot;value&quot;:&quot;electric-blues&quot;,&quot;norm_name&quot;:&quot;electric-blues&quot;},{&quot;name&quot;:&quot;gospel&quot;,&quot;value&quot;:&quot;gospel&quot;,&quot;norm_name&quot;:&quot;gospel&quot;},{&quot;name&quot;:&quot;bluegrass&quot;,&quot;value&quot;:&quot;bluegrass&quot;,&quot;norm_name&quot;:&quot;bluegrass&quot;}],&quot;classical&quot;:[{&quot;name&quot;:&quot;orchestral&quot;,&quot;value&quot;:&quot;orchestral&quot;,&quot;norm_name&quot;:&quot;orchestral&quot;},{&quot;name&quot;:&quot;neo-classical&quot;,&quot;value&quot;:&quot;neo-classical&quot;,&quot;norm_name&quot;:&quot;neo-classical&quot;},{&quot;name&quot;:&quot;chamber music&quot;,&quot;value&quot;:&quot;chamber-music&quot;,&quot;norm_name&quot;:&quot;chamber-music&quot;},{&quot;name&quot;:&quot;classical piano&quot;,&quot;value&quot;:&quot;classical-piano&quot;,&quot;norm_name&quot;:&quot;classical-piano&quot;},{&quot;name&quot;:&quot;contemporary classical&quot;,&quot;value&quot;:&quot;contemporary-classical&quot;,&quot;norm_name&quot;:&quot;contemporary-classical&quot;},{&quot;name&quot;:&quot;baroque&quot;,&quot;value&quot;:&quot;baroque&quot;,&quot;norm_name&quot;:&quot;baroque&quot;},{&quot;name&quot;:&quot;opera&quot;,&quot;value&quot;:&quot;opera&quot;,&quot;norm_name&quot;:&quot;opera&quot;},{&quot;name&quot;:&quot;choral&quot;,&quot;value&quot;:&quot;choral&quot;,&quot;norm_name&quot;:&quot;choral&quot;},{&quot;name&quot;:&quot;modern classical&quot;,&quot;value&quot;:&quot;modern-classical&quot;,&quot;norm_name&quot;:&quot;modern-classical&quot;},{&quot;name&quot;:&quot;avant garde&quot;,&quot;value&quot;:&quot;avant-garde&quot;,&quot;norm_name&quot;:&quot;avant-garde&quot;}],&quot;comedy&quot;:[{&quot;name&quot;:&quot;improv&quot;,&quot;value&quot;:&quot;improv&quot;,&quot;norm_name&quot;:&quot;improv&quot;},{&quot;name&quot;:&quot;stand-up&quot;,&quot;value&quot;:&quot;stand-up&quot;,&quot;norm_name&quot;:&quot;stand-up&quot;}],&quot;country&quot;:[{&quot;name&quot;:&quot;bluegrass&quot;,&quot;value&quot;:&quot;bluegrass&quot;,&quot;norm_name&quot;:&quot;bluegrass&quot;},{&quot;name&quot;:&quot;country rock&quot;,&quot;value&quot;:&quot;country-rock&quot;,&quot;norm_name&quot;:&quot;country-rock&quot;},{&quot;name&quot;:&quot;americana&quot;,&quot;value&quot;:&quot;americana&quot;,&quot;norm_name&quot;:&quot;americana&quot;},{&quot;name&quot;:&quot;country folk&quot;,&quot;value&quot;:&quot;country-folk&quot;,&quot;norm_name&quot;:&quot;country-folk&quot;},{&quot;name&quot;:&quot;alt-country&quot;,&quot;value&quot;:&quot;alt-country&quot;,&quot;norm_name&quot;:&quot;alt-country&quot;},{&quot;name&quot;:&quot;country blues&quot;,&quot;value&quot;:&quot;country-blues&quot;,&quot;norm_name&quot;:&quot;country-blues&quot;},{&quot;name&quot;:&quot;western&quot;,&quot;value&quot;:&quot;western&quot;,&quot;norm_name&quot;:&quot;western&quot;},{&quot;name&quot;:&quot;singer-songwriter&quot;,&quot;value&quot;:&quot;singer-songwriter&quot;,&quot;norm_name&quot;:&quot;singer-songwriter&quot;},{&quot;name&quot;:&quot;outlaw&quot;,&quot;value&quot;:&quot;outlaw&quot;,&quot;norm_name&quot;:&quot;outlaw&quot;},{&quot;name&quot;:&quot;honky-tonk&quot;,&quot;value&quot;:&quot;honky-tonk&quot;,&quot;norm_name&quot;:&quot;honky-tonk&quot;},{&quot;name&quot;:&quot;roots&quot;,&quot;value&quot;:&quot;roots&quot;,&quot;norm_name&quot;:&quot;roots&quot;},{&quot;name&quot;:&quot;hillbilly&quot;,&quot;value&quot;:&quot;hillbilly&quot;,&quot;norm_name&quot;:&quot;hillbilly&quot;}],&quot;devotional&quot;:[{&quot;name&quot;:&quot;christian&quot;,&quot;value&quot;:&quot;christian&quot;,&quot;norm_name&quot;:&quot;christian&quot;},{&quot;name&quot;:&quot;gospel&quot;,&quot;value&quot;:&quot;gospel&quot;,&quot;norm_name&quot;:&quot;gospel&quot;},{&quot;name&quot;:&quot;meditation&quot;,&quot;value&quot;:&quot;meditation&quot;,&quot;norm_name&quot;:&quot;meditation&quot;},{&quot;name&quot;:&quot;spiritual&quot;,&quot;value&quot;:&quot;spiritual&quot;,&quot;norm_name&quot;:&quot;spiritual&quot;},{&quot;name&quot;:&quot;worship&quot;,&quot;value&quot;:&quot;worship&quot;,&quot;norm_name&quot;:&quot;worship&quot;},{&quot;name&quot;:&quot;inspirational&quot;,&quot;value&quot;:&quot;inspirational&quot;,&quot;norm_name&quot;:&quot;inspirational&quot;}],&quot;electronic&quot;:[{&quot;name&quot;:&quot;house&quot;,&quot;value&quot;:&quot;house&quot;,&quot;norm_name&quot;:&quot;house&quot;},{&quot;name&quot;:&quot;electronica&quot;,&quot;value&quot;:&quot;electronica&quot;,&quot;norm_name&quot;:&quot;electronica&quot;},{&quot;name&quot;:&quot;downtempo&quot;,&quot;value&quot;:&quot;downtempo&quot;,&quot;norm_name&quot;:&quot;downtempo&quot;},{&quot;name&quot;:&quot;techno&quot;,&quot;value&quot;:&quot;techno&quot;,&quot;norm_name&quot;:&quot;techno&quot;},{&quot;name&quot;:&quot;electro&quot;,&quot;value&quot;:&quot;electro&quot;,&quot;norm_name&quot;:&quot;electro&quot;},{&quot;name&quot;:&quot;dubstep&quot;,&quot;value&quot;:&quot;dubstep&quot;,&quot;norm_name&quot;:&quot;dubstep&quot;},{&quot;name&quot;:&quot;beats&quot;,&quot;value&quot;:&quot;beats&quot;,&quot;norm_name&quot;:&quot;beats&quot;},{&quot;name&quot;:&quot;dance&quot;,&quot;value&quot;:&quot;dance&quot;,&quot;norm_name&quot;:&quot;dance&quot;},{&quot;name&quot;:&quot;idm&quot;,&quot;value&quot;:&quot;idm&quot;,&quot;norm_name&quot;:&quot;idm&quot;},{&quot;name&quot;:&quot;drum &amp; bass&quot;,&quot;value&quot;:&quot;drum-bass&quot;,&quot;norm_name&quot;:&quot;drum-bass&quot;},{&quot;name&quot;:&quot;breaks&quot;,&quot;value&quot;:&quot;breaks&quot;,&quot;norm_name&quot;:&quot;breaks&quot;},{&quot;name&quot;:&quot;trance&quot;,&quot;value&quot;:&quot;trance&quot;,&quot;norm_name&quot;:&quot;trance&quot;},{&quot;name&quot;:&quot;glitch&quot;,&quot;value&quot;:&quot;glitch&quot;,&quot;norm_name&quot;:&quot;glitch&quot;},{&quot;name&quot;:&quot;chiptune&quot;,&quot;value&quot;:&quot;chiptune&quot;,&quot;norm_name&quot;:&quot;chiptune&quot;},{&quot;name&quot;:&quot;chillwave&quot;,&quot;value&quot;:&quot;chillwave&quot;,&quot;norm_name&quot;:&quot;chillwave&quot;},{&quot;name&quot;:&quot;dub&quot;,&quot;value&quot;:&quot;dub&quot;,&quot;norm_name&quot;:&quot;dub&quot;},{&quot;name&quot;:&quot;edm&quot;,&quot;value&quot;:&quot;edm&quot;,&quot;norm_name&quot;:&quot;edm&quot;},{&quot;name&quot;:&quot;instrumental&quot;,&quot;value&quot;:&quot;instrumental&quot;,&quot;norm_name&quot;:&quot;instrumental&quot;},{&quot;name&quot;:&quot;witch house&quot;,&quot;value&quot;:&quot;witch-house&quot;,&quot;norm_name&quot;:&quot;witch-house&quot;},{&quot;name&quot;:&quot;garage&quot;,&quot;value&quot;:&quot;garage&quot;,&quot;norm_name&quot;:&quot;garage&quot;},{&quot;name&quot;:&quot;juke&quot;,&quot;value&quot;:&quot;juke&quot;,&quot;norm_name&quot;:&quot;juke&quot;},{&quot;name&quot;:&quot;footwork&quot;,&quot;value&quot;:&quot;footwork&quot;,&quot;norm_name&quot;:&quot;footwork&quot;},{&quot;name&quot;:&quot;vaporwave&quot;,&quot;value&quot;:&quot;vaporwave&quot;,&quot;norm_name&quot;:&quot;vaporwave&quot;},{&quot;name&quot;:&quot;synthwave&quot;,&quot;value&quot;:&quot;synthwave&quot;,&quot;norm_name&quot;:&quot;synthwave&quot;}],&quot;experimental&quot;:[{&quot;name&quot;:&quot;noise&quot;,&quot;value&quot;:&quot;noise&quot;,&quot;norm_name&quot;:&quot;noise&quot;},{&quot;name&quot;:&quot;drone&quot;,&quot;value&quot;:&quot;drone&quot;,&quot;norm_name&quot;:&quot;drone&quot;},{&quot;name&quot;:&quot;avant garde&quot;,&quot;value&quot;:&quot;avant-garde&quot;,&quot;norm_name&quot;:&quot;avant-garde&quot;},{&quot;name&quot;:&quot;experimental rock&quot;,&quot;value&quot;:&quot;experimental-rock&quot;,&quot;norm_name&quot;:&quot;experimental-rock&quot;},{&quot;name&quot;:&quot;improvisation&quot;,&quot;value&quot;:&quot;improvisation&quot;,&quot;norm_name&quot;:&quot;improvisation&quot;},{&quot;name&quot;:&quot;sound art&quot;,&quot;value&quot;:&quot;sound-art&quot;,&quot;norm_name&quot;:&quot;sound-art&quot;},{&quot;name&quot;:&quot;musique concrete&quot;,&quot;value&quot;:&quot;musique-concrete&quot;,&quot;norm_name&quot;:&quot;musique-concrete&quot;}],&quot;folk&quot;:[{&quot;name&quot;:&quot;singer-songwriter&quot;,&quot;value&quot;:&quot;singer-songwriter&quot;,&quot;norm_name&quot;:&quot;singer-songwriter&quot;},{&quot;name&quot;:&quot;folk rock&quot;,&quot;value&quot;:&quot;folk-rock&quot;,&quot;norm_name&quot;:&quot;folk-rock&quot;},{&quot;name&quot;:&quot;indie folk&quot;,&quot;value&quot;:&quot;indie-folk&quot;,&quot;norm_name&quot;:&quot;indie-folk&quot;},{&quot;name&quot;:&quot;pop folk&quot;,&quot;value&quot;:&quot;pop-folk&quot;,&quot;norm_name&quot;:&quot;pop-folk&quot;},{&quot;name&quot;:&quot;traditional&quot;,&quot;value&quot;:&quot;traditional&quot;,&quot;norm_name&quot;:&quot;traditional&quot;},{&quot;name&quot;:&quot;experimental folk&quot;,&quot;value&quot;:&quot;experimental-folk&quot;,&quot;norm_name&quot;:&quot;experimental-folk&quot;},{&quot;name&quot;:&quot;roots&quot;,&quot;value&quot;:&quot;roots&quot;,&quot;norm_name&quot;:&quot;roots&quot;}],&quot;funk&quot;:[{&quot;name&quot;:&quot;funk jam&quot;,&quot;value&quot;:&quot;funk-jam&quot;,&quot;norm_name&quot;:&quot;funk-jam&quot;},{&quot;name&quot;:&quot;deep funk&quot;,&quot;value&quot;:&quot;deep-funk&quot;,&quot;norm_name&quot;:&quot;deep-funk&quot;},{&quot;name&quot;:&quot;funk rock&quot;,&quot;value&quot;:&quot;funk-rock&quot;,&quot;norm_name&quot;:&quot;funk-rock&quot;},{&quot;name&quot;:&quot;jazz funk&quot;,&quot;value&quot;:&quot;jazz-funk&quot;,&quot;norm_name&quot;:&quot;jazz-funk&quot;},{&quot;name&quot;:&quot;boogie&quot;,&quot;value&quot;:&quot;boogie&quot;,&quot;norm_name&quot;:&quot;boogie&quot;},{&quot;name&quot;:&quot;g-funk&quot;,&quot;value&quot;:&quot;g-funk&quot;,&quot;norm_name&quot;:&quot;g-funk&quot;},{&quot;name&quot;:&quot;rare groove&quot;,&quot;value&quot;:&quot;rare-groove&quot;,&quot;norm_name&quot;:&quot;rare-groove&quot;},{&quot;name&quot;:&quot;electro&quot;,&quot;value&quot;:&quot;electro&quot;,&quot;norm_name&quot;:&quot;electro&quot;},{&quot;name&quot;:&quot;go-go&quot;,&quot;value&quot;:&quot;go-go&quot;,&quot;norm_name&quot;:&quot;go-go&quot;}],&quot;hip-hop-rap&quot;:[{&quot;name&quot;:&quot;rap&quot;,&quot;value&quot;:&quot;rap&quot;,&quot;norm_name&quot;:&quot;rap&quot;},{&quot;name&quot;:&quot;underground hip-hop&quot;,&quot;value&quot;:&quot;underground-hip-hop&quot;,&quot;norm_name&quot;:&quot;underground-hip-hop&quot;},{&quot;name&quot;:&quot;instrumental hip-hop&quot;,&quot;value&quot;:&quot;instrumental-hip-hop&quot;,&quot;norm_name&quot;:&quot;instrumental-hip-hop&quot;},{&quot;name&quot;:&quot;trap&quot;,&quot;value&quot;:&quot;trap&quot;,&quot;norm_name&quot;:&quot;trap&quot;},{&quot;name&quot;:&quot;conscious hip-hop&quot;,&quot;value&quot;:&quot;conscious-hip-hop&quot;,&quot;norm_name&quot;:&quot;conscious-hip-hop&quot;},{&quot;name&quot;:&quot;boom-bap&quot;,&quot;value&quot;:&quot;boom-bap&quot;,&quot;norm_name&quot;:&quot;boom-bap&quot;},{&quot;name&quot;:&quot;beat-tape&quot;,&quot;value&quot;:&quot;beat-tape&quot;,&quot;norm_name&quot;:&quot;beat-tape&quot;},{&quot;name&quot;:&quot;hardcore&quot;,&quot;value&quot;:&quot;hardcore&quot;,&quot;norm_name&quot;:&quot;hardcore&quot;},{&quot;name&quot;:&quot;grime&quot;,&quot;value&quot;:&quot;grime&quot;,&quot;norm_name&quot;:&quot;grime&quot;}],&quot;jazz&quot;:[{&quot;name&quot;:&quot;fusion&quot;,&quot;value&quot;:&quot;fusion&quot;,&quot;norm_name&quot;:&quot;fusion&quot;},{&quot;name&quot;:&quot;big band&quot;,&quot;value&quot;:&quot;big-band&quot;,&quot;norm_name&quot;:&quot;big-band&quot;},{&quot;name&quot;:&quot;nu jazz&quot;,&quot;value&quot;:&quot;nu-jazz&quot;,&quot;norm_name&quot;:&quot;nu-jazz&quot;},{&quot;name&quot;:&quot;modern jazz&quot;,&quot;value&quot;:&quot;modern-jazz&quot;,&quot;norm_name&quot;:&quot;modern-jazz&quot;},{&quot;name&quot;:&quot;swing&quot;,&quot;value&quot;:&quot;swing&quot;,&quot;norm_name&quot;:&quot;swing&quot;},{&quot;name&quot;:&quot;free jazz&quot;,&quot;value&quot;:&quot;free-jazz&quot;,&quot;norm_name&quot;:&quot;free-jazz&quot;},{&quot;name&quot;:&quot;soul jazz&quot;,&quot;value&quot;:&quot;soul-jazz&quot;,&quot;norm_name&quot;:&quot;soul-jazz&quot;},{&quot;name&quot;:&quot;latin jazz&quot;,&quot;value&quot;:&quot;latin-jazz&quot;,&quot;norm_name&quot;:&quot;latin-jazz&quot;},{&quot;name&quot;:&quot;vocal jazz&quot;,&quot;value&quot;:&quot;vocal-jazz&quot;,&quot;norm_name&quot;:&quot;vocal-jazz&quot;},{&quot;name&quot;:&quot;bebop&quot;,&quot;value&quot;:&quot;bebop&quot;,&quot;norm_name&quot;:&quot;bebop&quot;},{&quot;name&quot;:&quot;spiritual jazz&quot;,&quot;value&quot;:&quot;spiritual-jazz&quot;,&quot;norm_name&quot;:&quot;spiritual-jazz&quot;}],&quot;kids&quot;:[{&quot;name&quot;:&quot;family music&quot;,&quot;value&quot;:&quot;family-music&quot;,&quot;norm_name&quot;:&quot;family-music&quot;},{&quot;name&quot;:&quot;educational&quot;,&quot;value&quot;:&quot;educational&quot;,&quot;norm_name&quot;:&quot;educational&quot;},{&quot;name&quot;:&quot;music therapy&quot;,&quot;value&quot;:&quot;music-therapy&quot;,&quot;norm_name&quot;:&quot;music-therapy&quot;},{&quot;name&quot;:&quot;lullaby&quot;,&quot;value&quot;:&quot;lullaby&quot;,&quot;norm_name&quot;:&quot;lullaby&quot;},{&quot;name&quot;:&quot;baby&quot;,&quot;value&quot;:&quot;baby&quot;,&quot;norm_name&quot;:&quot;baby&quot;}],&quot;latin&quot;:[{&quot;name&quot;:&quot;brazilian&quot;,&quot;value&quot;:&quot;brazilian&quot;,&quot;norm_name&quot;:&quot;brazilian&quot;},{&quot;name&quot;:&quot;cumbia&quot;,&quot;value&quot;:&quot;cumbia&quot;,&quot;norm_name&quot;:&quot;cumbia&quot;},{&quot;name&quot;:&quot;tango&quot;,&quot;value&quot;:&quot;tango&quot;,&quot;norm_name&quot;:&quot;tango&quot;},{&quot;name&quot;:&quot;latin rock&quot;,&quot;value&quot;:&quot;latin-rock&quot;,&quot;norm_name&quot;:&quot;latin-rock&quot;},{&quot;name&quot;:&quot;flamenco&quot;,&quot;value&quot;:&quot;flamenco&quot;,&quot;norm_name&quot;:&quot;flamenco&quot;},{&quot;name&quot;:&quot;salsa&quot;,&quot;value&quot;:&quot;salsa&quot;,&quot;norm_name&quot;:&quot;salsa&quot;},{&quot;name&quot;:&quot;reggaeton&quot;,&quot;value&quot;:&quot;reggaeton&quot;,&quot;norm_name&quot;:&quot;reggaeton&quot;},{&quot;name&quot;:&quot;merengue&quot;,&quot;value&quot;:&quot;merengue&quot;,&quot;norm_name&quot;:&quot;merengue&quot;},{&quot;name&quot;:&quot;bolero&quot;,&quot;value&quot;:&quot;bolero&quot;,&quot;norm_name&quot;:&quot;bolero&quot;},{&quot;name&quot;:&quot;méxico d.f.&quot;,&quot;value&quot;:&quot;méxico-d.f.&quot;,&quot;norm_name&quot;:&quot;méxico-d.f.&quot;},{&quot;name&quot;:&quot;bachata&quot;,&quot;value&quot;:&quot;bachata&quot;,&quot;norm_name&quot;:&quot;bachata&quot;}],&quot;metal&quot;:[{&quot;name&quot;:&quot;hardcore&quot;,&quot;value&quot;:&quot;hardcore&quot;,&quot;norm_name&quot;:&quot;hardcore&quot;},{&quot;name&quot;:&quot;black metal&quot;,&quot;value&quot;:&quot;black-metal&quot;,&quot;norm_name&quot;:&quot;black-metal&quot;},{&quot;name&quot;:&quot;death metal&quot;,&quot;value&quot;:&quot;death-metal&quot;,&quot;norm_name&quot;:&quot;death-metal&quot;},{&quot;name&quot;:&quot;thrash metal&quot;,&quot;value&quot;:&quot;thrash-metal&quot;,&quot;norm_name&quot;:&quot;thrash-metal&quot;},{&quot;name&quot;:&quot;grindcore&quot;,&quot;value&quot;:&quot;grindcore&quot;,&quot;norm_name&quot;:&quot;grindcore&quot;},{&quot;name&quot;:&quot;doom&quot;,&quot;value&quot;:&quot;doom&quot;,&quot;norm_name&quot;:&quot;doom&quot;},{&quot;name&quot;:&quot;post hardcore&quot;,&quot;value&quot;:&quot;post-hardcore&quot;,&quot;norm_name&quot;:&quot;post-hardcore&quot;},{&quot;name&quot;:&quot;progressive metal&quot;,&quot;value&quot;:&quot;progressive-metal&quot;,&quot;norm_name&quot;:&quot;progressive-metal&quot;},{&quot;name&quot;:&quot;metalcore&quot;,&quot;value&quot;:&quot;metalcore&quot;,&quot;norm_name&quot;:&quot;metalcore&quot;},{&quot;name&quot;:&quot;sludge metal&quot;,&quot;value&quot;:&quot;sludge-metal&quot;,&quot;norm_name&quot;:&quot;sludge-metal&quot;},{&quot;name&quot;:&quot;heavy metal&quot;,&quot;value&quot;:&quot;heavy-metal&quot;,&quot;norm_name&quot;:&quot;heavy-metal&quot;},{&quot;name&quot;:&quot;deathcore&quot;,&quot;value&quot;:&quot;deathcore&quot;,&quot;norm_name&quot;:&quot;deathcore&quot;},{&quot;name&quot;:&quot;noise&quot;,&quot;value&quot;:&quot;noise&quot;,&quot;norm_name&quot;:&quot;noise&quot;}],&quot;pop&quot;:[{&quot;name&quot;:&quot;indie pop&quot;,&quot;value&quot;:&quot;indie-pop&quot;,&quot;norm_name&quot;:&quot;indie-pop&quot;},{&quot;name&quot;:&quot;synth pop&quot;,&quot;value&quot;:&quot;synth-pop&quot;,&quot;norm_name&quot;:&quot;synth-pop&quot;},{&quot;name&quot;:&quot;power pop&quot;,&quot;value&quot;:&quot;power-pop&quot;,&quot;norm_name&quot;:&quot;power-pop&quot;},{&quot;name&quot;:&quot;new wave&quot;,&quot;value&quot;:&quot;new-wave&quot;,&quot;norm_name&quot;:&quot;new-wave&quot;},{&quot;name&quot;:&quot;dream pop&quot;,&quot;value&quot;:&quot;dream-pop&quot;,&quot;norm_name&quot;:&quot;dream-pop&quot;},{&quot;name&quot;:&quot;noise pop&quot;,&quot;value&quot;:&quot;noise-pop&quot;,&quot;norm_name&quot;:&quot;noise-pop&quot;},{&quot;name&quot;:&quot;experimental pop&quot;,&quot;value&quot;:&quot;experimental-pop&quot;,&quot;norm_name&quot;:&quot;experimental-pop&quot;},{&quot;name&quot;:&quot;electro pop&quot;,&quot;value&quot;:&quot;electro-pop&quot;,&quot;norm_name&quot;:&quot;electro-pop&quot;},{&quot;name&quot;:&quot;adult contemporary&quot;,&quot;value&quot;:&quot;adult-contemporary&quot;,&quot;norm_name&quot;:&quot;adult-contemporary&quot;},{&quot;name&quot;:&quot;jangle pop&quot;,&quot;value&quot;:&quot;jangle-pop&quot;,&quot;norm_name&quot;:&quot;jangle-pop&quot;},{&quot;name&quot;:&quot;j-pop&quot;,&quot;value&quot;:&quot;j-pop&quot;,&quot;norm_name&quot;:&quot;j-pop&quot;}],&quot;punk&quot;:[{&quot;name&quot;:&quot;hardcore punk&quot;,&quot;value&quot;:&quot;hardcore-punk&quot;,&quot;norm_name&quot;:&quot;hardcore-punk&quot;},{&quot;name&quot;:&quot;garage&quot;,&quot;value&quot;:&quot;garage&quot;,&quot;norm_name&quot;:&quot;garage&quot;},{&quot;name&quot;:&quot;pop punk&quot;,&quot;value&quot;:&quot;pop-punk&quot;,&quot;norm_name&quot;:&quot;pop-punk&quot;},{&quot;name&quot;:&quot;punk rock&quot;,&quot;value&quot;:&quot;punk-rock&quot;,&quot;norm_name&quot;:&quot;punk-rock&quot;},{&quot;name&quot;:&quot;post-punk&quot;,&quot;value&quot;:&quot;post-punk&quot;,&quot;norm_name&quot;:&quot;post-punk&quot;},{&quot;name&quot;:&quot;post-hardcore&quot;,&quot;value&quot;:&quot;post-hardcore&quot;,&quot;norm_name&quot;:&quot;post-hardcore&quot;},{&quot;name&quot;:&quot;thrash&quot;,&quot;value&quot;:&quot;thrash&quot;,&quot;norm_name&quot;:&quot;thrash&quot;},{&quot;name&quot;:&quot;crust punk&quot;,&quot;value&quot;:&quot;crust-punk&quot;,&quot;norm_name&quot;:&quot;crust-punk&quot;},{&quot;name&quot;:&quot;folk punk&quot;,&quot;value&quot;:&quot;folk-punk&quot;,&quot;norm_name&quot;:&quot;folk-punk&quot;},{&quot;name&quot;:&quot;emo&quot;,&quot;value&quot;:&quot;emo&quot;,&quot;norm_name&quot;:&quot;emo&quot;},{&quot;name&quot;:&quot;ska&quot;,&quot;value&quot;:&quot;ska&quot;,&quot;norm_name&quot;:&quot;ska&quot;},{&quot;name&quot;:&quot;no wave&quot;,&quot;value&quot;:&quot;no-wave&quot;,&quot;norm_name&quot;:&quot;no-wave&quot;}],&quot;r-b-soul&quot;:[{&quot;name&quot;:&quot;soul&quot;,&quot;value&quot;:&quot;soul&quot;,&quot;norm_name&quot;:&quot;soul&quot;},{&quot;name&quot;:&quot;r&amp;b&quot;,&quot;value&quot;:&quot;r-b&quot;,&quot;norm_name&quot;:&quot;r-b&quot;},{&quot;name&quot;:&quot;neo-soul&quot;,&quot;value&quot;:&quot;neo-soul&quot;,&quot;norm_name&quot;:&quot;neo-soul&quot;},{&quot;name&quot;:&quot;gospel&quot;,&quot;value&quot;:&quot;gospel&quot;,&quot;norm_name&quot;:&quot;gospel&quot;},{&quot;name&quot;:&quot;contemporary r&amp;b&quot;,&quot;value&quot;:&quot;contemporary-r-b&quot;,&quot;norm_name&quot;:&quot;contemporary-r-b&quot;},{&quot;name&quot;:&quot;motown&quot;,&quot;value&quot;:&quot;motown&quot;,&quot;norm_name&quot;:&quot;motown&quot;},{&quot;name&quot;:&quot;urban&quot;,&quot;value&quot;:&quot;urban&quot;,&quot;norm_name&quot;:&quot;urban&quot;}],&quot;reggae&quot;:[{&quot;name&quot;:&quot;dub&quot;,&quot;value&quot;:&quot;dub&quot;,&quot;norm_name&quot;:&quot;dub&quot;},{&quot;name&quot;:&quot;ska&quot;,&quot;value&quot;:&quot;ska&quot;,&quot;norm_name&quot;:&quot;ska&quot;},{&quot;name&quot;:&quot;roots&quot;,&quot;value&quot;:&quot;roots&quot;,&quot;norm_name&quot;:&quot;roots&quot;},{&quot;name&quot;:&quot;dancehall&quot;,&quot;value&quot;:&quot;dancehall&quot;,&quot;norm_name&quot;:&quot;dancehall&quot;},{&quot;name&quot;:&quot;rocksteady&quot;,&quot;value&quot;:&quot;rocksteady&quot;,&quot;norm_name&quot;:&quot;rocksteady&quot;},{&quot;name&quot;:&quot;ragga&quot;,&quot;value&quot;:&quot;ragga&quot;,&quot;norm_name&quot;:&quot;ragga&quot;},{&quot;name&quot;:&quot;lovers rock&quot;,&quot;value&quot;:&quot;lovers-rock&quot;,&quot;norm_name&quot;:&quot;lovers-rock&quot;}],&quot;rock&quot;:[{&quot;name&quot;:&quot;indie&quot;,&quot;value&quot;:&quot;indie&quot;,&quot;norm_name&quot;:&quot;indie&quot;},{&quot;name&quot;:&quot;prog rock&quot;,&quot;value&quot;:&quot;prog-rock&quot;,&quot;norm_name&quot;:&quot;prog-rock&quot;},{&quot;name&quot;:&quot;post-rock&quot;,&quot;value&quot;:&quot;post-rock&quot;,&quot;norm_name&quot;:&quot;post-rock&quot;},{&quot;name&quot;:&quot;rock &amp; roll&quot;,&quot;value&quot;:&quot;rock-roll&quot;,&quot;norm_name&quot;:&quot;rock-roll&quot;},{&quot;name&quot;:&quot;psychedelic rock&quot;,&quot;value&quot;:&quot;psychedelic-rock&quot;,&quot;norm_name&quot;:&quot;psychedelic-rock&quot;},{&quot;name&quot;:&quot;hard rock&quot;,&quot;value&quot;:&quot;hard-rock&quot;,&quot;norm_name&quot;:&quot;hard-rock&quot;},{&quot;name&quot;:&quot;garage rock&quot;,&quot;value&quot;:&quot;garage-rock&quot;,&quot;norm_name&quot;:&quot;garage-rock&quot;},{&quot;name&quot;:&quot;surf rock&quot;,&quot;value&quot;:&quot;surf-rock&quot;,&quot;norm_name&quot;:&quot;surf-rock&quot;},{&quot;name&quot;:&quot;instrumental&quot;,&quot;value&quot;:&quot;instrumental&quot;,&quot;norm_name&quot;:&quot;instrumental&quot;},{&quot;name&quot;:&quot;math rock&quot;,&quot;value&quot;:&quot;math-rock&quot;,&quot;norm_name&quot;:&quot;math-rock&quot;},{&quot;name&quot;:&quot;rockabilly&quot;,&quot;value&quot;:&quot;rockabilly&quot;,&quot;norm_name&quot;:&quot;rockabilly&quot;}],&quot;soundtrack&quot;:[{&quot;name&quot;:&quot;film music&quot;,&quot;value&quot;:&quot;film-music&quot;,&quot;norm_name&quot;:&quot;film-music&quot;},{&quot;name&quot;:&quot;video game music&quot;,&quot;value&quot;:&quot;video-game-music&quot;,&quot;norm_name&quot;:&quot;video-game-music&quot;}],&quot;spoken-word&quot;:[{&quot;name&quot;:&quot;poetry&quot;,&quot;value&quot;:&quot;poetry&quot;,&quot;norm_name&quot;:&quot;poetry&quot;},{&quot;name&quot;:&quot;inspirational&quot;,&quot;value&quot;:&quot;inspirational&quot;,&quot;norm_name&quot;:&quot;inspirational&quot;},{&quot;name&quot;:&quot;storytelling&quot;,&quot;value&quot;:&quot;storytelling&quot;,&quot;norm_name&quot;:&quot;storytelling&quot;},{&quot;name&quot;:&quot;self-help&quot;,&quot;value&quot;:&quot;self-help&quot;,&quot;norm_name&quot;:&quot;self-help&quot;}],&quot;world&quot;:[{&quot;name&quot;:&quot;latin&quot;,&quot;value&quot;:&quot;latin&quot;,&quot;norm_name&quot;:&quot;latin&quot;},{&quot;name&quot;:&quot;roots&quot;,&quot;value&quot;:&quot;roots&quot;,&quot;norm_name&quot;:&quot;roots&quot;},{&quot;name&quot;:&quot;african&quot;,&quot;value&quot;:&quot;african&quot;,&quot;norm_name&quot;:&quot;african&quot;},{&quot;name&quot;:&quot;tropical&quot;,&quot;value&quot;:&quot;tropical&quot;,&quot;norm_name&quot;:&quot;tropical&quot;},{&quot;name&quot;:&quot;tribal&quot;,&quot;value&quot;:&quot;tribal&quot;,&quot;norm_name&quot;:&quot;tribal&quot;},{&quot;name&quot;:&quot;brazilian&quot;,&quot;value&quot;:&quot;brazilian&quot;,&quot;norm_name&quot;:&quot;brazilian&quot;},{&quot;name&quot;:&quot;celtic&quot;,&quot;value&quot;:&quot;celtic&quot;,&quot;norm_name&quot;:&quot;celtic&quot;},{&quot;name&quot;:&quot;world fusion&quot;,&quot;value&quot;:&quot;world-fusion&quot;,&quot;norm_name&quot;:&quot;world-fusion&quot;},{&quot;name&quot;:&quot;cumbia&quot;,&quot;value&quot;:&quot;cumbia&quot;,&quot;norm_name&quot;:&quot;cumbia&quot;},{&quot;name&quot;:&quot;gypsy&quot;,&quot;value&quot;:&quot;gypsy&quot;,&quot;norm_name&quot;:&quot;gypsy&quot;},{&quot;name&quot;:&quot;new age&quot;,&quot;value&quot;:&quot;new-age&quot;,&quot;norm_name&quot;:&quot;new-age&quot;},{&quot;name&quot;:&quot;balkan&quot;,&quot;value&quot;:&quot;balkan&quot;,&quot;norm_name&quot;:&quot;balkan&quot;},{&quot;name&quot;:&quot;reggaeton&quot;,&quot;value&quot;:&quot;reggaeton&quot;,&quot;norm_name&quot;:&quot;reggaeton&quot;}]},&quot;activation_url&quot;:&quot;https://arbee.bandcamp.com/album/des-papiers-ii&quot;,&quot;activation_sig&quot;:&quot;EJRODKlsJWi7tOYxekc+p1il6Ko=&quot;,&quot;is_phone&quot;:false,&quot;isMobile&quot;:false},&quot;mobile_app_url&quot;:&quot;x-bandcamp://open&quot;,&quot;platform_app_url&quot;:null,&quot;app_store_url&quot;:&quot;https://itunes.apple.com/us/app/bandcamp/id706408639?mt=8&quot;,&quot;play_store_url&quot;:&quot;https://play.google.com/store/apps/details?id=com.bandcamp.android&quot;,&quot;unsupported_device&quot;:true,&quot;fan_tralbum_data&quot;:null,&quot;album_id&quot;:948735258,&quot;pgload_sample_rate&quot;:5,&quot;item_sellers&quot;:{&quot;4038363339&quot;:{&quot;id&quot;:4038363339,&quot;name&quot;:&quot;arbee&quot;,&quot;currency&quot;:&quot;CAD&quot;,&quot;max_price&quot;:1000.0,&quot;digital_vat_enabled&quot;:true,&quot;is_dsa_trader&quot;:false}},&quot;gift_card_balance&quot;:null,&quot;limited_checkout&quot;:false,&quot;ab_test_tralbum_auth_entrypoints&quot;:false,&quot;identities&quot;:{&quot;user&quot;:null,&quot;ip_country_code&quot;:&quot;NL&quot;,&quot;fan&quot;:null,&quot;is_page_band_member&quot;:null,&quot;subscribed_to_page_band&quot;:null,&quot;bands&quot;:[],&quot;partner&quot;:false,&quot;is_admin&quot;:null,&quot;labels&quot;:[],&quot;page_band&quot;:null,&quot;active_licenses&quot;:[]},&quot;rec_footer&quot;:{},&quot;show_tos_banner_layout&quot;:true}"></div>
+
+    <div id="menubar-wrapper" class="
+        header-rework-2018
+        
+        header-discover-2023
+    ">
+    
+
+
+
+
+
+
+
+
+    
+    
+    
+    
+
+
+
+
+    
+
+
+
+    
+    
+
+
+
+    
+    
+
+
+
+    
+    
+
+
+
+    
+
+
+<div id="menubar-vm" class="menubar-outer loading header-discover-2023" data-initial-values="{&quot;any_pro&quot;:false,&quot;is_tralbum_page&quot;:true,&quot;admin_level&quot;:null,&quot;artist_service_active&quot;:false,&quot;artist_subscriptions_enabled&quot;:false,&quot;active_profile_photo&quot;:null,&quot;cart_quantity&quot;:null,&quot;discover_root&quot;:&quot;https://bandcamp.com/discover&quot;,&quot;page_path&quot;:&quot;/album/des-papiers-ii&quot;,&quot;is_fan_page&quot;:false,&quot;is_download_page&quot;:false,&quot;show_crowdfunding_link&quot;:true,&quot;show_add_live_show&quot;:null,&quot;show_guide_link&quot;:null}">
+<div id="menubar"
+    class="
+        menubar-2018
+        out 
+        
+        
+    "
+>
+<ul id="site-nav" class="menubar-section horizontal" data-test="site-nav">
+
+    
+    
+        
+        
+        
+    
+    <li class="bclogo white" data-test="mb-bandcamp-logo">
+        <a href="https://bandcamp.com/?from=menubar_logo_logged_out">
+            <svg width="108px" height="17px" viewBox="0 0 127 20"><use xlink:href="#bandcamp-logo-color-white"></svg>
+        </a>
+    </li>
+    <li class="bclogo aqua" data-test="mb-bandcamp-logo">
+        <a href="https://bandcamp.com/?from=menubar_logo_logged_out">
+            <svg width="108px" height="17px" viewBox="0 0 127 20"><use xlink:href="#bandcamp-logo-color-bcaqua"></svg>
+        </a>
+    </li>
+
+    <!-- ko if: showBandControls() || showLimitedAccessControls() -->
+    
+    <li class="menubar-item hoverable hidden-while-loading add-menu" data-test="mb-add">
+        <a class="menubar-add-link">+ add</a>
+        <ul class="menu hidden-while-loading">
+            
+            <!-- ko if: showBandControls() || showLimitedAccessControls() -->
+            <ol data-bind="css: {'page-band-links': pageBand.isLabel()}">
+                <li class="submenu-item" data-test="mb-add-album"><a data-bind="attr: {href: pageBand.trackpipeLocalUrl() + '/edit_album'}, click: addAlbumClick">album</a></li>
+                <li class="submenu-item" data-test="mb-add-track"><a data-bind="attr: {href: pageBand.trackpipeLocalUrl() + '/edit_track'}, click: addTrackClick">track</a></li>
+                <li class="submenu-item"data-test="mb-add-merch"><a id="menubar-add-merch-link" data-bind="attr: {href: pageBand.trackpipeLocalUrl() + '/edit_merch'}, click: addMerchClick"><span class="add-music">merch</span></a></li>
+                
+                    <li class="submenu-item" data-test="mb-add-vinyl"><a id="menubar-add-merch-link" data-bind="attr: {href: pageBand.trackpipeLocalUrl() + '/edit_vinyl_campaign'}"><span class="add-music">vinyl campaign</span></a></li>
+                
+
+                
+
+                <li class="submenu-item" data-test="mb-add-listening-party"><a data-bind="attr: {href: pageBand.trackpipeLocalUrl() + '/edit_listening_party'}, click: addListeningPartyClick">listening party</a></li>
+            </ol>
+            <!-- /ko -->
+            <!-- ko if: showBandControls() && pageBand.isLabel() -->
+            <ol>
+                <li class="ui-widget-content ui-menu-divider"></li>
+                <li class="submenu-item"><a data-bind="click: addNewArtist">new artist</a></li>
+                <li class="submenu-item"><a data-bind="click: addExistingArtist">existing artist</a></li>
+            </ol>
+            <!-- /ko -->
+        </ul>
+    </li>
+    <!-- /ko -->
+
+    
+
+    <!-- ko if: showBandControls() || showLimitedAccessControls() -->
+    
+    
+
+    
+        <li class="menubar-item hoverable hidden-while-loading" data-test="mb-stats">
+            <a data-bind="attr: {href: statsLinkHref2018}">stats</a>
+        </li>
+
+    
+
+    
+
+    <!-- /ko -->
+    <!-- ko ifnot: showBandControls() || showLimitedAccessControls() -->
+    <!-- ko ifnot: showMobileAutocomplete() -->
+    
+        <li id="main-search-container" class="search extended menubar-item " data-test="mb-search-box">
+            <form aria-label="autocomplete search" class="menubar-search signup-tooltip-parent" action="/search" method="get" data-tooltip-id="s" aria-busy="false">
+  <input tabindex="0" aria-autocomplete="list" class="dismiss-tooltip-alt search-bar" type="text" name="q" placeholder="Search for artist, album, or track" autocomplete="off" maxlength="2048">
+    <div role="progressbar" class="loading-icon" id="search-loading-icon" aria-busy="false">
+        <svg aria-label="loading icon" class="search-spinner" width="15" height="16" viewBox="-1 -1 16 16">
+            <use href="#search-spinner"></use>
+        </svg>
+    </div>
+    <div aria-label="clear search" class="clear-autocomplete" >×</div>
+  </input>
+  <input type="hidden" class="selected-filter" name="item_type" value="" />
+  <button type="submit" tabindex="-1" aria-label="submit for full search page" class="menubar-search-icon"><svg width="15" height="16" viewBox="0 0 15 16"><use href="#menubar-search-input-icon" /></svg></button>
+  <ul role="listbox" class="genre-list" aria-busy="false"></ul>
+  <ul class="filter-list" aria-busy="false"></ul>
+  <ul role="listbox" class="search-autocomplete" aria-busy="false">
+    
+    <li class="simple results-see-all">
+      <a tabindex="-1" aria-label="visit full-search page">
+        <span>See all results</span>
+        <span><svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg></span>
+      </a>
+    </li>
+    <li class="simple results-tags">
+      <a tabindex="-1" >
+        <span class="msg"></span>
+        <span><svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg></span>
+      </a>
+    </li>
+    <li class="simple results-genre">
+      <a tabindex="-1">
+        <span class="msg"></span>
+        <span><svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg></span>
+      </a>
+    </li>
+    <li aria-label="no matching results" class="autocomplete-no-results" >
+      <p class="noresults-header">No matching results</p>
+      <p class="noresults-text">Try a different filter or a new search keyword.</p>
+      <div class="tumbleweed">
+        <img loading="lazy" src="/img/search/tumbleweed-emptystate-lightbg.gif"/>
+      </div>
+    </li>
+  </ul>
+  <li class="simple mobile-results-tags no-show">
+    <a>
+      <span class="msg"></span>
+      <span><svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg></span>
+    </a>
+  </li>
+  <div class="mobile-placeholder">
+      <p>Search all Bandcamp artists, tracks, and albums</p>
+  </div>
+  <template id="autocomplete-results-item"><li class="result-item">
+    <a tabindex="-1">
+      <span class="result-art"><img></span>
+      <span class="result-info">
+        <div class="result-title"><strong></strong></div>
+        <cite></cite>
+        <div class="result-type"></div>
+      </span>
+    </a>
+  </li></template>
+  <div class="signup-tooltip-outer search-tooltip-outer header-2018"></div>
+</form>
+<div aria-label="cancel search" class="cancel-autocomplete" >cancel</div>
+        </li>
+    
+    <!-- /ko -->
+    <!-- /ko -->
+</ul>
+
+<ul id="user-nav" class="menubar-section horizontal">
+<!-- ko if: user() -->
+
+    
+    <!-- ko if: partner() -->
+    <li class="menubar-item hoverable hidden-while-loading">
+        <a href="https://bandcamp.com/partner">partner</a>
+    </li>
+    <!-- /ko -->
+
+    <!-- ko if: showBandControls() || showLimitedAccessControls() -->
+    
+        
+        
+        <!-- ko ifnot: showMobileAutocomplete() -->
+        <!-- ko if: altSearch() -->
+        <li id="alt-search-container" class="search extended menubar-item  hidden-while-loading" data-bind="visible: altSearch()">
+            <form aria-label="autocomplete search" class="menubar-search signup-tooltip-parent" action="/search" method="get" data-tooltip-id="s" aria-busy="false">
+  <input tabindex="0" aria-autocomplete="list" class="dismiss-tooltip-alt search-bar" type="text" name="q" placeholder="Search for artist, album, or track" autocomplete="off" maxlength="2048">
+    <div role="progressbar" class="loading-icon" id="search-loading-icon" aria-busy="false">
+        <svg aria-label="loading icon" class="search-spinner" width="15" height="16" viewBox="-1 -1 16 16">
+            <use href="#search-spinner"></use>
+        </svg>
+    </div>
+    <div aria-label="clear search" class="clear-autocomplete" >×</div>
+  </input>
+  <input type="hidden" class="selected-filter" name="item_type" value="" />
+  <button type="submit" tabindex="-1" aria-label="submit for full search page" class="menubar-search-icon"><svg width="15" height="16" viewBox="0 0 15 16"><use href="#menubar-search-input-icon" /></svg></button>
+  <ul role="listbox" class="genre-list" aria-busy="false"></ul>
+  <ul class="filter-list" aria-busy="false"></ul>
+  <ul role="listbox" class="search-autocomplete" aria-busy="false">
+    
+    <li class="simple results-see-all">
+      <a tabindex="-1" aria-label="visit full-search page">
+        <span>See all results</span>
+        <span><svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg></span>
+      </a>
+    </li>
+    <li class="simple results-tags">
+      <a tabindex="-1" >
+        <span class="msg"></span>
+        <span><svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg></span>
+      </a>
+    </li>
+    <li class="simple results-genre">
+      <a tabindex="-1">
+        <span class="msg"></span>
+        <span><svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg></span>
+      </a>
+    </li>
+    <li aria-label="no matching results" class="autocomplete-no-results" >
+      <p class="noresults-header">No matching results</p>
+      <p class="noresults-text">Try a different filter or a new search keyword.</p>
+      <div class="tumbleweed">
+        <img loading="lazy" src="/img/search/tumbleweed-emptystate-lightbg.gif"/>
+      </div>
+    </li>
+  </ul>
+  <li class="simple mobile-results-tags no-show">
+    <a>
+      <span class="msg"></span>
+      <span><svg class="arrow" viewBox="0 0 24 24"><use href="#discover-arrow"></svg></span>
+    </a>
+  </li>
+  <div class="mobile-placeholder">
+      <p>Search all Bandcamp artists, tracks, and albums</p>
+  </div>
+  <template id="autocomplete-results-item"><li class="result-item">
+    <a tabindex="-1">
+      <span class="result-art"><img></span>
+      <span class="result-info">
+        <div class="result-title"><strong></strong></div>
+        <cite></cite>
+        <div class="result-type"></div>
+      </span>
+    </a>
+  </li></template>
+  <div class="signup-tooltip-outer search-tooltip-outer header-2018"></div>
+</form>
+<div aria-label="cancel search" class="cancel-autocomplete" >cancel</div>
+        </li>
+        <!-- /ko -->
+        
+        <li class="you-autocomplete-me menubar-item hidden-while-loading hoverable" data-bind="click: showAltSearch, visible: !altSearch()">
+            <a><svg width="26px" height="26px" viewBox="0 0 26 26" class="svg-icon"><use xlink:href="#menubar-search-icon"></svg></a>
+        </li>
+        <!-- /ko -->
+    
+    <!-- /ko --> <!-- claire minimized search for artist -->
+
+    
+
+    
+
+    
+
+    
+
+    <!-- ko if: (fan() && !fan().private) -->
+    
+        <li id="feed-main" class="signup-tooltip-parent menubar-item hoverable hidden-while-loading" data-tooltip-id="f" data-test="mb-feed">
+            <a href="" title="feed">
+                <svg width="26px" height="26px" viewBox="0 0 26 26" class="svg-icon"><use xlink:href="#menubar-feed-icon"></svg>
+            </a>
+            <div class="signup-tooltip-outer feed-tooltip-outer header-2018"></div>
+        </li>
+    
+
+    
+        
+        <li id="collection-main" class="menubar-item hoverable signup-tooltip-parent hidden-while-loading" data-tooltip-id="c" data-test="mb-collection">
+            <a href="" title="collection">
+                <svg width="26" height="26" viewBox="0 0 26 26" class="svg-icon"><use xlink:href="#menubar-collection-icon"></svg>
+            </a>
+            <div class="signup-tooltip-outer collection-tooltip-outer header-2018"></div>
+        </li>
+        
+    
+    <!-- /ko -->
+        <li class="menubar-item hoverable hidden-while-loading" data-test="user-menu">
+        <a>
+            <div data-bind="with: artistsMenu">
+                
+                    <!-- Fan only profile pic -->
+                    <!-- ko if: $parent.loggedInFanPhoto() -->
+                    <div class="userpic  hidden-while-loading">
+                        <img src="https://f4.bcbits.com/img/blank.gif" data-bind="src_image: {image_id: $parent.loggedInFanPhoto(), format: 'art_embedded_player'}"
+                        >
+                    </div>
+                    <!-- /ko -->
+                    <!-- ko ifnot: $parent.loggedInFanPhoto() -->
+                    <div class="userpic  ">
+                        <div class="no-image-placeholder"></div>
+                    </div>
+                    <!-- /ko -->
+                
+            </div>
+        </a>
+
+        <ul class="menu user-menu hidden-while-loading" data-bind="with: artistsMenu, css: { label: (artistsMenu.loggedInLabelMemberBands().length > 0 || artistsMenu.linkedNonLabelMemberBands().length > 1) }">
+        <ol class="user-menu-wrapper">
+            <!-- ARTIST -->
+            <!-- ko if: bmgr.bands().length >= 1 && loggedInBand() -->
+                <li class="submenu-item">
+                    <a data-bind="attr: { href: loggedInBand().trackpipeLocalUrl()}" class="name">
+                        <strong class="menu-bandname" data-bind="text: optionsLoggedInBand().title, css: { long: !optionsLoggedInBand().showPro}">artists</strong>
+                        
+                        <div data-bind="visible: optionsLoggedInBand().showPro" class="menubar-badge-pro round3 hidden-while-loading">PRO</div>
+                        <div class="view-site">view site</div>              
+                    </a>
+                </li> 
+
+                <li class="submenu-item">
+                    <a data-bind="
+                        attr: {href: 'https://bandcamp.com/profile?from=menubar&id=' + loggedInBand().id},
+                        css: {admin: optionsLoggedInBand().adminAccess}"
+                    >
+                        <span>edit profile</span>
+                    </a>
+                </li>
+                <li class="submenu-item">
+                    <a data-bind="
+                        attr: {href: 'https://bandcamp.com/tools?from=menubar&id=' + loggedInBand().id},
+                        css: {admin: optionsLoggedInBand().adminAccess}"
+                    >
+                        <span>tools</span>
+                    </a>
+                </li>
+                
+
+                <li class="ui-menu-item  submenu-item">
+                    <!-- ko ifnot: loggedInBand().hasService() -->
+                        <a data-bind="attr: { href: 'https://bandcamp.com/subscriptions?band_id=' + loggedInBand().id + '&from=menubar'}">subscription</a>
+                    <!-- /ko -->
+                    <!-- ko if: loggedInBand().hasService() -->
+                        <a data-bind="attr: { href: loggedInBand().trackpipeLocalUrl() + '/' + loggedInBand().serviceUrlFragment() + '?from=menubar'}">subscription</a>
+                    <!-- /ko -->
+                </li>
+            <!-- /ko -->
+            
+            <!-- FAN -->
+            <!-- ko if: ($parent.fan() && !$parent.fan().private) -->
+            <li class="submenu-item">
+                <a href="" class="name">
+                    <strong class="menu-bandname long" data-test="fan-username"></strong>
+                    
+                    <div class="view-collection" data-test="submenu-item-view-collection">view collection</div>
+                </a>
+            </li>
+            <li class="submenu-item"><a href=""><span data-test="submenu-item-purchases">purchases</span></a></li>
+            <!-- /ko -->
+            <li class="ui-widget-content ui-menu-divider first"></li>
+
+            <!-- LABEL ARTISTS -->
+            <!-- ko if: loggedInLabelMemberBands() && loggedInLabelMemberBands().length > 0 -->
+            <li class="menu-switch ui-menu-item submenu-item ui-state-disabled" data-bind="visible: !showLinkedBands()">
+                <span data-bind="attr: {href: loggedInBand().trackpipeLocalUrl() + '/artists?from=menubar_artist_dropdown'}, text: loggedInLabelMemberBandsCountStr()"></span>
+            </li>
+
+            <ol class="label-artist-menu no-pro-badges ui-state-disabled ui-menu-item" data-bind="visible: !showLinkedBands()" data-test="label-artists">
+            <input type="text" class="artist-filter-text" data-test="artist-filter-text" data-bind="textInput: labelMemberBandsSearchTerm, visible: loggedInLabelMemberBands().length > 10" placeholder="Search all artists">
+
+                <!-- ko foreach: filteredLoggedInLabelMemberBands() -->
+                    <li class="label-member-band submenu-item" data-bind="template: {
+                        'name': 'band-menuitem-template-options'
+                    }"></li>
+                <!-- /ko -->
+
+                <!-- ko if: filteredLoggedInLabelMemberBands().length == 0 -->
+                    <li class="no-results submenu-item">no results</li>
+                <!-- /ko -->
+            </ol>
+            <li class="ui-widget-content ui-menu-divider" data-bind="visible: !showLinkedBands()"></li>
+            <!-- /ko -->
+
+            <!-- CONNECTED ACCOUNTS -->
+            <!-- ko if: linkedNonLabelMemberBands().length > 1 -->
+            <ol class="linked-accounts-wrapper">
+                <li class="menu-switch ui-menu-item submenu-item linked-accounts-menu ui-state-disabled" data-bind="click: () => showLinkedBands(!showLinkedBands())" data-test="linked-accounts-header">
+                <span data-bind="text: loggedInLinkedBandsCountStr()"></span><div data-bind="css: { 'arrow-down': showLinkedBands(), 'arrow-right' : !showLinkedBands() }"></div>
+                </li>
+                <ol class="linked-accounts-menu-content" data-bind="visible: showLinkedBands()" data-test="linked-accounts">
+                <!-- ko foreach: linkedNonLabelMemberBands() -->
+                    <li class="submenu-item" data-bind="template: {
+                        'name': 'band-menuitem-template'
+                    },
+                    css: {
+                        'hidden': ($data.id == $root.artistsMenu.loggedInBand().id)
+                    }"></li>
+                <!-- /ko -->
+                </ol>
+            </ol>
+            <li class="ui-widget-content ui-menu-divider"></li>
+            <!-- /ko -->
+
+
+            <!-- ALL USERS -->
+            <ol class="all-user-option">
+                <li class="submenu-item"><a href="https://bandcamp.com/settings?from=menubar" data-test="submenu-item-settings">settings</a></li>
+                
+                <li class="submenu-item"><a href="https://get.bandcamp.help" data-test="submenu-item-help">help</a></li>
+                <li class="submenu-item"><a class="logout-action" href="https://bandcamp.com/logout" data-test="submenu-item-logout">log out</a></li>
+            </ol>
+        </ol>
+        </ul>
+    </li>
+<!-- /ko -->
+
+<!-- ko ifnot: user() -->
+    
+    
+    <li data-bind="visible: hasCart" class="menubar-item hoverable cart-wrapper hidden-while-loading svg-icon" data-test="mb-cart">
+        <a href="https://bandcamp.com/cart" data-bind="click: goCart" title="cart">
+            <svg width="26" height="26" class="menubar-cart-icon">
+                <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#menubar-cart-icon"></use>
+                <text data-bind="text: numCartItemsDisplay" x="15" y="12" dominant-baseline="middle" text-anchor="middle">
+                    
+                </text>
+            </svg>
+        </a>
+    </li>
+    
+    
+        
+            <li class="menubar-item hoverable  " data-test="mb-signup">
+                <a class="all-signup-link">
+                    
+                        sign up
+                    
+                </a>
+            </li>
+        
+        <li class="menubar-item hoverable  " data-test="mb-login">
+            <a href="https://bandcamp.com/login?from=menubar" class="login-link">
+                
+                    log in
+                
+            </a>
+        </li>
+    
+<!-- /ko -->
+
+
+
+
+</ul>
+</div>
+
+
+
+<div class='corp-banners'>
+
+
+
+
+
+
+
+
+
+
+
+
+    
+        
+    
+
+</div>
+
+<!-- Knockout template for list items in the artists menu -->
+<script type="text/html" id="band-menuitem-template">
+    <a class="menu-artistitem"
+        data-bind="css: {'is-pro': isPro()}, attr: {href: $root.artistsMenu.isPageBand(id) ? '' : trackpipeLocalUrl()}"
+    >
+        <span class="menu-artistpic">
+            <!-- ko if: photo() -->
+            <img data-bind="src_image: {image_id: photo(), format: 'art_embedded_player'}">
+            <!-- /ko -->
+            <!-- ko ifnot: photo() -->
+            <div class="no-image-placeholder"></div>
+            <!-- /ko -->
+        </span>
+        <span data-bind="text: name()" class="menu-bandname menu-text"></span>
+        <span data-bind="visible: isPro()" class="menubar-badge-pro round3">PRO</span>
+    </a>
+</script>
+
+<script type="text/html" id="band-menuitem-template-options">
+    <a data-bind="attr: {href: trackpipeLocalUrl()}" class="menu-artistitem">
+        <span class="menu-artistpic">
+            <!-- ko if: photo() -->
+            <img data-bind="src_image: {image_id: photo(), format: 'art_embedded_player'}">
+            <!-- /ko -->
+            <!-- ko ifnot: photo() -->
+            <div class="no-image-placeholder"></div>
+            <!-- /ko -->
+        </span>
+        <span data-bind="text: name()" class="menu-bandname menu-text"></span>
+        <span class="show-more" data-bind="visible: $root.artistsMenu.bmgr.bandByID(id) || $root.artistsMenu.lmgr.isMemberBandAuthed(id), click: () => $root.artistsMenu.setActiveLabelMemberBand(id)">•••</span>
+    </a>
+    <!-- ko if: ($root.artistsMenu.activeLabelMemberBand() == id) -->
+    <div class="label-artist-menu-links ui-menu-item">
+        <span data-bind="visible: $root.artistsMenu.bmgr.bandByID(id) || $root.artistsMenu.lmgr.isMemberBandAuthed(id)">
+            <a data-bind="
+                attr: {href: 'https://bandcamp.com/profile?from=menubar&id=' + id}"
+            >
+                <span class="menu-text">edit profile</span>
+            </a>
+            <a data-bind="
+                attr: {href: 'https://bandcamp.com/tools?from=menubar&id=' + id}"
+            >
+                <span class="menu-text">tools<span>
+            </a>
+            <!-- ko if: hasItems -->
+                <a data-bind="click: $root.artistsMenu.launchPageDesign.bind($data)"><span class="menu-text">page design</span></a>
+            <!-- /ko -->
+
+            <!-- ko ifnot: hasService() -->
+                <a data-bind="attr: { href: 'https://bandcamp.com/subscriptions?band_id=' + id + '&from=menubar'}"><span class="menu-text">subscription</span></a>
+            <!-- /ko -->
+            <!-- ko if: hasService() -->
+                <a data-bind="attr: { href: trackpipeLocalUrl() + '/' + serviceUrlFragment() + '?from=menubar'}"><span data-bind="text: serviceName()" class="menu-text">subscription</span></a>
+            <!-- /ko -->
+        </span>
+    </div>
+    <!-- /ko -->
+    <span class="show-less" data-bind="visible: $root.artistsMenu.activeLabelMemberBand() == id && ($root.artistsMenu.bmgr.bandByID(id) || $root.artistsMenu.lmgr.isMemberBandAuthed(id)), click: () => $root.artistsMenu.setActiveLabelMemberBand(id)">show less</span>
+</script>
+
+
+<!-- Knockout template for the parent label -->
+<script type="text/html" id="band-parentlabel-template">
+    <div data-bind="css: {'artist-listing-with-links': $parent.columns() > 1}">
+        <a class="menu-artistitem" data-bind="attr: {href: trackpipeUrlHttps()}">
+        <!-- ko if: $parent.columns() === 1 -->
+            <span class="menu-artistpic">
+                <img data-bind="src_image: {image_id: photo(), format: 'bio_navbar'}">
+            </span>
+            <span data-bind="text: name()" class="menu-bandname"></span>
+        <!-- /ko -->
+        <!-- ko if: $parent.columns() > 1 -->
+            <!-- ko if: photo() -->
+                <img class="photo" data-bind="src_image: {image_id: photo(), format: 'fan_bio_thumb_small'}">
+            <!-- /ko -->
+            <!-- ko ifnot: photo() -->
+                <div class="photo none"></div>
+            <!-- /ko -->
+        <!-- /ko -->
+        </a>
+   
+        <div class="infobox">
+            <p class="name"><a data-bind="attr: {href: trackpipeUrl()}, text: name()"></a></p>
+            <p class="actions">
+                <a data-bind="attr: {href: 'https://bandcamp.com/profile?from=menubar&id=' + id}">profile</a> &middot;
+                <a data-bind="attr: {href: 'https://bandcamp.com/tools?from=menubar&id=' + id}">tools</a> &middot;
+                <a data-bind="attr: {href: trackpipeLocalUrl() + '/stats?from=menubar'}">stats</a>
+            </p>
+        </div>
+    </div>
+</script>
+</div>
+
+    </div>
+    
+
+
+
+    
+    
+
+
+
+
+
+
+
+    <div class="bannercontainer">
+
+
+
+
+
+
+
+
+    </div>
+
+    
+
+
+
+
+
+
+
+    
+    
+    
+    
+
+    
+<div class="corpbanner newsletter-invite-banner" style="display: none;">
+    <span class="tell-us-what-you-like">Get fresh music recommendations delivered to your inbox every Friday.</span> <svg class="dismiss" width="18" height="18" viewBox="0 0 24 24"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#material-close"></use></svg>
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+    <div class="corpbanner tos-update">
+    
+    <div class="text">
+        
+        
+        We’ve updated our <a class="tos-update-link" target="_blank" href="/terms_of_use">Terms of Use</a>. You can review the changes <a class="tos-update-link" target="_blank" href="/terms_of_use">here</a>.
+    </div>
+    <div class="text text-phone">
+         
+        We’ve updated our <a class="tos-update-link" target="_blank" href="/terms_of_use">Terms of Use</a>. You can review the changes <a class="tos-update-link" target="_blank" href="/terms_of_use">here</a>.
+    </div>
+
+    <a class="dismiss-banner" href="#">
+        <span class="ui-icon dismiss-icon"></span>
+    </a>
+</div>
+
+
+
+
+<!--  -->
+
+<div id="centerWrapper" >
+    <div id="propOpenWrapper">
+        
+
+        
+
+        
+
+        
+
+    
+    
+    
+
+    
+
+        <div id="pgBd" class="yui-skin-sam">
+            
+
+
+
+
+    
+    
+
+
+
+
+
+
+
+
+
+
+
+
+    
+
+    
+    
+    
+
+
+
+    
+
+
+
+
+<style type="text/css" id="custom-design-rules-style" data-design="{&quot;bg_color&quot;:&quot;000000&quot;,&quot;text_color&quot;:&quot;DEDEDE&quot;,&quot;secondary_text_color&quot;:&quot;E4C381&quot;,&quot;link_color&quot;:&quot;CF8D26&quot;,&quot;body_color&quot;:&quot;000000&quot;,&quot;hd_ft_color&quot;:&quot;333333&quot;,&quot;navbar_bg_color&quot;:&quot;1A1A1A&quot;,&quot;invert_iconography&quot;:1,&quot;tile_bg&quot;:null,&quot;bg_halign&quot;:&quot;l&quot;,&quot;bg_image_id&quot;:null,&quot;bg_file_name&quot;:null,&quot;defaultbg&quot;:false,&quot;bg_fixed&quot;:null,&quot;bg_behavior&quot;:&quot;r&quot;}">
+
+    #propOpenWrapper {
+        background: none transparent;
+    }
+
+    #pgBd {
+        background: #000000;
+        color: #DEDEDE;
+    }
+
+    a.custom-color, .custom-link-color, #trackInfo a:not(.notSkinnable), #trackInfo .buy-link,
+    #tagArea a, #rightColumn a, #name-section a, #indexpage a, .editable-grid a, .featured-grid a, #band-navbar a,
+    #live-ticket-item a.themeable, #live-ticket-item .buy-link, #live-ticket-item .more-merch a,
+    #merch-item p a, #merch-item .buy a, #merch-item .more-merch a, button.order_package_link.buy-link, h4.ft.compound-button.send-as-gift,
+    .share-collect-controls a, .share-collect-controls button, .follow-unfollow, .follow-unfollow div, .collected-by a,
+    .subscribe a, .sub a, .video-list a, .sub .main a, .subwelcome a, .artists-grid-name a, .featured-grid-name,
+    .label-welcome .buttons a.new, .themed .label-band-selector a.themeable, .tralbum-tags a,
+    button.join-live-event.live-event.live-event-stream-button  {
+        color: #CF8D26;
+    }
+
+
+    #trackInfo .g-button:not(.send-as-gift):not([disabled]), 
+    #merch-item .g-button:not(.send-as-gift):not([disabled]) {
+        background-color: #CF8D26;
+        border-color: #CF8D26;
+        color: #000000;
+    }
+
+    #trackInfo .g-button.send-as-gift:not([disabled]),
+    #merch-item .g-button.send-as-gift:not([disabled]) {
+        color: #CF8D26;
+        border-color: rgba(255, 255, 255, 0.32);
+    }
+
+    .themed .label-band-selector .bands-menu {
+        border: 1px solid #000000;
+    }
+
+    .themed .label-band-selector .bands-menu,
+    .themed .label-band-selector .bands-menu .menu-artistpic {
+         background: #000000;
+    }
+
+    .label-welcome h2, .label-welcome p {
+        color: #DEDEDE;
+    }
+
+    .label-welcome .buttons a.new {
+        box-shadow: 2px 2px #CF8D26;
+    }
+
+    .label-welcome .buttons a.existing {
+        box-shadow: 2px 2px #DEDEDE;
+    }
+
+
+    #live-ticket-item .buy,
+    #live-ticket-item .included-tralbum-info a {
+        color: #CF8D26;
+    }
+    #live-calendar-icon-stroke, #live-clock-icon-stroke {
+        stroke: #DEDEDE;
+    }
+
+    .campaign-custom-header #customHeader {
+        background-color: #;
+    }
+
+    .primaryText,
+    #discography a.primaryText,
+    #trackInfo a.title_link,
+    .label-welcome .buttons a.existing {
+        color: #DEDEDE;
+    }
+
+    .secondaryText {
+        color: #E4C381;
+    }
+
+    #band-navbar a:hover {
+        border-color: #CF8D26;
+    }
+
+    #band-navbar a.active {
+        color: #DEDEDE;
+        border-color: #DEDEDE;
+    }
+
+    .themed .label-band-selector .label {
+        color: #E4C381;
+    }
+
+    .themed .label-band-selector .tabs > li {
+        border-color: #E4C381;
+    }
+
+    .themed .label-band-selector a.selected {
+        color: #DEDEDE;
+    }
+
+    .themed .label-band-selector .caret {
+        fill: #CF8D26;
+    }
+
+    .themed .label-band-selector .selected .caret {
+        fill: #DEDEDE;
+    }
+
+    #trackInfo a.notable {
+        color: red; /* overrides above */
+    }
+
+    
+    #band-navbar {
+        background-color: #1A1A1A;
+    }
+    
+
+    body {
+        background: #000000;
+        
+            background-position: left top;
+            background-repeat: repeat;
+        
+        background-image: none;
+        
+    }
+
+    
+    
+        body.has-menubar {
+            background-position: left 53px;
+        }
+        body.has-top-banner {
+            background-position: left 40px;
+        }
+        body.has-menubar.has-top-banner {
+            background-position: left 88px;
+        }
+        
+        body.has-corpbanner2 {
+            background-position: left calc(48px - 1px);
+        }
+        body.has-menubar.has-corpbanner2 {
+            background-position: left calc(53px + 48px - 1px);
+        }
+    
+
+    #pgHd, .lang-picker-content {
+        background-color: #333333;
+    }
+
+    .just-icon {
+        color: #000000;
+    }
+
+    .just-icon-bg {
+        border-right-color: #DEDEDE;
+    }
+
+    .collected-by .ellipsis-text {
+        color: #CF8D26;
+    }
+    .collected-by .ellipsis-bg {
+        background-color: #CF8D26;
+    }
+
+    button.subtop,
+    button.subbot,
+    button.custom-color {
+        background: #CF8D26;
+        color: #000000;
+    }
+
+    .sub .includeditems .item a {
+        color: #DEDEDE;
+    }
+
+    .sub .post-message-link {
+        background-color: rgba(207, 141, 38, 0.2);
+        color: #CF8D26;
+    }
+
+    .sub ul.tierslist li.tier {
+        border-color: rgba(207, 141, 38, 0.2);
+    }
+
+    .sub button.tierbutton .spacer {
+        background-color: #000000;
+    }
+
+    ol.sub-navbar li.active,
+    .invertIconography ol.sub-navbar li.active {
+        background-color: #000000;
+    }
+
+    ol.sub-navbar a {
+        color: #CF8D26;
+    }
+
+    .post-subscribe .button-background {
+        background-color: rgba(207, 141, 38, 0.2);
+        color: #CF8D26;
+    }
+
+    .post-subscribe .band-link-color,
+    .post-subscribe .message-text button,
+    .post-subscribe .new-feed-stories button,
+    .post-subscribe .new-feed-stories-floater button {
+        color: #CF8D26;
+    }
+
+    .post-subscribe .new-feed-stories-floater button {
+        background-color: #000000;
+    }
+
+    .buyFullDiscography .art .art-thumb {
+        background-color: #000000;
+    }
+
+    .collected-by .loading {
+        color: #DEDEDE;
+    }
+
+    /* Styles for 05-2019 tralbum page tests -- temporary only */
+    .artist-support {
+        border: 2px solid #CF8D26;
+    }
+    .artist-support__bg {
+        background-color: #CF8D26;
+    }
+
+    /* community page styles */
+    
+</style>
+
+
+
+
+<style>
+
+</style>
+
+
+
+
+    
+    
+
+
+<div id="customHeaderWrapper">
+
+
+
+    
+
+
+
+
+
+
+
+
+
+
+
+
+    <div id="customHeader">
+    
+        <div class="desktop-header">
+            <a href="/" referrerpolicy="strict-origin-when-cross-origin"><img src="https://f4.bcbits.com/img/0031590441_100.png" width="975" height="180"></a>
+            
+        </div>
+    
+    
+    </div>
+
+
+
+
+
+
+
+
+
+    
+        <div class="band-navbar-wrapper flex">
+            <ol id="band-navbar">
+                
+                    <li>
+                        <a href="/music" class="primaryText active">
+                        
+                        
+                        
+                        
+                                music
+                            
+                        </a>
+                    </li>
+                
+                    <li>
+                        <a href="/merch" >
+                        
+                        
+                        
+                        
+                                merch
+                            
+                        </a>
+                    </li>
+                
+                    <li>
+                        <a href="/subscribe" >
+                        
+                        
+                        
+                        
+                                subscribe
+                            
+                        </a>
+                    </li>
+                
+
+                
+            </ol>
+        </div>
+    
+
+
+
+
+
+
+
+
+
+
+    <div class="bannercontainer">
+
+
+
+
+
+
+
+
+    </div>
+
+</div>
+
+
+
+<div class="trackView leftMiddleColumns has-art"
+     data-tooltips="{&quot;tooltips&quot;:[],&quot;dash_seen&quot;:null}">
+    
+    <div id="name-section" >
+        <h2 class="trackTitle">
+            Des papiers II
+            
+        </h2>
+
+        <h3 style="margin:0px;">by 
+        <span> 
+          <a href="https://arbee.bandcamp.com">arbee</a>
+          </span>
+        
+        </h3>
+
+    
+        
+            <div class="release-label">subscriber exclusive</div>
+        
+    
+
+    
+    </div>
+    <div class="middleColumn">
+        
+        
+
+        <div id="tralbumArt">
+        
+            <a class="popupImage" href="https://f4.bcbits.com/img/a1289075493_10.jpg">
+                <img src="https://f4.bcbits.com/img/a1289075493_16.jpg">
+            </a>
+        
+        </div>
+
+        
+            <div class="share-panel-wrapper-desktop signup-tooltip-parent" data-tooltip-id="x"></div>            
+            
+                
+<div class="collected-by tralbum collectors">
+    
+        <div class="message">
+            
+                
+                  supported by
+                
+            
+        </div>
+    
+
+    
+    
+    
+    
+    
+    
+    <div class="deets populated">
+        
+
+
+
+
+
+<div class="no-writing">
+
+	
+    <a class="fan pic" href="https://bandcamp.com/sharonshay?from=fanthanks">
+    
+    <div class="tooltip">
+        <div class="round3">
+        	<img class="grid lazy" src="/img/0.gif" data-original="https://f4.bcbits.com/img/0034637047_50.jpg" style="display: inline-block;"/>
+            <div class="name">sharonshay</div>
+            
+        </div>
+    </div>
+    
+    
+    
+    <img class="thumb" src="https://f4.bcbits.com/img/0034637047_42.jpg" alt="sharonshay thumbnail"/>
+    
+</a>
+
+
+	
+    <a class="fan pic" href="https://bandcamp.com/sechogs1?from=fanthanks">
+    
+    <div class="tooltip">
+        <div class="round3">
+        	<img class="grid lazy" src="/img/0.gif" data-original="https://f4.bcbits.com/img/0039002132_50.jpg" style="display: inline-block;"/>
+            <div class="name">Randall </div>
+            
+        </div>
+    </div>
+    
+    
+    
+    <img class="thumb" src="https://f4.bcbits.com/img/0039002132_42.jpg" alt="Randall  thumbnail"/>
+    
+</a>
+
+
+	
+    <a class="fan pic" href="https://bandcamp.com/rikm?from=fanthanks">
+    
+    <div class="tooltip">
+        <div class="round3">
+        	<img class="grid lazy" src="/img/0.gif" data-original="https://f4.bcbits.com/img/0010008876_50.jpg" style="display: inline-block;"/>
+            <div class="name">rikm</div>
+            
+        </div>
+    </div>
+    
+    
+    
+    <img class="thumb" src="https://f4.bcbits.com/img/0010008876_42.jpg" alt="rikm thumbnail"/>
+    
+</a>
+
+
+	
+    <a class="fan pic" href="https://bandcamp.com/cinnamonskull?from=fanthanks">
+    
+    <div class="tooltip">
+        <div class="round3">
+        	<img class="grid lazy" src="/img/0.gif" data-original="https://f4.bcbits.com/img/0037897404_50.jpg" style="display: inline-block;"/>
+            <div class="name">Ur Trommler</div>
+            
+        </div>
+    </div>
+    
+    
+    
+    <img class="thumb" src="https://f4.bcbits.com/img/0037897404_42.jpg" alt="Ur Trommler thumbnail"/>
+    
+</a>
+
+
+	
+    <a class="fan pic" href="https://bandcamp.com/pertin-nce?from=fanthanks">
+    
+    <div class="tooltip">
+        <div class="round3">
+        	<img class="grid lazy" src="/img/0.gif" data-original="https://f4.bcbits.com/img/0004279367_50.jpg" style="display: inline-block;"/>
+            <div class="name">maxime tanguay</div>
+            
+        </div>
+    </div>
+    
+    
+    
+    <img class="thumb" src="https://f4.bcbits.com/img/0004279367_42.jpg" alt="maxime tanguay thumbnail"/>
+    
+</a>
+
+
+	
+    <a class="fan pic" href="https://bandcamp.com/eeem?from=fanthanks">
+    
+    <div class="tooltip">
+        <div class="round3">
+        	<img class="grid lazy" src="/img/0.gif" data-original="https://f4.bcbits.com/img/0000830407_50.jpg" style="display: inline-block;"/>
+            <div class="name">Emmanuel Toledo</div>
+            
+        </div>
+    </div>
+    
+    
+    
+    <img class="thumb" src="https://f4.bcbits.com/img/0000830407_42.jpg" alt="Emmanuel Toledo thumbnail"/>
+    
+</a>
+
+
+</div>
+
+
+    </div>
+</div>
+
+            
+        
+    </div>
+
+    <div id="trackInfo" class="leftColumn">
+        <div id="trackInfoInner">
+            
+            
+            
+                <div class="inline_player hidden"><table>
+    <tr>
+        <td class="play_cell" rowspan="2">
+            <a role="button" aria-label="Play/pause"><div class="playbutton"></div></a>
+        </td>
+        <td class="track_cell" colspan="3">
+            <div class="track_info">
+                <span class="title-section hiddenelem">
+                    <a class="title_link primaryText" href="#"><span class="title"></span></a>
+                </span>
+                <span class="time secondaryText hiddenelem">
+                    <span class="time_elapsed"></span>
+                    /
+                    <span class="time_total"></span>
+                </span>
+                <span class="message hiddenelem"></span>
+            </div>
+        </td>
+    </tr>
+    <tr>
+        <td class="progbar_cell">
+            <div class="progbar">
+                <div class="progbar_empty">
+                    <div class="progbar_fill"></div>
+                    <div class="thumb"></div>
+                </div>
+            </div>
+        </td>
+        <td class="prev_cell">
+            <a role="button" aria-label="Previous track"><div class="prevbutton hiddenelem"></div></a>
+        </td>
+        <td class="next_cell">
+            <a role="button" aria-label="Next track"><div class="nextbutton hiddenelem"></div></a>
+        </td>
+    </tr>
+</table>
+</div>
+            
+
+            
+            <ul class="tralbumCommands">
+                
+                
+                
+                 
+
+                
+
+                
+
+                
+                    
+                        
+
+    
+    
+    
+
+
+<li class="buyItem subscribeLink">
+    <h3 class="hd">
+        <a class="subscribe-link" href="https://arbee.bandcamp.com/subscribe">
+          <span class="buyItemPackageTitle primaryText">Subscription</span>
+        </a>
+    </h3>
+    
+    <div class="bd">
+        
+        Subscribe
+        
+        now to receive all the new
+        
+        music
+        
+        arbee creates, 
+        
+            including 
+            
+            
+                100 back-catalog releases,
+            
+        
+        delivered instantly to you via the Bandcamp app for iOS and Android. 
+        
+            You’ll also get access to
+            
+            subscriber-only
+            
+            exclusives like this album.
+        
+        <a href="https://arbee.bandcamp.com/subscribe">Learn more</a>.
+    </div>
+
+    <h4 class="ft compound-button">
+        <a class="buy-link" href="https://arbee.bandcamp.com/subscribe">
+        Subscribe
+        
+        Now</a>
+        <span class="nobreak">
+            <span class="base-text-color">&nbsp;$3 </span>
+            <span class="buyItemExtra secondaryText">CAD</span><span class="buyItemExtra buyItemNyp secondaryText">/month or more</span>
+        </span>
+    </h4>
+</li>
+
+                    
+                
+
+                
+                    
+                                 
+
+                
+                 
+
+                
+                
+                
+                    
+                    <li id='collect-item-placeholder'></li>
+                
+                
+            </ul>
+            
+ 
+            <table class="track_list track_table" id="track_table">
+                
+                                
+                
+                
+                    
+                    <tr class="track_row_view linked" rel="tracknum=1">
+                        
+<td class="play-col"><a role="button" aria-label="Play Des papiers II"><div class="play_status disabled"></div></a></td>
+<td class="track-number-col"><div class="track_number secondaryText">1.</div></td>
+<td class="title-col">
+    <div class="title">
+    
+        <a href="/track/des-papiers-ii"><span class="track-title">Des papiers II</span></a>
+    
+    
+    
+    
+    
+        <span class="time secondaryText">
+        
+            03:01
+        
+        </span>
+    
+    
+    
+
+    </div> 
+</td>
+
+<td class="info-col"><div class="info_link"><a href="/track/des-papiers-ii" ></a></div></td>
+<td class="download-col">
+<div class="dl_link">
+
+</div></td>
+
+                    </tr>
+                
+                
+                
+            </table>
+            
+            
+
+
+  
+  
+
+
+
+            
+            <h3 class="about-label">about</h3>
+            <div class="tralbumData tralbum-about">Des papiers II.<br>
+<br>
+Subscriber-exclusive ambient.</div>
+            
+            
+                <script type="text/javascript" nonce="wTheumiB9KwnlhpIPDSBvQ==">
+                    $(".tralbum-about").last().bcTruncate(TruncateProfile.get("tralbum_about"), "more", "less");
+                </script>
+            
+            
+                      
+            <h3 class="credits-label">credits</h3>
+            <div class="tralbumData tralbum-credits">
+            
+                released April 30, 2025
+            
+            
+            </div>
+            
+            
+                
+            
+
+            
+
+<h3 class="license-label">license</h3>
+<div id="license" class="info license">
+
+  <span class="cc-icons commercial"></span>all rights reserved
+
+
+
+</div>
+
+        </div>
+        
+
+    </div>
+    
+    
+    
+    
+    
+
+    
+        <h3 class="tags-label">tags</h3>
+        <div class="tralbumData tralbum-tags tralbum-tags-nu hidden">
+            <h3><span class="tags-inline-label">Tags</span></h3>
+            
+            <a class="tag" href="https://bandcamp.com/discover/electronic?from=tralbum&artist=4038363339"
+                >electronic</a>
+        
+            <a class="tag" href="https://bandcamp.com/discover/ambient?from=tralbum&artist=4038363339"
+                >ambient</a>
+        
+            <a class="tag" href="https://bandcamp.com/discover/drone?from=tralbum&artist=4038363339"
+                >drone</a>
+        
+            <a class="tag" href="https://bandcamp.com/discover/field-recordings?from=tralbum&artist=4038363339"
+                >field recordings</a>
+        
+            <a class="tag" href="https://bandcamp.com/discover/noises?from=tralbum&artist=4038363339"
+                >noises</a>
+        
+            <a class="tag" href="https://bandcamp.com/discover/noisy-ambient?from=tralbum&artist=4038363339"
+                >noisy ambient</a>
+        
+            <a class="tag" href="https://bandcamp.com/discover/textures?from=tralbum&artist=4038363339"
+                >textures</a>
+        
+            <a class="tag" href="https://bandcamp.com/discover/canada?from=tralbum&artist=4038363339"
+                >Canada</a>
+        </div>
+    
+
+
+</div>
+
+
+<div id="rightColumn" class="rightColumn">
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<div id="sidecart" style="display: none" class="menubar-2018-mobile-cart">
+    <div id="sidecartReveal" class="reveal">
+        <div id="sidecartBody">
+            
+            <div id="sidecartHeader">
+                
+                <h3 class="title shopping-cart">Shopping cart</h3>
+                
+            </div>
+            
+            <div id="sidecart-phone-reveal">
+                <div id="sidecartContents">
+                    <div id="item_list">
+                        
+                    </div>
+                </div>
+                <div id="sidecartFooter">
+                    <div id="sidecartSummary">
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+                        
+
+
+<table id="summary">
+  <tr class="small">
+      <th>subtotal</th>
+      <td class="numeric"></span></td>
+      <td class="currency"><a class="country-picker">USD</a></td>
+  </tr>
+  
+  <tr>
+      <td colspan="3" class="small sidecartTaxText">taxes calculated at checkout</td>
+  </tr>
+  
+  
+</table>
+
+<div class="summary-notes">
+  
+</div>
+
+                    </div>
+                    
+                        <a id="sidecartCheckout" class="buttonLink notSkinnable" href="#" data-test="sidecartCheckout">
+                        
+                            
+                            Check out
+                        
+                        </a>
+
+                        
+                    
+
+                    
+                    
+                    
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+
+
+
+
+
+<div class="tralbum-tooltip-parent bio-image" data-bind="css: {'show-tooltip': showing}">
+    <div class="tralbum-tooltip-outer">
+        <div class="inner-squarecle-wrapper">
+            <div class="inner-squarecle"></div>
+            <div class="inner-squarecle-contents">
+                <a class="tooltip-action" data-bind="click: close, text: centralText"></a>
+            </div>
+        </div>
+        <div class="tralbum-tooltip">
+            <div class="tralbum-tooltip-inner">
+                <span class="progress" data-bind="text: progress"></span>
+                <span data-bind="text: tipText"></span>
+                <a class="dismiss-tooltip" data-bind="click: continueTips, text: closeText"></a>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+
+
+
+<div id="bio-container"  data-bind="css: {'ko-ready': $data}">
+    <h3 class="title bio-label hiddenAccess">about</h3>
+    
+        
+            
+            <div class="artists-bio-pic artists-bio-pic-uploaded  landscape">
+                <div class="signed-out bio-pic">
+                    <a class="popupImage" href="https://f4.bcbits.com/img/0000014017_10.jpg" data-image-size="907,907" data-image-preload="true">
+                        
+                        <img src="https://f4.bcbits.com/img/0000014017_21.jpg" class="band-photo" alt="arbee image">
+                    </a>
+                </div>
+            </div>
+        
+    
+
+    <p id="band-name-location">
+        <span class="title">arbee</span>
+        <span class="location secondaryText">Québec</span>
+    </p>
+
+    
+    <div class="following-actions-wrapper signup-tooltip-parent" data-tooltip-id="b">
+        
+        <div id="following-actions">
+            
+            <button type="button" class="follow-unfollow compound-button" style="visibility: hidden;">
+                <div>placeholder</div>
+            </button>
+        </div>
+        <div class="signup-tooltip-outer follow-tooltip-outer"></div>
+        
+    </div>
+    
+
+    
+        <div class="signed-out-artists-bio-text">
+            
+                
+                    <p id="bio-text">electronic &amp; ambient music</p>
+                
+            
+        </div>
+    
+    
+    
+        <ol id="band-links">
+            
+                <li><a target="_blank" rel="nofollow ugc me" referrerpolicy="strict-origin-when-cross-origin" href="https://arbee.ca">arbee.ca</a></li>
+            
+                <li><a target="_blank" rel="nofollow ugc me" referrerpolicy="strict-origin-when-cross-origin" href="https://linktr.ee/arbeemonkey">linktr.ee</a></li>
+            
+        </ol>
+    
+
+    
+    
+    
+    
+    
+    
+    
+    
+
+    
+
+</div>
+<div class="tralbum-tooltip-parent bio-text" data-bind="css: {'show-tooltip': showing}">
+    <div class="tralbum-tooltip-outer">
+        <div class="inner-squarecle-wrapper">
+            <div class="inner-squarecle"></div>
+            <div class="inner-squarecle-contents">
+                <a class="tooltip-action" data-bind="click: close, text: centralText"></a>
+            </div>
+        </div>
+        <div class="tralbum-tooltip">
+            <div class="tralbum-tooltip-inner">
+                <span class="progress" data-bind="text: progress"></span>
+                <span data-bind="text: tipText"></span>
+                <a class="dismiss-tooltip" data-bind="click: continueTips, text: closeText"></a>
+            </div>
+        </div>
+    </div>
+</div>
+
+
+
+
+
+
+
+    
+    
+    
+
+
+
+<div id="discography"  > 
+<h3 class="title">discography</h3>
+<ul>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/phobos">
+                <img src="https://f4.bcbits.com/img/a1962758576_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/phobos">Phobos</a></div>
+            <div class="trackYear secondaryText">May 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/forlorn">
+                <img src="https://f4.bcbits.com/img/a3177236037_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/forlorn">forlorn</a></div>
+            <div class="trackYear secondaryText">Apr 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/une-promesse">
+                <img src="https://f4.bcbits.com/img/a1050027506_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/une-promesse">Une promesse</a></div>
+            <div class="trackYear secondaryText">Apr 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/clairsem">
+                <img src="https://f4.bcbits.com/img/a3768745674_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/clairsem">Clairsemé</a></div>
+            <div class="trackYear secondaryText">Apr 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/city-lights-midnight-skies">
+                <img src="https://f4.bcbits.com/img/a1200615468_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/city-lights-midnight-skies">City Lights, Midnight Skies</a></div>
+            <div class="trackYear secondaryText">Mar 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/snow-day-campfire">
+                <img src="https://f4.bcbits.com/img/a2174595276_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/snow-day-campfire">Snow Day Campfire</a></div>
+            <div class="trackYear secondaryText">Mar 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/seaside-memories">
+                <img src="https://f4.bcbits.com/img/a0303923353_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/seaside-memories">Seaside memories</a></div>
+            <div class="trackYear secondaryText">Mar 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/l-ger-retard">
+                <img src="https://f4.bcbits.com/img/a0247644345_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/l-ger-retard">Léger retard</a></div>
+            <div class="trackYear secondaryText">Feb 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/destined">
+                <img src="https://f4.bcbits.com/img/a2280192020_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/destined">destined</a></div>
+            <div class="trackYear secondaryText">Feb 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/how-the-end-always-is">
+                <img src="https://f4.bcbits.com/img/a0178892905_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/how-the-end-always-is">how the end always is</a></div>
+            <div class="trackYear secondaryText">Jan 2025</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/phantasm">
+                <img src="https://f4.bcbits.com/img/a2542138348_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/phantasm">phantasm</a></div>
+            <div class="trackYear secondaryText">Dec 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/une-impulsion">
+                <img src="https://f4.bcbits.com/img/a3388227303_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/une-impulsion">Une impulsion</a></div>
+            <div class="trackYear secondaryText">Nov 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/scattered-dreams">
+                <img src="https://f4.bcbits.com/img/a2765973335_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/scattered-dreams">Scattered Dreams</a></div>
+            <div class="trackYear secondaryText">Nov 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/broken">
+                <img src="https://f4.bcbits.com/img/a1313267898_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/broken">Broken</a></div>
+            <div class="trackYear secondaryText">Nov 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/entre-prises">
+                <img src="https://f4.bcbits.com/img/a3761399903_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/entre-prises">Entre prises</a></div>
+            <div class="trackYear secondaryText">Oct 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/lost-world">
+                <img src="https://f4.bcbits.com/img/a2330465073_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/lost-world">Lost World</a></div>
+            <div class="trackYear secondaryText">Oct 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/out-past-the-trees">
+                <img src="https://f4.bcbits.com/img/a2195399637_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/out-past-the-trees">Out Past The Trees</a></div>
+            <div class="trackYear secondaryText">Sep 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/vol-manqu">
+                <img src="https://f4.bcbits.com/img/a1050986548_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/vol-manqu">Vol Manqué</a></div>
+            <div class="trackYear secondaryText">Sep 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/dans-une-ruelle-suite">
+                <img src="https://f4.bcbits.com/img/a0496490114_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/dans-une-ruelle-suite">Dans une ruelle, suite</a></div>
+            <div class="trackYear secondaryText">Aug 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/cette-pi-ce-suite">
+                <img src="https://f4.bcbits.com/img/a3021524328_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/cette-pi-ce-suite">Cette pièce, suite</a></div>
+            <div class="trackYear secondaryText">Aug 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/reverie">
+                <img src="https://f4.bcbits.com/img/a3214144510_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/reverie">Reverie</a></div>
+            <div class="trackYear secondaryText">Jul 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/palissade">
+                <img src="https://f4.bcbits.com/img/a1730187274_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/palissade">Palissade</a></div>
+            <div class="trackYear secondaryText">Jul 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/small-eruptions">
+                <img src="https://f4.bcbits.com/img/a1841615477_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/small-eruptions">Small Eruptions</a></div>
+            <div class="trackYear secondaryText">Jul 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/saturation">
+                <img src="https://f4.bcbits.com/img/a0445831444_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/saturation">Saturation</a></div>
+            <div class="trackYear secondaryText">Jun 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/stellar-moment">
+                <img src="https://f4.bcbits.com/img/a0816081601_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/stellar-moment">Stellar Moment</a></div>
+            <div class="trackYear secondaryText">Jun 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/une-maison-suite">
+                <img src="https://f4.bcbits.com/img/a1968622669_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/une-maison-suite">Une maison, suite</a></div>
+            <div class="trackYear secondaryText">May 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/comme-une-pie-suite">
+                <img src="https://f4.bcbits.com/img/a3898605676_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/comme-une-pie-suite">Comme une pie, suite</a></div>
+            <div class="trackYear secondaryText">May 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/full-day">
+                <img src="https://f4.bcbits.com/img/a0712601771_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/full-day">Full Day</a></div>
+            <div class="trackYear secondaryText">May 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/au-milieu-suite">
+                <img src="https://f4.bcbits.com/img/a4223348954_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/au-milieu-suite">Au milieu, suite</a></div>
+            <div class="trackYear secondaryText">May 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/pente-douce">
+                <img src="https://f4.bcbits.com/img/a2566847647_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/pente-douce">Pente-douce</a></div>
+            <div class="trackYear secondaryText">May 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/altruisme">
+                <img src="https://f4.bcbits.com/img/a1108687518_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/altruisme">Altruisme</a></div>
+            <div class="trackYear secondaryText">Apr 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/tension">
+                <img src="https://f4.bcbits.com/img/a0336918243_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/tension">Tension</a></div>
+            <div class="trackYear secondaryText">Mar 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/introspect">
+                <img src="https://f4.bcbits.com/img/a3530384052_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/introspect">introspect</a></div>
+            <div class="trackYear secondaryText">Feb 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/capillaire">
+                <img src="https://f4.bcbits.com/img/a4221039996_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/capillaire">Capillaire</a></div>
+            <div class="trackYear secondaryText">Jan 2024</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/m-nisque">
+                <img src="https://f4.bcbits.com/img/a1836198448_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/m-nisque">Ménisque</a></div>
+            <div class="trackYear secondaryText">Dec 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/bouchons">
+                <img src="https://f4.bcbits.com/img/a1058364384_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/bouchons">Bouchons</a></div>
+            <div class="trackYear secondaryText">Nov 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/discretion">
+                <img src="https://f4.bcbits.com/img/a1432711060_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/discretion">discretion</a></div>
+            <div class="trackYear secondaryText">Nov 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/track/stellar-spirit">
+                <img src="https://f4.bcbits.com/img/a1051228339_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/track/stellar-spirit">Stellar spirit</a></div>
+            <div class="trackYear secondaryText">Oct 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/secrets-within-the-mountain">
+                <img src="https://f4.bcbits.com/img/a2037799182_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/secrets-within-the-mountain">Secrets within the mountain</a></div>
+            <div class="trackYear secondaryText">Jun 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/ourselves-blue-montain-lullaby">
+                <img src="https://f4.bcbits.com/img/a3062078126_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/ourselves-blue-montain-lullaby">Ourselves &amp; Blue Montain Lullaby</a></div>
+            <div class="trackYear secondaryText">Apr 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/lumen">
+                <img src="https://f4.bcbits.com/img/a1710292704_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/lumen">Lumen</a></div>
+            <div class="trackYear secondaryText">Feb 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/rampe-de-lancement">
+                <img src="https://f4.bcbits.com/img/a0798585401_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/rampe-de-lancement">Rampe de lancement</a></div>
+            <div class="trackYear secondaryText">Feb 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/aurora">
+                <img src="https://f4.bcbits.com/img/a3831054911_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/aurora">Aurora</a></div>
+            <div class="trackYear secondaryText">Jan 2023</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/one-day-setting-sail">
+                <img src="https://f4.bcbits.com/img/a2789956251_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/one-day-setting-sail">One Day &amp; Setting Sail</a></div>
+            <div class="trackYear secondaryText">Oct 2022</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/merging-day-into-night">
+                <img src="https://f4.bcbits.com/img/a2150940085_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/merging-day-into-night">Merging Day Into Night</a></div>
+            <div class="trackYear secondaryText">Oct 2022</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/perceptible">
+                <img src="https://f4.bcbits.com/img/a1591066880_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/perceptible">Perceptible</a></div>
+            <div class="trackYear secondaryText">Jul 2022</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/safe-room">
+                <img src="https://f4.bcbits.com/img/a2468526819_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/safe-room">Safe Room</a></div>
+            <div class="trackYear secondaryText">Jun 2022</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/if-ever">
+                <img src="https://f4.bcbits.com/img/a3735403453_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/if-ever">If Ever</a></div>
+            <div class="trackYear secondaryText">May 2022</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/track/midnight-ride">
+                <img src="https://f4.bcbits.com/img/a0049217303_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/track/midnight-ride">Midnight Ride</a></div>
+            <div class="trackYear secondaryText">Mar 2022</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/life-between-the-waves">
+                <img src="https://f4.bcbits.com/img/a2165311933_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/life-between-the-waves">Life Between The Waves</a></div>
+            <div class="trackYear secondaryText">Feb 2022</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/pr-cipit">
+                <img src="https://f4.bcbits.com/img/a0650333886_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/pr-cipit">Précipité</a></div>
+            <div class="trackYear secondaryText">Jan 2022</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/pour-une-fois">
+                <img src="https://f4.bcbits.com/img/a1237604911_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/pour-une-fois">Pour une fois</a></div>
+            <div class="trackYear secondaryText">Nov 2021</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/bascules">
+                <img src="https://f4.bcbits.com/img/a3943356472_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/bascules">Bascules</a></div>
+            <div class="trackYear secondaryText">Jun 2021</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/track/comme-une-chim-re">
+                <img src="https://f4.bcbits.com/img/a0538159130_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/track/comme-une-chim-re">Comme une chimère</a></div>
+            <div class="trackYear secondaryText">Jun 2021</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/soustraction">
+                <img src="https://f4.bcbits.com/img/a2442940329_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/soustraction">Soustraction</a></div>
+            <div class="trackYear secondaryText">May 2021</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/track/chinook-wave">
+                <img src="https://f4.bcbits.com/img/a2368403481_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/track/chinook-wave">Chinook Wave</a></div>
+            <div class="trackYear secondaryText">May 2021</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/r-flexions-automnales">
+                <img src="https://f4.bcbits.com/img/a1196222287_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/r-flexions-automnales">réflexions automnales</a></div>
+            <div class="trackYear secondaryText">Feb 2021</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/amble">
+                <img src="https://f4.bcbits.com/img/a3510554088_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/amble">amble</a></div>
+            <div class="trackYear secondaryText">Jan 2021</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/echo-of-nature">
+                <img src="https://f4.bcbits.com/img/a3637168116_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/echo-of-nature">Echo of Nature</a></div>
+            <div class="trackYear secondaryText">Nov 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/paragraphs">
+                <img src="https://f4.bcbits.com/img/a2875193964_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/paragraphs">Paragraphs</a></div>
+            <div class="trackYear secondaryText">Oct 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/petit-pain">
+                <img src="https://f4.bcbits.com/img/a3327977705_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/petit-pain">Petit Pain</a></div>
+            <div class="trackYear secondaryText">Oct 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/parcimonie">
+                <img src="https://f4.bcbits.com/img/a3872342962_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/parcimonie">Parcimonie</a></div>
+            <div class="trackYear secondaryText">Sep 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/transpaque">
+                <img src="https://f4.bcbits.com/img/a1383348369_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/transpaque">Transpaque</a></div>
+            <div class="trackYear secondaryText">Sep 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/deux-rien">
+                <img src="https://f4.bcbits.com/img/a2459264166_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/deux-rien">Deux Rien</a></div>
+            <div class="trackYear secondaryText">Sep 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/toile-de-fond">
+                <img src="https://f4.bcbits.com/img/a1943328761_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/toile-de-fond">Toile de fond</a></div>
+            <div class="trackYear secondaryText">Jul 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/quatre-digression-s">
+                <img src="https://f4.bcbits.com/img/a3315471567_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/quatre-digression-s">quatre, digression(s)</a></div>
+            <div class="trackYear secondaryText">Jun 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/polys-mie-iii">
+                <img src="https://f4.bcbits.com/img/a2818084876_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/polys-mie-iii">Polysémie III</a></div>
+            <div class="trackYear secondaryText">Mar 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/savoureuses-d-coupes">
+                <img src="https://f4.bcbits.com/img/a3933368357_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/savoureuses-d-coupes">Savoureuses Découpes</a></div>
+            <div class="trackYear secondaryText">Feb 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/tout-en-retenu">
+                <img src="https://f4.bcbits.com/img/a1889405563_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/tout-en-retenu">Tout en retenu</a></div>
+            <div class="trackYear secondaryText">Jan 2020</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/prises">
+                <img src="https://f4.bcbits.com/img/a3258491211_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/prises">prises</a></div>
+            <div class="trackYear secondaryText">Oct 2019</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/arborescence">
+                <img src="https://f4.bcbits.com/img/a4035104167_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/arborescence">Arborescence</a></div>
+            <div class="trackYear secondaryText">Sep 2019</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/trois-la-t-te-qui-bouge">
+                <img src="https://f4.bcbits.com/img/a1862277626_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/trois-la-t-te-qui-bouge">trois, la tête qui bouge</a></div>
+            <div class="trackYear secondaryText">Feb 2019</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/contemplation-du-rien">
+                <img src="https://f4.bcbits.com/img/a3659807149_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/contemplation-du-rien">Contemplation du Rien</a></div>
+            <div class="trackYear secondaryText">Dec 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/att-nuation">
+                <img src="https://f4.bcbits.com/img/a1031623865_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/att-nuation">Atténuation</a></div>
+            <div class="trackYear secondaryText">Nov 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/obsolescence-programm-e">
+                <img src="https://f4.bcbits.com/img/a2582687129_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/obsolescence-programm-e">Obsolescence Programmée</a></div>
+            <div class="trackYear secondaryText">Sep 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/rebours">
+                <img src="https://f4.bcbits.com/img/a0632433636_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/rebours">à rebours</a></div>
+            <div class="trackYear secondaryText">Aug 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/deux-tout-doucement">
+                <img src="https://f4.bcbits.com/img/a0628112171_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/deux-tout-doucement">deux, tout doucement</a></div>
+            <div class="trackYear secondaryText">Aug 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/demi-mot">
+                <img src="https://f4.bcbits.com/img/a4188266342_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/demi-mot">À demi​-​mot</a></div>
+            <div class="trackYear secondaryText">Jun 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/lieux-communs">
+                <img src="https://f4.bcbits.com/img/a2881399683_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/lieux-communs">lieux communs</a></div>
+            <div class="trackYear secondaryText">Jun 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/un-certaine-assurance">
+                <img src="https://f4.bcbits.com/img/a0199379247_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/un-certaine-assurance">un, certaine assurance</a></div>
+            <div class="trackYear secondaryText">Apr 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/polys-mie-ii">
+                <img src="https://f4.bcbits.com/img/a2021822430_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/polys-mie-ii">Polysémie II</a></div>
+            <div class="trackYear secondaryText">Feb 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/au-beau-fixe">
+                <img src="https://f4.bcbits.com/img/a2892402510_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/au-beau-fixe">Au beau fixe</a></div>
+            <div class="trackYear secondaryText">Jan 2018</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/polys-mie">
+                <img src="https://f4.bcbits.com/img/a1294117195_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/polys-mie">Polysémie</a></div>
+            <div class="trackYear secondaryText">Dec 2017</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/au-calme">
+                <img src="https://f4.bcbits.com/img/a0609915111_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/au-calme">Au calme</a></div>
+            <div class="trackYear secondaryText">Oct 2017</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/ces-coups-l">
+                <img src="https://f4.bcbits.com/img/a2312928217_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/ces-coups-l">ces coups​-​là</a></div>
+            <div class="trackYear secondaryText">Apr 2017</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/seul">
+                <img src="https://f4.bcbits.com/img/a3549991105_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/seul">Seul</a></div>
+            <div class="trackYear secondaryText">Jan 2017</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/paysages-clectiques">
+                <img src="https://f4.bcbits.com/img/a1290382786_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/paysages-clectiques">Paysages Éclectiques</a></div>
+            <div class="trackYear secondaryText">Jan 2017</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/halte-d-rives">
+                <img src="https://f4.bcbits.com/img/a2261418289_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/halte-d-rives">halte, dérives</a></div>
+            <div class="trackYear secondaryText">Nov 2016</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/jusqu-laverse">
+                <img src="https://f4.bcbits.com/img/a3861663308_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/jusqu-laverse">jusqu&#39;à l&#39;averse</a></div>
+            <div class="trackYear secondaryText">Aug 2016</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/belle-chemise">
+                <img src="https://f4.bcbits.com/img/a2681857555_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/belle-chemise">Belle Chemise</a></div>
+            <div class="trackYear secondaryText">May 2016</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/tout-simplement">
+                <img src="https://f4.bcbits.com/img/a1087736353_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/tout-simplement">tout simplement</a></div>
+            <div class="trackYear secondaryText">May 2016</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/side-to-side">
+                <img src="https://f4.bcbits.com/img/a1184218961_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/side-to-side">Side To Side</a></div>
+            <div class="trackYear secondaryText">Oct 2015</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/dislocations">
+                <img src="https://f4.bcbits.com/img/a3803396180_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/dislocations">dislocations</a></div>
+            <div class="trackYear secondaryText">Oct 2015</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/propositions-verd-tres">
+                <img src="https://f4.bcbits.com/img/a1328936392_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/propositions-verd-tres">Propositions Verdâtres</a></div>
+            <div class="trackYear secondaryText">Jun 2015</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/d-sencombrement">
+                <img src="https://f4.bcbits.com/img/a2864118214_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/d-sencombrement">désencombrement</a></div>
+            <div class="trackYear secondaryText">Jun 2015</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/un-sur-quatre">
+                <img src="https://f4.bcbits.com/img/a3865928765_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/un-sur-quatre">un sur quatre</a></div>
+            <div class="trackYear secondaryText">May 2015</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/variations-verd-tres">
+                <img src="https://f4.bcbits.com/img/a2327911422_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/variations-verd-tres">Variations Verdâtres</a></div>
+            <div class="trackYear secondaryText">Jan 2015</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/r-cidives-2">
+                <img src="https://f4.bcbits.com/img/a3865202886_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/r-cidives-2">Récidives</a></div>
+            <div class="trackYear secondaryText">Oct 2014</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/sunshinewoods">
+                <img src="https://f4.bcbits.com/img/a1610382759_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/sunshinewoods">sunshinewoods</a></div>
+            <div class="trackYear secondaryText">Aug 2014</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/rendement-possible">
+                <img src="https://f4.bcbits.com/img/a0363085880_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/rendement-possible">rendement possible?</a></div>
+            <div class="trackYear secondaryText">Jun 2014</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/elemental-gathering">
+                <img src="https://f4.bcbits.com/img/a0430993241_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/elemental-gathering">Elemental Gathering</a></div>
+            <div class="trackYear secondaryText">Mar 2014</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/variations-sur-tout-ce-qui-pousse-musique-pour-station-orbitale">
+                <img src="https://f4.bcbits.com/img/a1765125481_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/variations-sur-tout-ce-qui-pousse-musique-pour-station-orbitale">Variations sur tout ce qui pousse (musique pour station orbitale)</a></div>
+            <div class="trackYear secondaryText">Jan 2014</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/mtml-2">
+                <img src="https://f4.bcbits.com/img/a0117702381_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/mtml-2">mtml 2</a></div>
+            <div class="trackYear secondaryText">Dec 2013</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/un-trait">
+                <img src="https://f4.bcbits.com/img/a2766499742_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/un-trait">Un Trait</a></div>
+            <div class="trackYear secondaryText">Dec 2013</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/persistance">
+                <img src="https://f4.bcbits.com/img/a0926935457_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/persistance">Persistance</a></div>
+            <div class="trackYear secondaryText">Sep 2013</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/6-steps-to-red-forest">
+                <img src="https://f4.bcbits.com/img/a1487475645_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/6-steps-to-red-forest">6 Steps to Red Forest</a></div>
+            <div class="trackYear secondaryText">Sep 2013</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/tectonique-des-plaques">
+                <img src="https://f4.bcbits.com/img/a1322059512_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/tectonique-des-plaques">tectonique des plaques</a></div>
+            <div class="trackYear secondaryText">Jul 2013</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/distances-inconnues">
+                <img src="https://f4.bcbits.com/img/a1759318892_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/distances-inconnues">distances inconnues</a></div>
+            <div class="trackYear secondaryText">Jun 2013</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/mtml">
+                <img src="https://f4.bcbits.com/img/a2365289870_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/mtml">mtml</a></div>
+            <div class="trackYear secondaryText">Jan 2013</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/libre-arbitre">
+                <img src="https://f4.bcbits.com/img/a1565437910_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/libre-arbitre">libre arbitre</a></div>
+            <div class="trackYear secondaryText">Dec 2012</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/calme-relatif">
+                <img src="https://f4.bcbits.com/img/a0275061706_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/calme-relatif">calme relatif</a></div>
+            <div class="trackYear secondaryText">Dec 2012</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/filtre-naturel">
+                <img src="https://f4.bcbits.com/img/a1484673934_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/filtre-naturel">filtre naturel</a></div>
+            <div class="trackYear secondaryText">Nov 2012</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/30-3">
+                <img src="https://f4.bcbits.com/img/a0436166343_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/30-3">30*3</a></div>
+            <div class="trackYear secondaryText">Jul 2012</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/faux-pas-quil-vente">
+                <img src="https://f4.bcbits.com/img/a0122300272_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/faux-pas-quil-vente">faux pas qu&#39;il vente</a></div>
+            <div class="trackYear secondaryText">Feb 2012</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/morceaux-dambiances">
+                <img src="https://f4.bcbits.com/img/a1299861546_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/morceaux-dambiances">morceaux d&#39;ambiances</a></div>
+            <div class="trackYear secondaryText">Feb 2012</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/motifs">
+                <img src="https://f4.bcbits.com/img/a3777680774_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/motifs">motifs</a></div>
+            <div class="trackYear secondaryText">Jan 2012</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/nous-sommes-trois">
+                <img src="https://f4.bcbits.com/img/a2973195585_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/nous-sommes-trois">nous sommes trois</a></div>
+            <div class="trackYear secondaryText">Aug 2011</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/alt-rations">
+                <img src="https://f4.bcbits.com/img/a3252507421_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/alt-rations">altérations</a></div>
+            <div class="trackYear secondaryText">Dec 2010</div>
+            
+        </li>
+    
+        
+        <li>
+        
+            <div>
+                <a class="thumbthumb " href="/album/la-permanence-de-lobjet">
+                <img src="https://f4.bcbits.com/img/a1784250214_7.jpg">
+            
+                </a>
+            </div>
+            <div class="trackTitle"><a href="/album/la-permanence-de-lobjet">la permanence de l&#39;objet</a></div>
+            <div class="trackYear secondaryText">Sep 2010</div>
+            
+        </li>
+    
+</ul>
+
+</div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<h3 id="contact-help" class="title">contact / help</h3>
+
+
+
+<p id="contact-tracker-data" data-band-id="4038363339">
+
+    <a href="/contact?b=4038363339&amp;n=arbee" title="Send an email to arbee">Contact arbee</a>
+
+</p>
+
+
+<p><a href="https://bandcamp.com/help/downloading?from=tralbum_downloading" target="_blank">Streaming and <span id="sidebar-contact-label-break"><br></span>Download help</a></p>
+
+
+
+
+
+<p><a href="https://arbee.bandcamp.com/yum">Redeem code</a></p>
+
+
+
+
+
+    <p id="report-account-vm" data-tou-report-params="{&quot;i_type&quot;:&quot;a&quot;,&quot;i_id&quot;:948735258,&quot;a_id&quot;:4038363339}">
+        <a data-bind="click: showDialog">
+            
+                Report this album or account
+            
+        </a>
+    </p>
+
+
+
+</div>
+
+<div id="collectors-data" data-blob="{&quot;thumbs&quot;:[{&quot;fan_id&quot;:4984351,&quot;username&quot;:&quot;sharonshay&quot;,&quot;name&quot;:&quot;sharonshay&quot;,&quot;image_id&quot;:34637047,&quot;token&quot;:&quot;1:1746064648:4984351:0:1:0&quot;},{&quot;fan_id&quot;:2153335,&quot;username&quot;:&quot;sechogs1&quot;,&quot;name&quot;:&quot;Randall &quot;,&quot;image_id&quot;:39002132,&quot;token&quot;:&quot;1:1746064648:2153335:0:1:0&quot;},{&quot;fan_id&quot;:1519638,&quot;username&quot;:&quot;rikm&quot;,&quot;name&quot;:&quot;rikm&quot;,&quot;image_id&quot;:10008876,&quot;token&quot;:&quot;1:1746064648:1519638:0:1:0&quot;},{&quot;fan_id&quot;:1306727,&quot;username&quot;:&quot;cinnamonskull&quot;,&quot;name&quot;:&quot;Ur Trommler&quot;,&quot;image_id&quot;:37897404,&quot;token&quot;:&quot;1:1746064648:1306727:0:1:0&quot;},{&quot;fan_id&quot;:425141,&quot;username&quot;:&quot;pertin-nce&quot;,&quot;name&quot;:&quot;maxime tanguay&quot;,&quot;image_id&quot;:4279367,&quot;token&quot;:&quot;1:1746064648:425141:0:1:0&quot;},{&quot;fan_id&quot;:1471,&quot;username&quot;:&quot;eeem&quot;,&quot;name&quot;:&quot;Emmanuel Toledo&quot;,&quot;image_id&quot;:830407,&quot;token&quot;:&quot;1:1746064648:1471:0:1:0&quot;}],&quot;more_thumbs_available&quot;:false,&quot;reviews&quot;:[],&quot;more_reviews_available&quot;:false,&quot;band_thanks_text&quot;:&quot;supported by&quot;,&quot;shown_reviews&quot;:[],&quot;shown_thumbs&quot;:[{&quot;fan_id&quot;:4984351,&quot;username&quot;:&quot;sharonshay&quot;,&quot;name&quot;:&quot;sharonshay&quot;,&quot;image_id&quot;:34637047,&quot;token&quot;:&quot;1:1746064648:4984351:0:1:0&quot;},{&quot;fan_id&quot;:2153335,&quot;username&quot;:&quot;sechogs1&quot;,&quot;name&quot;:&quot;Randall &quot;,&quot;image_id&quot;:39002132,&quot;token&quot;:&quot;1:1746064648:2153335:0:1:0&quot;},{&quot;fan_id&quot;:1519638,&quot;username&quot;:&quot;rikm&quot;,&quot;name&quot;:&quot;rikm&quot;,&quot;image_id&quot;:10008876,&quot;token&quot;:&quot;1:1746064648:1519638:0:1:0&quot;},{&quot;fan_id&quot;:1306727,&quot;username&quot;:&quot;cinnamonskull&quot;,&quot;name&quot;:&quot;Ur Trommler&quot;,&quot;image_id&quot;:37897404,&quot;token&quot;:&quot;1:1746064648:1306727:0:1:0&quot;},{&quot;fan_id&quot;:425141,&quot;username&quot;:&quot;pertin-nce&quot;,&quot;name&quot;:&quot;maxime tanguay&quot;,&quot;image_id&quot;:4279367,&quot;token&quot;:&quot;1:1746064648:425141:0:1:0&quot;},{&quot;fan_id&quot;:1471,&quot;username&quot;:&quot;eeem&quot;,&quot;name&quot;:&quot;Emmanuel Toledo&quot;,&quot;image_id&quot;:830407,&quot;token&quot;:&quot;1:1746064648:1471:0:1:0&quot;}]}"></div>
+
+
+
+            <div style="clear:both"></div>
+        </div>
+
+        
+            <div id="pgFt">
+                <div class="recommendations-container" id="recommendations_container" data-nosnippet>
+
+<div class="recommendations-content">
+
+    <div class="first-row">
+        
+        <div class="recs-section bc-recs">
+            <p class="section-title">
+                
+                    If you like arbee, you may also like:
+                
+            </p>            
+            <ul class="horizontal">
+                
+                    <li class="recommended-album footer-cc"
+    id="id-652949122"
+    data-trackid="3873474511"
+    data-audiourl="{&quot;mp3-128&quot;:&quot;https://bandcamp.com/stream_redirect?enc=mp3-128&amp;track_id=3873474511&amp;ts=1748598399&amp;t=0b3c3a0e95efd5bd825b4a01b4c232f38d0142ff&quot;}"
+    data-albumtitle="Continental Drift"
+    data-albumid="652949122"
+    data-artist="Faures"
+    data-artistid="856051961"
+    data-from="footer-cc-a948735258">
+    <div class="album-art-container">
+        <img class="album-art" src="https://f4.bcbits.com/img/a2018265335_9.jpg">
+        <div class="play-button">
+            <div class="play-icon"></div>
+        </div>
+    </div>
+    <p class="title-and-artist">
+        <a class="album-link" href="https://homenormal.bandcamp.com/album/continental-drift?from=footer-cc-a948735258"><span class="release-title">Continental Drift</span><br><span class="spacer"></span><span class="by-artist">by Faures</span></a>
+    </p>
+    <div class="album-details">
+        
+            <p class="supporters-text">supported by 6 fans who also own “Des papiers II”</p>
+        
+        
+            <p class="comment"><span class="comment-contents">mostly soothing and gradually developing, with just a few occasional edges to keep things interesting. fadeouts leave me wanting more! </span><span class="comment-author">Giles</span></p>
+        
+        
+        
+        
+        <a class="go-to-album album-link" href="https://homenormal.bandcamp.com/album/continental-drift?from=footer-cc-a948735258">go to album</a>
+    </div>
+</li>
+
+                
+                    <li class="recommended-album footer-cc"
+    id="id-3024772571"
+    data-trackid="2105048534"
+    data-audiourl="{&quot;mp3-128&quot;:&quot;https://bandcamp.com/stream_redirect?enc=mp3-128&amp;track_id=2105048534&amp;ts=1748598399&amp;t=4a614ccd6d6cd5bb09adc832eb653f213b7807c5&quot;}"
+    data-albumtitle="Music For Piano &amp; Patience"
+    data-albumid="3024772571"
+    data-artist="Ithaca Trio"
+    data-artistid="856051961"
+    data-from="footer-cc-a948735258">
+    <div class="album-art-container">
+        <img class="album-art" src="https://f4.bcbits.com/img/a0972201264_9.jpg">
+        <div class="play-button">
+            <div class="play-icon"></div>
+        </div>
+    </div>
+    <p class="title-and-artist">
+        <a class="album-link" href="https://homenormal.bandcamp.com/album/music-for-piano-patience?from=footer-cc-a948735258"><span class="release-title">Music For Piano &amp; Patience</span><br><span class="spacer"></span><span class="by-artist">by Ithaca Trio</span></a>
+    </p>
+    <div class="album-details">
+        
+            <p class="supporters-text">supported by 6 fans who also own “Des papiers II”</p>
+        
+        
+            <p class="comment"><span class="comment-contents">Atmospheric and deeply affecting. Tape-y piano loops and woozy meditations. One of my very favorites. </span><span class="comment-author">Ruhe</span></p>
+        
+        
+        
+        
+        <a class="go-to-album album-link" href="https://homenormal.bandcamp.com/album/music-for-piano-patience?from=footer-cc-a948735258">go to album</a>
+    </div>
+</li>
+
+                
+                    <li class="recommended-album footer-cc"
+    id="id-128602311"
+    data-trackid="296940566"
+    data-audiourl="{&quot;mp3-128&quot;:&quot;https://bandcamp.com/stream_redirect?enc=mp3-128&amp;track_id=296940566&amp;ts=1748598399&amp;t=ccd855c912abd5fd62a0618d72cf99d326102ed8&quot;}"
+    data-albumtitle="and then there was nothing"
+    data-albumid="128602311"
+    data-artist="Ian Hawgood"
+    data-artistid="856051961"
+    data-from="footer-cc-a948735258">
+    <div class="album-art-container">
+        <img class="album-art" src="https://f4.bcbits.com/img/a2193252233_9.jpg">
+        <div class="play-button">
+            <div class="play-icon"></div>
+        </div>
+    </div>
+    <p class="title-and-artist">
+        <a class="album-link" href="https://homenormal.bandcamp.com/album/and-then-there-was-nothing?from=footer-cc-a948735258"><span class="release-title">and then there was nothing</span><br><span class="spacer"></span><span class="by-artist">by Ian Hawgood</span></a>
+    </p>
+    <div class="album-details">
+        
+            <p class="supporters-text">supported by 5 fans who also own “Des papiers II”</p>
+        
+        
+            <p class="comment"><span class="comment-contents">Thank you for a lovely album. Very best wishes to you. </span><span class="comment-author">Roland Pyle</span></p>
+        
+        
+        
+        
+        <a class="go-to-album album-link" href="https://homenormal.bandcamp.com/album/and-then-there-was-nothing?from=footer-cc-a948735258">go to album</a>
+    </div>
+</li>
+
+                
+                    <li class="recommended-album footer-nn"
+    id="id-3287299729"
+    data-trackid="3359525184"
+    data-audiourl="{&quot;mp3-128&quot;:&quot;https://bandcamp.com/stream_redirect?enc=mp3-128&amp;track_id=3359525184&amp;ts=1748598399&amp;t=1c397f2f1505d047e4e215a08d2268ce2f97793d&quot;}"
+    data-albumtitle="Unreleased Territory vol. 5: Low Voltage"
+    data-albumid="3287299729"
+    data-artist="VA"
+    data-artistid="1319491037"
+    data-from="footer-nn-a948735258">
+    <div class="album-art-container">
+        <img class="album-art" src="https://f4.bcbits.com/img/a4080708168_9.jpg">
+        <div class="play-button">
+            <div class="play-icon"></div>
+        </div>
+    </div>
+    <p class="title-and-artist">
+        <a class="album-link" href="https://electricshapes.bandcamp.com/album/unreleased-territory-vol-5-low-voltage?from=footer-nn-a948735258"><span class="release-title">Unreleased Territory vol. 5: Low Voltage</span><br><span class="spacer"></span><span class="by-artist">by VA</span></a>
+    </p>
+    <div class="album-details">
+        
+        
+        
+            <p class="comment"><span class="comment-contents">Explore ambient music from across the globe in drifting and soothing songs on the new compilation from Electric Shapes. </span><span class="comment-author">Bandcamp New &amp; Notable <span class="date">Apr 24, 2024</span></span></p>
+        
+        
+        
+        <a class="go-to-album album-link" href="https://electricshapes.bandcamp.com/album/unreleased-territory-vol-5-low-voltage?from=footer-nn-a948735258">go to album</a>
+    </div>
+</li>
+
+                
+                    <li class="recommended-album footer-nn"
+    id="id-1406045366"
+    data-trackid="1037054868"
+    data-audiourl="{&quot;mp3-128&quot;:&quot;https://bandcamp.com/stream_redirect?enc=mp3-128&amp;track_id=1037054868&amp;ts=1748598399&amp;t=925c57687b6ef27f9fb5b09a3954482404eaf8d1&quot;}"
+    data-albumtitle="Sjunger För Varandra"
+    data-albumid="1406045366"
+    data-artist="Marta Forsberg"
+    data-artistid="3344594942"
+    data-from="footer-nn-a948735258">
+    <div class="album-art-container">
+        <img class="album-art" src="https://f4.bcbits.com/img/a0672718049_9.jpg">
+        <div class="play-button">
+            <div class="play-icon"></div>
+        </div>
+    </div>
+    <p class="title-and-artist">
+        <a class="album-link" href="https://martaforsberg.bandcamp.com/album/sjunger-fo-r-varandra?from=footer-nn-a948735258"><span class="release-title">Sjunger För Varandra</span><br><span class="spacer"></span><span class="by-artist">by Marta Forsberg</span></a>
+    </p>
+    <div class="album-details">
+        
+        
+        
+            <p class="comment"><span class="comment-contents">Swedish composer Marta Forsberg&#39;s latest is a nuanced blending of choral music, contemporary minimalism, and electronic music. </span><span class="comment-author">Bandcamp New &amp; Notable <span class="date">Feb 17, 2024</span></span></p>
+        
+        
+        
+        <a class="go-to-album album-link" href="https://martaforsberg.bandcamp.com/album/sjunger-fo-r-varandra?from=footer-nn-a948735258">go to album</a>
+    </div>
+</li>
+
+                
+                    <li class="recommended-album footer-nn"
+    id="id-2647712089"
+    data-trackid="1529681514"
+    data-audiourl="{&quot;mp3-128&quot;:&quot;https://bandcamp.com/stream_redirect?enc=mp3-128&amp;track_id=1529681514&amp;ts=1748598399&amp;t=4d6c88e09ebef88ed0e8eca7f1375a7212736c40&quot;}"
+    data-albumtitle="VA - Serotonin"
+    data-albumid="2647712089"
+    data-artist="Edited Arts"
+    data-artistid="2042047297"
+    data-from="footer-nn-a948735258">
+    <div class="album-art-container">
+        <img class="album-art" src="https://f4.bcbits.com/img/a2558791344_9.jpg">
+        <div class="play-button">
+            <div class="play-icon"></div>
+        </div>
+    </div>
+    <p class="title-and-artist">
+        <a class="album-link" href="https://editedarts.bandcamp.com/album/va-serotonin?from=footer-nn-a948735258"><span class="release-title">VA - Serotonin</span><br><span class="spacer"></span><span class="by-artist">by Edited Arts</span></a>
+    </p>
+    <div class="album-details">
+        
+        
+        
+            <p class="comment"><span class="comment-contents">This 19-track charity compilation from London label Edited Arts showcases the moodier side of electronic music in songs that hover &amp; float. </span><span class="comment-author">Bandcamp New &amp; Notable <span class="date">Feb 6, 2021</span></span></p>
+        
+        
+        
+        <a class="go-to-album album-link" href="https://editedarts.bandcamp.com/album/va-serotonin?from=footer-nn-a948735258">go to album</a>
+    </div>
+</li>
+
+                
+                    <li class="recommended-album footer-cc"
+    id="id-1638303264"
+    data-trackid="1199501402"
+    data-audiourl="{&quot;mp3-128&quot;:&quot;https://bandcamp.com/stream_redirect?enc=mp3-128&amp;track_id=1199501402&amp;ts=1748598399&amp;t=29e5c8083cd62dcb7fcfd93b45193624c21fc958&quot;}"
+    data-albumtitle="Care And Gestures"
+    data-albumid="1638303264"
+    data-artist="Music For Sleep"
+    data-artistid="4019566841"
+    data-from="footer-cc-a948735258">
+    <div class="album-art-container">
+        <img class="album-art" src="https://f4.bcbits.com/img/a0468681416_9.jpg">
+        <div class="play-button">
+            <div class="play-icon"></div>
+        </div>
+    </div>
+    <p class="title-and-artist">
+        <a class="album-link" href="https://mforsleep.bandcamp.com/album/care-and-gestures?from=footer-cc-a948735258"><span class="release-title">Care And Gestures</span><br><span class="spacer"></span><span class="by-artist">by Music For Sleep</span></a>
+    </p>
+    <div class="album-details">
+        
+            <p class="supporters-text">supported by 5 fans who also own “Des papiers II”</p>
+        
+        
+            <p class="comment"><span class="comment-contents">Perfect while waking up on a Sunday morning by the ocean. Thank you for these gems. </span><span class="comment-author">Fabien</span></p>
+        
+        
+        
+        
+        <a class="go-to-album album-link" href="https://mforsleep.bandcamp.com/album/care-and-gestures?from=footer-cc-a948735258">go to album</a>
+    </div>
+</li>
+
+                
+            </ul>
+        </div>
+    </div>
+
+    <div class="second-row">
+        <img src="/img/0.gif" class="lazy first-row-beacon"
+        data-clicks=footer_cc_rec_seen,footer_cc_rec_seen,footer_cc_rec_seen,footer_nn_rec_seen,footer_nn_rec_seen,footer_nn_rec_seen,footer_cc_rec_seen,footer_seen>
+        <div class="bc-daily-section">
+            <p class="section-title"><a class="bcd-title" href="https://daily.bandcamp.com?utm_source=footer">Bandcamp Daily</a>&nbsp;&nbsp;<span class="subtitle">your guide to the world of Bandcamp</span></p>
+            <ul class="horizontal">
+                
+                    <li class="recommended-story genre-related">
+    <a class="daily-link" href="https://daily.bandcamp.com/features/machinefabriek-interview?utm_source=footer">
+        <div class="story-image-container"><img class="story-image" src="https://f4.bcbits.com/img/0010061917_33.jpg"></div>
+        <p class="story-headline">Machinefabriek’s Experimental Electronic Music Swings From Murmur to Explosion</p>
+    </a>
+</li>
+
+                
+                    <li class="recommended-story genre-related">
+    <a class="daily-link" href="https://daily.bandcamp.com/features/the-bug-dylan-carlson-earth-interview?utm_source=footer">
+        <div class="story-image-container"><img class="story-image" src="https://f4.bcbits.com/img/0009974748_33.jpg"></div>
+        <p class="story-headline">On “Concrete Desert,” The Bug and Earth’s Dylan Carlson Destroy L.A.</p>
+    </a>
+</li>
+
+                
+                    <li class="recommended-story genre-related">
+    <a class="daily-link" href="https://daily.bandcamp.com/features/eleh-interview?utm_source=footer">
+        <div class="story-image-container"><img class="story-image" src="https://f4.bcbits.com/img/0009014511_33.jpg"></div>
+        <p class="story-headline">Mysterious Composer Eleh Blends Drone and Otherworldly Sounds to Haunting Effect</p>
+    </a>
+</li>
+
+                
+            </ul>
+            
+        </div>
+        <div class="bc-weekly-section">
+            <p class="section-title">On Bandcamp Radio</p>
+            <div class="bc-weekly-content">
+                <div class="bcw-image-container">
+                    <a class="bcw-link" href="https://bandcamp.com/?show=841&amp;play=1"><img class="bcw-image" src="https://f4.bcbits.com/img/0039848212_33.jpg"></a>
+                </div>
+                <div class="blurb-and-button">
+                    <a class="linked-blurb bcw-link" href="https://bandcamp.com/?show=841&amp;play=1"><p class="bcw-blurb">dreamcastmoe stops by to talk about his new release &#39;The Lost Tape Vol 3&#39;.</p></a>
+                    <a class="go-to-bcweekly bcw-link" href="https://bandcamp.com/?show=841&amp;play=1"><div><span>listen now </span> <svg class="icon play-bcweekly" viewBox="0 0 12 14"><use href="#play-bcweekly"></use></svg></div></a>
+                </div>
+            </div>
+        </div>
+        <img src="/img/0.gif" class="lazy editorial-seen-beacon"
+        data-clicks=footer_genre_article_seen,footer_genre_article_seen,footer_genre_article_seen,footer_bcw_seen>
+    </div>
+</div>
+
+<svg class="svg-defs" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+    <path id="bc-daily-arrow" d="M 14,3.5 9,0 9,3 0,3 0,4 9,4 9,7 z"></path>
+    <path id="play-bcweekly" d="M 10,6 0,0 0,12  z"></path>
+    </defs>
+</svg>
+
+</div>
+
+            </div>
+        
+
+        
+            <span id="webapp-selector-ui" class="webapp-selector-ui" style="display:none" data-webapps="[&quot;flexotest01-1&quot;,&quot;flexotest01-2&quot;,&quot;flexotest01-3&quot;,&quot;flexotest01-4&quot;,&quot;flexotest01-5&quot;,&quot;flexotest01-6&quot;,&quot;flexotest01-7&quot;,&quot;flexotest01-8&quot;,&quot;flexotest01-9&quot;,&quot;flexotest01-10&quot;,&quot;flexotest01-11&quot;,&quot;flexotest01-12&quot;,&quot;flexotest01-13&quot;,&quot;flexotest01-14&quot;,&quot;flexotest01-15&quot;,&quot;flexotest01-16&quot;]" data-backendid="flexocentral-qknz-6" data-bccookie="" data-cookiename="bc_webapp3"></span>
+
+            <page-footer page-context="{&quot;env&quot;:&quot;production&quot;,&quot;fanId&quot;:null,&quot;isAdmin&quot;:null,&quot;isMobile&quot;:false,&quot;userId&quot;:null,&quot;isLoggedIn&quot;:false,&quot;colorScheme&quot;:&quot;light&quot;,&quot;languages&quot;:{&quot;en&quot;:&quot;English&quot;,&quot;de&quot;:&quot;Deutsch&quot;,&quot;es&quot;:&quot;Español&quot;,&quot;fr&quot;:&quot;Français&quot;,&quot;pt&quot;:&quot;Português&quot;,&quot;ja&quot;:&quot;日本語&quot;},&quot;bcStrings&quot;:null,&quot;isPageMobilized&quot;:true}" ></page-footer>
+              
+        
+    </div>
+</div>
+
+<div id="global-invisible-recaptcha" style="position: absolute; top: 0;"></div>
+<div id="fan-signup-addnl-bundle" data-url="https://s4.bcbits.com/client-bundle/1/trackpipe/masonry-869dd12d44260637b4aba1df92b7ac4d.js"></div>
+
+
+
+
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/GlobalJS_1/tko_trackpipe-525ac32695cf93110d7d35f736fd51e7.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" ></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/global_foot1-3efcad97cf0d4fc3c2883cae0b531bcc.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" ></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/global_foot2-1a13c0398dfe235deb8dc88c2b3fdf2d.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" ></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/GlobalJS_1/time-43d34bf55f11a53e195fed07dde95ccc.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" ></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/Fraud_1/fraud_js-2dae71c049a60b82b63f4cd24b1b062f.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" data-enterprise-recaptcha="{&quot;render_url&quot;:&quot;https://www.recaptcha.net/recaptcha/enterprise.js?render=6LeBNSocAAAAADrhkgX9-hQq4E4K1P_HVzB7IDFD&quot;,&quot;public_site_key&quot;:&quot;6LeBNSocAAAAADrhkgX9-hQq4E4K1P_HVzB7IDFD&quot;}"></script>
+
+
+
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/tralbum-7c6f81d695530ec421f52336cc0be0f8.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" data-page="&quot;tralbum_page0&quot;"></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/tralbum_templates-370da67a08cc61757ee2b7fa7f0d8614.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" ></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/jquery_lazyload-2b969f913b6f4096c826181b09ab943a.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" ></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/GlobalJS_2/web_components-582ca09d7869cee2e20c489913b24787.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" ></script>
+
+
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/Tracker_1/analytics-4b005fb3a73d78f9fbbd6bec6d5d8de5.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" data-data="{&quot;env&quot;:2,&quot;domain_match&quot;:true,&quot;bandGoogleAnalyticsId&quot;:null}"></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/Tracker_1/impl-2adf8819c63716af8b5fa95e16511f95.js" crossorigin="anonymous" nonce="wTheumiB9KwnlhpIPDSBvQ==" data-enabled="true" data-transport="&quot;beacon&quot;" data-record-url="&quot;https://bandcamp.com/api/tracker/1/record&quot;" data-send-delay="5" data-auto-track-clicks="true" data-auto-track-filters="null"></script>
+ 
+
+</body>
+</html>
+<!-- flexocentral-qknz-6 2025-05-30 09:46:39 UTC -->
+<!-- album id 948735258 -->
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:2465ca5c-5455-4ead-826e-639178775f41>
+WARC-Target-URI: https://bandcamp.com/EmbeddedPlayer/album=948735258
+WARC-Date: 2025-05-30T09:46:40.365Z
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:25f4ae30-bc62-40fd-a97c-7ea7ec983bbe>
+Content-Type: application/http; msgtype=request
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:df65ffa3fc9d97400f561c96c6eb00c55d93edb61b72b23f4340763a67705666
+Content-Length: 48
+
+GET /EmbeddedPlayer/album=948735258 HTTP/1.1
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:2465ca5c-5455-4ead-826e-639178775f41>
+WARC-Target-URI: https://bandcamp.com/EmbeddedPlayer/album=948735258
+WARC-Date: 2025-05-30T09:46:40.365Z
+WARC-Type: metadata
+WARC-Record-ID: <urn:uuid:22395556-6c80-46ac-a764-196f6a5e29ae>
+Content-Type: application/warc-fields
+WARC-Payload-Digest: sha256:ad340633affa855c56402df3e74abf874836f321a942e1b7cb87dffb206ad228
+WARC-Block-Digest: sha256:ad340633affa855c56402df3e74abf874836f321a942e1b7cb87dffb206ad228
+Content-Length: 424
+
+harEntryId: 1af71df5ef33d82a86f1a3ea8ab4c310
+harEntryOrder: 0
+cache: {}
+startedDateTime: 2025-05-30T09:46:40.031Z
+time: 320
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":320,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 70
+warcRequestCookies: []
+warcResponseHeadersSize: 827
+warcResponseCookies: [{"name":"BACKENDID3","value":"flexocentral-t638-6","path":"/","secure":true}]
+responseDecoded: false
+
+
+WARC/1.1
+WARC-Target-URI: https://bandcamp.com/EmbeddedPlayer/album=948735258
+WARC-Date: 2025-05-30T09:46:40.364Z
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:2465ca5c-5455-4ead-826e-639178775f41>
+Content-Type: application/http; msgtype=response
+WARC-Payload-Digest: sha256:549283fad8100a3e1aa22dd22ff8aaf99e16ff4ab4d321017695806cd7894273
+WARC-Block-Digest: sha256:7cd89b974ee338e90a5d10fc68882e92a95dae3b126871e8ecbb13fb65fda74c
+Content-Length: 24497
+
+HTTP/1.1 200 OK
+accept-ranges: bytes
+connection: keep-alive
+content-encoding: gzip
+content-security-policy: base-uri 'none'; object-src 'none'; report-uri https://bandcamp.com/api/cspreport/1/violation; script-src http: https: 'nonce-9L8E58qzaYN3lBm/BIlVVQ==' 'report-sample' 'strict-dynamic'
+content-type: text/html; charset=UTF-8
+date: Fri, 30 May 2025 09:46:40 GMT
+referrer-policy: no-referrer-when-downgrade
+server: nginx
+set-cookie: BACKENDID3=flexocentral-t638-6; path=/; Secure
+strict-transport-security: max-age=63072000
+transfer-encoding: chunked
+vary: Accept-Encoding
+via: 1.1 varnish, 1.1 varnish
+x-cache: MISS, MISS
+x-cache-hits: 0, 0
+x-served-by: cache-rtm-ehrd2290041-RTM, cache-rtm-ehrd2290057-RTM
+x-timer: S1748598400.142399,VS0,VE268
+x-pollyjs-finalurl: https://bandcamp.com/EmbeddedPlayer/album=948735258
+
+<!DOCTYPE HTML>
+<html>
+<head>
+<!-- player/EmbeddedPlayer.html -->
+    <meta name="viewport" content="width=device-width,height=500">
+    <meta name="viewport" content="width=device-width,height=500" id="viewportmeta" />
+
+    
+<script type="text/javascript" nonce="9L8E58qzaYN3lBm/BIlVVQ==">
+window.BCTracker=window.BCTracker||{preloadQueue:[],record:function(){this.preloadQueue.push(Array.prototype.slice.call(arguments))},prePageViewCallbacks:[],afterPageView:function(e){this.prePageViewCallbacks.push(e)}},window.ScrollDepthTracker=function(){this.track=function(){}},window.ScrollDepthTracker.track=function(){}
+</script>
+
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/BCCookies_1/bccookies-cd3c4e8de65a85913bb6db9b8ad7de36.js" crossorigin="anonymous" nonce="9L8E58qzaYN3lBm/BIlVVQ==" ></script>
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/jquery-5a925ca31f3b3dcc6f1353d451cb7208.js" crossorigin="anonymous" nonce="9L8E58qzaYN3lBm/BIlVVQ==" ></script>
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/jquery_ui-e99202a60d0829a8d58663a3534484fb.js" crossorigin="anonymous" nonce="9L8E58qzaYN3lBm/BIlVVQ==" ></script>
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/GlobalJS_1/tko_trackpipe-525ac32695cf93110d7d35f736fd51e7.js" crossorigin="anonymous" nonce="9L8E58qzaYN3lBm/BIlVVQ==" ></script>
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/trackpipe/embedded_player-7ff99163d13590be7ea88572b154d82a.js" crossorigin="anonymous" nonce="9L8E58qzaYN3lBm/BIlVVQ==" data-browser="{&quot;type&quot;:&quot;gecko&quot;,&quot;make&quot;:&quot;firefox&quot;,&quot;version&quot;:[113,0],&quot;platform&quot;:&quot;mac&quot;,&quot;grade&quot;:&quot;A&quot;,&quot;platform_name&quot;:&quot;&quot;,&quot;platform_closed&quot;:false,&quot;download_difficulty&quot;:&quot;easy&quot;,&quot;media_mode&quot;:&quot;desktop&quot;,&quot;mobile_app_compatible&quot;:false}" data-templ-globals="{&quot;siteroot&quot;:&quot;http://bandcamp.com&quot;,&quot;siteroot_https&quot;:&quot;https://bandcamp.com&quot;,&quot;siteroot_current&quot;:&quot;https://bandcamp.com&quot;,&quot;static_siteroot&quot;:&quot;https://s4.bcbits.com&quot;,&quot;is_https&quot;:true,&quot;image_siteroot&quot;:&quot;https://f4.bcbits.com&quot;,&quot;image_siteroot_https&quot;:&quot;https://f4.bcbits.com&quot;,&quot;image_formats&quot;:[{&quot;id&quot;:0,&quot;name&quot;:&quot;original&quot;,&quot;resize_algo&quot;:&quot;original&quot;,&quot;file_format&quot;:null},{&quot;id&quot;:1,&quot;name&quot;:&quot;fullsize&quot;,&quot;resize_algo&quot;:&quot;scrub&quot;,&quot;file_format&quot;:&quot;original&quot;},{&quot;id&quot;:2,&quot;name&quot;:&quot;art_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:350,&quot;height&quot;:350,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:3,&quot;name&quot;:&quot;art_thumbthumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:100,&quot;height&quot;:100,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:4,&quot;name&quot;:&quot;art_embedded_metadata&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:300,&quot;height&quot;:300,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:5,&quot;name&quot;:&quot;art_embedded_metadata_large&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:6,&quot;name&quot;:&quot;art_embedded_player&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:100,&quot;height&quot;:100,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:7,&quot;name&quot;:&quot;art_embedded_player_large&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:150,&quot;height&quot;:150,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:8,&quot;name&quot;:&quot;art_tags&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:124,&quot;height&quot;:124,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:9,&quot;name&quot;:&quot;art_tags_large&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:210,&quot;height&quot;:210,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:10,&quot;name&quot;:&quot;screen&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1200,&quot;height&quot;:1200,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:11,&quot;name&quot;:&quot;art_tag_search&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:172,&quot;height&quot;:172,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:12,&quot;name&quot;:&quot;art_artist_index&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:138,&quot;height&quot;:138,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:13,&quot;name&quot;:&quot;art_solo_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:380,&quot;height&quot;:380,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:14,&quot;name&quot;:&quot;art_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:368,&quot;height&quot;:368,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:15,&quot;name&quot;:&quot;art_feed_new_release&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:135,&quot;height&quot;:135,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:16,&quot;name&quot;:&quot;art_app_large&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:70,&quot;minsize&quot;:{&quot;size&quot;:30000,&quot;format&quot;:5}},{&quot;id&quot;:20,&quot;name&quot;:&quot;bio_screen&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1024,&quot;height&quot;:1024,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:21,&quot;name&quot;:&quot;bio_thumb&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:120,&quot;height&quot;:180,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:22,&quot;name&quot;:&quot;bio_navbar&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:25,&quot;height&quot;:25,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:23,&quot;name&quot;:&quot;bio_phone&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:300,&quot;height&quot;:300,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:24,&quot;name&quot;:&quot;bio_licensing&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:300,&quot;height&quot;:300,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:25,&quot;name&quot;:&quot;bio_app&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:70},{&quot;id&quot;:26,&quot;name&quot;:&quot;bio_subscribe&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:800,&quot;height&quot;:600,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:27,&quot;name&quot;:&quot;bio_subscribe2&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:715,&quot;height&quot;:402,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:28,&quot;name&quot;:&quot;bio_featured&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:768,&quot;height&quot;:432,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:29,&quot;name&quot;:&quot;bio_autocomplete&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:100,&quot;height&quot;:75,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:31,&quot;name&quot;:&quot;package_screen&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1024,&quot;height&quot;:1024,&quot;file_format&quot;:&quot;original&quot;},{&quot;id&quot;:32,&quot;name&quot;:&quot;package_solo_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:380,&quot;height&quot;:285,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:33,&quot;name&quot;:&quot;package_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:368,&quot;height&quot;:276,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:36,&quot;name&quot;:&quot;package_page&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:400,&quot;height&quot;:300,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:37,&quot;name&quot;:&quot;package_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:168,&quot;height&quot;:126,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:38,&quot;name&quot;:&quot;package_thumb_small&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:144,&quot;height&quot;:108,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:41,&quot;name&quot;:&quot;fan_bio_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:210,&quot;height&quot;:210,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:42,&quot;name&quot;:&quot;fan_bio_thumb_small&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;height&quot;:50,&quot;width&quot;:50,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:43,&quot;name&quot;:&quot;fan_banner&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;height&quot;:100,&quot;width&quot;:99999,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:44,&quot;name&quot;:&quot;fan_banner_2x&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;height&quot;:200,&quot;width&quot;:99999,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:50,&quot;name&quot;:&quot;results_grid&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:140,&quot;height&quot;:140,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:65,&quot;name&quot;:&quot;tralbum_page_cover_art&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:70,&quot;minsize&quot;:{&quot;size&quot;:30000,&quot;format&quot;:69},&quot;anim_ok&quot;:true},{&quot;id&quot;:66,&quot;name&quot;:&quot;tralbum_page_cover_art_popup&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1200,&quot;height&quot;:1200,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:67,&quot;name&quot;:&quot;art_thumb_anim_ok&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:350,&quot;height&quot;:350,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:68,&quot;name&quot;:&quot;art_tags_large_anim_ok&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:210,&quot;height&quot;:210,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:69,&quot;name&quot;:&quot;art_embedded_metadata_large_anim_ok&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:700,&quot;height&quot;:700,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:70,&quot;name&quot;:&quot;tralbum_page_package_small&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:360,&quot;height&quot;:270,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;mozjpeg&quot;:true},{&quot;id&quot;:71,&quot;name&quot;:&quot;tralbum_page_package_large&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:720,&quot;height&quot;:540,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;mozjpeg&quot;:true},{&quot;id&quot;:100,&quot;name&quot;:&quot;custom_header_desktop&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:975,&quot;max_height&quot;:180,&quot;file_format&quot;:&quot;original&quot;,&quot;allow_transparency&quot;:true},{&quot;id&quot;:101,&quot;name&quot;:&quot;custom_header_paypal&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:750,&quot;height&quot;:90,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:120,&quot;name&quot;:&quot;custom_header_phone&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:640,&quot;max_height&quot;:124,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:130,&quot;name&quot;:&quot;design_background&quot;,&quot;resize_algo&quot;:&quot;scrub&quot;,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:140,&quot;name&quot;:&quot;subscribe_message&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:60,&quot;height&quot;:45,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:150,&quot;name&quot;:&quot;video_landscape&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:1280,&quot;height&quot;:720,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:151,&quot;name&quot;:&quot;video_portrait&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:720,&quot;height&quot;:1280,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:160,&quot;name&quot;:&quot;buy_full_email_thumb_montage&quot;,&quot;resize_algo&quot;:&quot;thumb_crop&quot;,&quot;width&quot;:60,&quot;height&quot;:100,&quot;left&quot;:40,&quot;top&quot;:0,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:161,&quot;name&quot;:&quot;buy_full_email_thumb_montage_release&quot;,&quot;resize_algo&quot;:&quot;thumb_crop&quot;,&quot;width&quot;:40,&quot;height&quot;:80,&quot;left&quot;:40,&quot;top&quot;:0,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:100},{&quot;id&quot;:165,&quot;name&quot;:&quot;ppp_email_gift_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb_composite&quot;,&quot;overlay_image&quot;:&quot;public/img/banner_email.png&quot;,&quot;x_offset&quot;:92,&quot;y_offset&quot;:0,&quot;width&quot;:210,&quot;height&quot;:210,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;quality&quot;:100},{&quot;id&quot;:170,&quot;name&quot;:&quot;weekly_mobile_web&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:750,&quot;height&quot;:422,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:171,&quot;name&quot;:&quot;weekly_desktop&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1244,&quot;height&quot;:646,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:180,&quot;name&quot;:&quot;bcdaily_homepage_big&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1244,&quot;height&quot;:646,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;anim_ok&quot;:true},{&quot;id&quot;:200,&quot;name&quot;:&quot;mobile_fan_banner_ios_3x&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1125,&quot;height&quot;:420,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:201,&quot;name&quot;:&quot;mobile_fan_banner_ios_2x&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:750,&quot;height&quot;:280,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:202,&quot;name&quot;:&quot;mobile_fan_banner_ios_1x&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:375,&quot;height&quot;:140,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:203,&quot;name&quot;:&quot;mobile_fan_banner_android_xxxhdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:1125,&quot;height&quot;:420,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:204,&quot;name&quot;:&quot;mobile_fan_banner_android_xxhdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:960,&quot;height&quot;:360,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:205,&quot;name&quot;:&quot;mobile_fan_banner_android_xhdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:640,&quot;height&quot;:240,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:206,&quot;name&quot;:&quot;mobile_fan_banner_android_hdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:480,&quot;height&quot;:180,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:207,&quot;name&quot;:&quot;mobile_fan_banner_android_mdpi&quot;,&quot;resize_algo&quot;:&quot;fit&quot;,&quot;width&quot;:320,&quot;height&quot;:120,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:220,&quot;name&quot;:&quot;newsletter_artist_feature&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:900,&quot;height&quot;:468,&quot;file_format&quot;:&quot;JPEG&quot;},{&quot;id&quot;:300,&quot;name&quot;:&quot;grayscale_thumb&quot;,&quot;resize_algo&quot;:&quot;thumb&quot;,&quot;width&quot;:350,&quot;height&quot;:350,&quot;file_format&quot;:&quot;JPEG&quot;,&quot;filter&quot;:&quot;grayscale&quot;}],&quot;custom_domains_active&quot;:true,&quot;base_port_str&quot;:null,&quot;sitedomain&quot;:&quot;bandcamp.com&quot;}" data-use-script="true" data-siteroot-current="&quot;https://bandcamp.com&quot;" data-parent-page="&quot;&quot;"></script>
+    <script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/GlobalJS_1/time-43d34bf55f11a53e195fed07dde95ccc.js" crossorigin="anonymous" nonce="9L8E58qzaYN3lBm/BIlVVQ==" ></script>
+
+    <link type="text/css" rel="stylesheet" href="https://s4.bcbits.com/client-bundle/1/trackpipe/embedded_player-e5952006057763222369c3ef2adc00c5.css">
+    
+
+    <style type="text/css">
+    
+        body {
+        background-color: #;
+        
+            overflow: hidden;
+        }
+        #player .error {
+            position: absolute;
+            top: 0px;
+            left: 0px;
+            margin: 1em;
+            white-space: normal;
+            visibility: hidden;
+        }
+        #player .error em {
+            font-style: normal;
+            font-weight: bold;
+        }
+
+        
+        
+        
+
+        
+        
+        
+        a,.linktext {
+            color: #;
+        }
+        .thumb.ui-draggable-dragging {
+            border: solid 1px #;
+        }
+
+        .merchthumb.selected {
+            outline: 1px solid #;
+        }
+        .classic .fgtext {
+            color: #;
+        }
+    
+    </style>
+</head>
+<body>
+    <!-- use_script: true  use_css: true -->
+    
+    <div id="player" class="inline_player initialstate">
+        <div id="artarea">
+            <a id="artlink" href="#">
+                <div id="art" class="item"></div>
+            </a>
+            <div id="big_play_button" class="item"><div id="big_play_icon"></div></div>
+            <a class="logo" href="#" target="_blank"><span class="icon">&nbsp;</span></a>
+        </div>
+
+        <div id="nonartarea">
+        <div id="merch" class="item">
+        </div>
+
+        <div id="infolayer">
+            <a class="artlink" href="#">
+                <div class="art item"></div>
+            </a>
+            <div class="info">
+            <a class="logo" href="#" target="_blank"><span class="icon">&nbsp;</span></a>
+            <a id="logoalt2" href="#" target="_blank"><span class="icon">&nbsp;</span></a>
+            <div id="maintext" class="item linktext">
+                <a id="maintextlink" href="#" target="_blank"></a>
+            </div>
+            <div id="linkarea" class="item">
+                <span id="buyordownload">
+                    <a id="buyordownloadlink" href="#" target="_blank">download</a>
+                </span>
+                <span id="share">
+                    <a id="sharelink" href="#" target="_blank">share</a>
+                </span>
+            </div>
+
+            <div id="subtext" class="item linktext">
+                <a id="subtextlink" href="#" target="_blank"></a>
+            </div>
+
+            <div id="albumtrackartistrow">
+                <div id="album" class="item">
+                </div>
+                <div id="trackname" class="item">
+                    <a id="tracknamelink" href="#" target="_blank"></a>
+                </div>
+                <div id="artist" class="item">
+                </div>
+            </div>
+
+            <div id="play" class="embeddedplaybutton item"></div>
+
+            <div id="currenttitlerow"><!-- provide block layout item for inline-block stuff before timeline-->
+                <div id="currenttitle" class="item">
+                    <span id="currenttitle_tracknum"></span>
+                    <span id="currenttitle_title" class="fgtext"></span>
+                </div>
+                <div id="currenttimeblock">
+                    <div id="currenttime" class="item"></div>
+                    <div id="totaltime" class="item"></div>
+                </div>
+            </div>
+
+            <div id="timelinecontainer">
+                <div id="timeline" class="item">
+                    <div class="progbar_empty">
+                        <div id="progbar_fill" class="progbar_fill">
+                            <div id="progbar_fill_played" class="progbar_fill played"></div>
+                        </div>
+                    <div class="thumb" id="progbar_thumb"></div>
+                    </div>
+                </div>
+            </div>
+            <div id="prevnext">
+                <div id="prev" class="prevbutton item big"><div class="icon"></div></div>
+                <div id="next" class="nextbutton item big"><div class="icon"></div></div>
+            </div>
+            </div>
+        </div>
+
+        <div id="tracklist" class="item">
+            <div id="tracklist_scroller">
+                <ul id="tracklist_ul">
+                </ul>
+            </div>
+        </div>
+
+        <div id="linkareaalt" class="item">
+            <span id="buyordownloadalt">
+                <a id="buyordownloadlinkalt" href="#" target="_blank">download</a>
+            </span>
+            <span id="sharealt">
+                <a id="sharelinkalt" href="#" target="_blank">share</a>
+            </span>
+        </div>
+        <a id="logoalt" href="#" target="_blank"><span class="icon">&nbsp;</span></a>
+
+        </div>
+
+        <div id="sharedialog" title="Share">
+            <p>
+                <a href="?action=embed" target="_blank">Embed this album<span class="icons"><span class="small bc-ui2">small</span><span class="medium bc-ui2">medium</span><span class="large bc-ui2">large</span></span></a>
+            </p>
+            <p>
+                Email:
+                <input id="shareurl" type="text" value="" readonly />
+            </p>
+
+            
+        </div>
+
+        <div id="tinyplayer" class="tinyplayer item"><a href="#" target="_blank" id="infolink"></a></div>
+        <div id="badtralbumerror" class="error">Sorry, this track or album is not available.</div>
+        <div id="tralbumpermissionserror" class="error">This exclusive embed is not set up for usage on <em><span class="hostname"></span></em>.</div>
+        <div id="tralbumwordpresspermissionserror" class="error">
+        This exclusive embed is not set up for usage from <em><span class="hostname"></span>wordpress.com</em>. Perhaps it's restricted to a custom domain, and you're currently looking at the preview on <em><span class="hostname"></span>wordpress.com</em>? If so, fear not, your embed will work when you publish.
+        </div>
+
+        <div id="badbrowsererror" class="error">Sorry, this player does not support your browser. Your browser must either support native HTML audio or have the Flash plugin installed.</div>
+    </div>
+        
+    
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/Tracker_1/analytics-4b005fb3a73d78f9fbbd6bec6d5d8de5.js" crossorigin="anonymous" nonce="9L8E58qzaYN3lBm/BIlVVQ==" data-data="{&quot;env&quot;:2,&quot;domain_match&quot;:true}"></script>
+<script type="text/javascript" src="https://s4.bcbits.com/client-bundle/1/Tracker_1/impl-2adf8819c63716af8b5fa95e16511f95.js" crossorigin="anonymous" nonce="9L8E58qzaYN3lBm/BIlVVQ==" data-enabled="true" data-transport="&quot;beacon&quot;" data-record-url="&quot;https://bandcamp.com/api/tracker/1/record&quot;" data-send-delay="5" data-auto-track-clicks="true" data-auto-track-filters="null"></script>
+ 
+
+</body>
+</html>
+
+

--- a/tests/test-data/__recordings__/soundcloud-provider_749668182/extracting-images_1310741912/does-not-load-all-track-images-if-some-could-not-be-loaded_3382566896.warc
+++ b/tests/test-data/__recordings__/soundcloud-provider_749668182/extracting-images_1310741912/does-not-load-all-track-images-if-some-could-not-be-loaded_3382566896.warc
@@ -1,8 +1,8 @@
 WARC/1.1
 WARC-Filename: soundcloud provider/extracting images/does not load all track images if some could not be loaded
-WARC-Date: 2025-05-14T14:07:40.994Z
+WARC-Date: 2025-05-30T09:47:24.567Z
 WARC-Type: warcinfo
-WARC-Record-ID: <urn:uuid:c00f02f7-c2dd-40f2-8fd3-a88250c3b07e>
+WARC-Record-ID: <urn:uuid:27863d0d-dd68-4ca1-b9fe-1697df92fd50>
 Content-Type: application/warc-fields
 Content-Length: 119
 
@@ -12,11 +12,11 @@ harCreator: {"name":"Polly.JS","version":"6.0.6","comment":"persister:fs-warc"}
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:227e492b-9110-408a-8c9d-4244c74b5d3f>
+WARC-Concurrent-To: <urn:uuid:01eb4c43-72ce-4b9d-a39d-6d5d76f7556b>
 WARC-Target-URI: https://soundcloud.com/soundcloud/sets/i-am-other-vol-2
-WARC-Date: 2025-05-14T14:07:40.994Z
+WARC-Date: 2025-05-30T09:47:24.569Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:567014c0-11e4-406b-90a8-834b6ad8a2b5>
+WARC-Record-ID: <urn:uuid:1045a809-81dd-4cc3-ab38-8ca985050616>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:277d65b87d0c830e0ed2ad9a50d805606a9204663140c3e884a92cc2a132f88a
@@ -27,11 +27,11 @@ GET /soundcloud/sets/i-am-other-vol-2 HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:227e492b-9110-408a-8c9d-4244c74b5d3f>
+WARC-Concurrent-To: <urn:uuid:01eb4c43-72ce-4b9d-a39d-6d5d76f7556b>
 WARC-Target-URI: https://soundcloud.com/soundcloud/sets/i-am-other-vol-2
-WARC-Date: 2025-05-14T14:07:40.994Z
+WARC-Date: 2025-05-30T09:47:24.569Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:1ab5caf0-54c5-47a4-9bc6-7f770f3b1108>
+WARC-Record-ID: <urn:uuid:34493a43-9a68-464b-8479-dbf04aa12bfc>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:e58b30f38f63194e7801a80c4678b247d6bbfaf101d9a2d4fb08f3f2d6943cff
 WARC-Block-Digest: sha256:e58b30f38f63194e7801a80c4678b247d6bbfaf101d9a2d4fb08f3f2d6943cff
@@ -52,9 +52,9 @@ responseDecoded: false
 
 WARC/1.1
 WARC-Target-URI: https://soundcloud.com/soundcloud/sets/i-am-other-vol-2
-WARC-Date: 2025-05-14T14:07:40.994Z
+WARC-Date: 2025-05-30T09:47:24.568Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:227e492b-9110-408a-8c9d-4244c74b5d3f>
+WARC-Record-ID: <urn:uuid:01eb4c43-72ce-4b9d-a39d-6d5d76f7556b>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:722bdda73604a63e5d57410d8d22b084bec7aca074818162fa26643fb9ed7456
 WARC-Block-Digest: sha256:eace151d75276f4e3b9af83d0b586d277bd1806ff356f76c59b9db77995db8ee
@@ -334,11 +334,11 @@ Please download one of our supported browsers.
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:d5ee275a-78bd-4dc1-bed4-a7ed9596a640>
+WARC-Concurrent-To: <urn:uuid:813e6643-3979-41fe-ae43-36f2f5270798>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-waWa9GoBmtNTbqo1-pwoMvA-large.jpg
-WARC-Date: 2025-05-14T14:07:40.995Z
+WARC-Date: 2025-05-30T09:47:24.569Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:6aee6000-4714-43d5-b372-25be7947547b>
+WARC-Record-ID: <urn:uuid:2032555a-d386-4890-9055-d6bd60b04e73>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:ab991f57ffedd49702e1ee75cf752a40464771ddf5528b1ee0440542bfee2778
@@ -349,11 +349,11 @@ GET /artworks-waWa9GoBmtNTbqo1-pwoMvA-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:d5ee275a-78bd-4dc1-bed4-a7ed9596a640>
+WARC-Concurrent-To: <urn:uuid:813e6643-3979-41fe-ae43-36f2f5270798>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-waWa9GoBmtNTbqo1-pwoMvA-large.jpg
-WARC-Date: 2025-05-14T14:07:40.995Z
+WARC-Date: 2025-05-30T09:47:24.569Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:73995f51-299d-41e8-b260-9485cf81181f>
+WARC-Record-ID: <urn:uuid:08179a6e-e086-4052-94df-2acafd9fbbde>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:ad82ce3972b2a76b77fea0b7e402873e3140a45742b930bfb0b433f3562ac1df
 WARC-Block-Digest: sha256:ad82ce3972b2a76b77fea0b7e402873e3140a45742b930bfb0b433f3562ac1df
@@ -375,9 +375,9 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-waWa9GoBmtNTbqo1-pwoMvA-large.jpg
-WARC-Date: 2025-05-14T14:07:40.994Z
+WARC-Date: 2025-05-30T09:47:24.569Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:d5ee275a-78bd-4dc1-bed4-a7ed9596a640>
+WARC-Record-ID: <urn:uuid:813e6643-3979-41fe-ae43-36f2f5270798>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:6d136ded19a26ef36e2517556909dee07b3d918b06582e47988591e540aa3dfd
 WARC-Block-Digest: sha256:ebba4bd1ff863dd268cc5d4af52363f08f5a5e9b8148df4e3402742d0acef1c0
@@ -438,11 +438,11 @@ Y6 ®Îc˚·â*ø&ª,%6•hU“”(‹®®Ñ£–[UµΩ±G<∫‹’óU"ÍK™ yà∑kﬂé≈©?MÊ¶Û0¶Zµ%'·Èèê“
   ﬁ¿Ñ‹⁄€ìé¥€‘*Ï”&KgÍrV‘ó5Çµ ‡ë±=»ƒƒ¿r mïO›øæ:w`™r (Fƒ&ﬁOÎøæ4<çMÀ\5Ffäe…©πo˘-k7@∫`lï(ﬂÆ˜«r%-û R‚2ñõnóm∆)l%*`¨ß¶¬„†µ±10'rÌR‚æ≥1Øülä’+ﬁ^|V-®f Q O I€‘˘‚ﬁ?≤„¬-Aˆdπ!¿√éj|ê≤∞u\{ﬂ¯©öêä€–⁄∂(∆l'˛õh!		Ù∞òòavIu_Ò⁄œ¨ —x2dn£o-º±Q>’˜∑5≤å∫ïZåÀÒ∏$ëÚ˘±€õ*èCu˙T ÃxH}i-¥–NΩ	 πÎúPMQß«m»˚-e7'}∑6¯ƒƒ√ßÏ’mF†n˘íœpL˘¡"}qS{L®Ì‘5©±ïRè 7ÿË6¬âXÃYW5…ÅFíÀqê¿[!f‰õÓq110i’ôÊiG;∫ßNÂ’CòÿÏ«O; Ï”¢Ø∫)∫ª…Ì™Uz(YöÖ&f$nK$ìÊN?ˇŸ
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:3d7286b4-0c6b-4daf-867f-63f4336eb81b>
+WARC-Concurrent-To: <urn:uuid:331ca56d-310e-47f9-96b5-a7c938e865e6>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-yKWEoE0xZS11dixW-tVPxNA-large.jpg
-WARC-Date: 2025-05-14T14:07:40.995Z
+WARC-Date: 2025-05-30T09:47:24.570Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:5877b8a7-a45c-483e-9457-c33457bcffb4>
+WARC-Record-ID: <urn:uuid:dd4d1996-97d2-4d77-a338-799032c1f2ad>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:483bd8a048e26989a0a7b4b58f408c486438cef0de75670f07bc13cdb34f829a
@@ -453,11 +453,11 @@ GET /artworks-yKWEoE0xZS11dixW-tVPxNA-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:3d7286b4-0c6b-4daf-867f-63f4336eb81b>
+WARC-Concurrent-To: <urn:uuid:331ca56d-310e-47f9-96b5-a7c938e865e6>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-yKWEoE0xZS11dixW-tVPxNA-large.jpg
-WARC-Date: 2025-05-14T14:07:40.996Z
+WARC-Date: 2025-05-30T09:47:24.570Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:31949d2f-7914-4c4c-82ea-af03a8dae07a>
+WARC-Record-ID: <urn:uuid:3373f61b-54b8-4c4e-a312-ec4002f55f18>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:c18d3ec8260bc24c4c8e11bd6e84ed95157ba3f9200342aee99e9d3499a22688
 WARC-Block-Digest: sha256:c18d3ec8260bc24c4c8e11bd6e84ed95157ba3f9200342aee99e9d3499a22688
@@ -479,9 +479,9 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-yKWEoE0xZS11dixW-tVPxNA-large.jpg
-WARC-Date: 2025-05-14T14:07:40.995Z
+WARC-Date: 2025-05-30T09:47:24.570Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:3d7286b4-0c6b-4daf-867f-63f4336eb81b>
+WARC-Record-ID: <urn:uuid:331ca56d-310e-47f9-96b5-a7c938e865e6>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:dc9a0caa0071e6379c94a26010ee2442ef4015ebdfce94694ab75171fc637bfe
 WARC-Block-Digest: sha256:e2b6ba1502810c747ee368a25d7e7749059c0dcc9bde0fb49aab04eff2bc4fc0
@@ -573,11 +573,11 @@ UØ~ªﬂUô´ıYßÿï@X^9‰œ$t≈wòjz˙ÌRú°[RŒ‚,ë∫˛#$Ib=#—)LÁÍDFR”m“‚©ä[IJò÷S”aq–Zÿå
 /a˝˛8¿∏ë≈ú≈îÛ\ö}K-∆HlÖõíoπ¬wh˙Û8…≥Ø≤Q©!	7H&HûøLzi˚0~Ãûk› ﬁwû≤‚ﬂSãL•¬êò  ò˜ì&O1 ˇŸ
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:925ae41f-4bbb-44c7-afb7-4fc47b9a2065>
+WARC-Concurrent-To: <urn:uuid:91edb684-3005-4056-96a6-3676c14b9612>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-qLvJJfstzJcnCP3S-F9GwNQ-large.jpg
-WARC-Date: 2025-05-14T14:07:40.996Z
+WARC-Date: 2025-05-30T09:47:24.571Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:36dd7e58-36ca-4442-9a64-e21474260ab4>
+WARC-Record-ID: <urn:uuid:ea639fb7-f96b-460e-9c7f-211d2a1c364b>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:5c86b5ff4d037ce7b10d06f357b339d4531eb02a297e00ab5190718d10c0937a
@@ -588,11 +588,11 @@ GET /artworks-qLvJJfstzJcnCP3S-F9GwNQ-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:925ae41f-4bbb-44c7-afb7-4fc47b9a2065>
+WARC-Concurrent-To: <urn:uuid:91edb684-3005-4056-96a6-3676c14b9612>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-qLvJJfstzJcnCP3S-F9GwNQ-large.jpg
-WARC-Date: 2025-05-14T14:07:40.996Z
+WARC-Date: 2025-05-30T09:47:24.571Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:44fee577-3c70-470c-a940-5e5380737c42>
+WARC-Record-ID: <urn:uuid:b9f36cf0-eff2-478e-bb9a-5dc26ad225d7>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:e4ca9e6bbe30e0acd95359a7029fc953f4a1dc988e37d7417d9167365ee1518a
 WARC-Block-Digest: sha256:e4ca9e6bbe30e0acd95359a7029fc953f4a1dc988e37d7417d9167365ee1518a
@@ -614,9 +614,9 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-qLvJJfstzJcnCP3S-F9GwNQ-large.jpg
-WARC-Date: 2025-05-14T14:07:40.996Z
+WARC-Date: 2025-05-30T09:47:24.571Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:925ae41f-4bbb-44c7-afb7-4fc47b9a2065>
+WARC-Record-ID: <urn:uuid:91edb684-3005-4056-96a6-3676c14b9612>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:bf6b729c062d0f8abc9307cb87ceb8d110566a3852a75de9bb994a3c9159fd11
 WARC-Block-Digest: sha256:6534d5209de68aba97a5854ac7e4ff4f498b9e9ba095eedaa4ae032c916f3eb5
@@ -662,11 +662,11 @@ H˜Ûπv{⁄Oï’÷≤ôÃ’f˛êÀ’í$úÿí¥÷-}√ø‹)‰Y„é©1 ‰°K∑JüØ›KTikz˚Gf±ôe“2Q•ì©ãî:¢ÿÚß
 º∏˙¸Tù˝t™±4M'Û¨cc‰<Tùâÿˆ?÷˝vªUQ—˙ñ;Ÿ®Â±UQÅÖ[Ú Æ˚0+øaπmœ¡ÿàç@¥éNIqs,ï§`Íä°xÉˇ Å;mÒ∑¯ÍKEO•‚ã6⁄‡dV≠≈ßm¸Ô*Û-ÕH GœaË∑±‘v≠ü6NE”ëœ`b3,\à*>|`~˜ıπ€–>¡Ís.òπÖÌœwçqÕÓ◊`EQ˝å7‹ø/Ÿˇ }@„¨}¨`¿Hv Ó˘ÈèÙÂŸ‹Ou≤π…5tó+‚±—”Ø∞HcﬁÂ´qƒÅõãm≈˜1ÙGπ nzdÎ£Z’™Àê“ëVï, ø%[s%Î_i%hêƒB¥¢$*—∫â•|ªGäÌï=&ÿ<öd€'åVø*Hßk@,é9ÊÖLdä±ÂÔ`®·±˜÷xè{oˇ G©léYÊ˛+ô´áé08ôaíS!?ÿ(˝z˘#Á≠Ÿ,.ù'öé~ΩÈónGRD-ª}∑°∞ ˇ Ωø]A®#‰|ıêﬂoè˙Î◊cﬂÎ¶˜`4ô÷«05ã™öØ	áó=Ä<Ω$QÿØ◊FΩÃÏœo⁄=î”7„ñZuﬁZSÅ&”2L©≈w$[˚ﬂ„o◊Ó∂$º¿Ì÷ vÿm∑«˝ıΩ‚H‘ÄãÛÚG^BØJ£ıËu‰èü˚ÎGœ˘Î ˛?]zØ=düc¨é≤≥ImíGø≥¡àﬂ¨µôù8<“≤m˝%…ﬂ„Æi?´˝uˇŸ
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:fbd58081-c15f-4039-b02a-8a9cd326c19f>
+WARC-Concurrent-To: <urn:uuid:bda1530e-cb9f-4eb4-9678-c74e1fb6114a>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-zY2HTkauzmNxTA50-Chh4zw-large.jpg
-WARC-Date: 2025-05-14T14:07:40.997Z
+WARC-Date: 2025-05-30T09:47:24.618Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:9fda952c-a597-4d68-89a6-ea9f8747bb57>
+WARC-Record-ID: <urn:uuid:ac0203fb-4a83-4b07-a60d-50717cf0d323>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:add8d928b654c28f61ee8f82384ce006a115ac170d0dc1977a266ad7a6a3b531
@@ -677,11 +677,11 @@ GET /artworks-zY2HTkauzmNxTA50-Chh4zw-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:fbd58081-c15f-4039-b02a-8a9cd326c19f>
+WARC-Concurrent-To: <urn:uuid:bda1530e-cb9f-4eb4-9678-c74e1fb6114a>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-zY2HTkauzmNxTA50-Chh4zw-large.jpg
-WARC-Date: 2025-05-14T14:07:40.997Z
+WARC-Date: 2025-05-30T09:47:24.622Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:d932f37c-d6c9-41c8-9076-e4c9b59b2b2b>
+WARC-Record-ID: <urn:uuid:00096211-a1db-4fb9-a3a1-e17bb14af168>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:a7c9dff3ae0257a2f559299c7d8f2bfb6dc66c04c9505b3e3fb627c3d786415c
 WARC-Block-Digest: sha256:a7c9dff3ae0257a2f559299c7d8f2bfb6dc66c04c9505b3e3fb627c3d786415c
@@ -703,9 +703,9 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-zY2HTkauzmNxTA50-Chh4zw-large.jpg
-WARC-Date: 2025-05-14T14:07:40.997Z
+WARC-Date: 2025-05-30T09:47:24.571Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:fbd58081-c15f-4039-b02a-8a9cd326c19f>
+WARC-Record-ID: <urn:uuid:bda1530e-cb9f-4eb4-9678-c74e1fb6114a>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:54f89346648a1ddf0d13f2682f940814f2da761801e33f57a0de5ddec9963491
 WARC-Block-Digest: sha256:11d998a61b180cb5ff4208a50595958d67c7da8ed8c31bca19fe41aedee6fb9f
@@ -758,11 +758,11 @@ uó
 KàP@!YNO«<c]+J# yJ|†ü∑#ˇ ZZZ°sÖÄ°=pÑ‹ãZìR{r§∏¯díx		p‡mA∫3Æ å7JÉSh5ù)∆v¸:’«Àîç--;¯Á≈)0˛•æã¶¨&M˚AaeAπ√K ˇ Ö@ÉØE/üˆ4K]ÁYÖ0>òæoûeÂE‰„ë«c«”KKE™ëÏk7I?d:8ò˜?xÅ˜U{©ı©W/Ñ∫d⁄™˜»â[j"úå∂⁄Tüô«’[u¥îúèm--z¿§Ê(Uñ∆O *_q£¸5©<˚f*IÊC›ˇ úÈik≤íπY!ktÂ’≠g?‚Q:µ~õHÍ]m“2∂®ªSìÿ)ÊÛ˛√KKA©˝ó'Ë?}ΩÍ¯HÇ€/, ´Áúˇ ¶ñññ≥ÎWeˇŸ
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:ef987426-c29c-44f6-9b15-b3038e77f4ca>
+WARC-Concurrent-To: <urn:uuid:dd28a8d1-a640-4786-81e6-22db6ac39f5a>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg
-WARC-Date: 2025-05-14T14:07:40.997Z
+WARC-Date: 2025-05-30T09:47:24.623Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:dc57a8a8-04df-449d-918a-a92ae2c30585>
+WARC-Record-ID: <urn:uuid:34764191-5ccb-47a6-b6e4-9747746a5d5d>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:c65d68f303fa1822dc407cc9e4cdedce4277146be47943da077ccf0a34e9f510
@@ -773,11 +773,11 @@ GET /artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:ef987426-c29c-44f6-9b15-b3038e77f4ca>
+WARC-Concurrent-To: <urn:uuid:dd28a8d1-a640-4786-81e6-22db6ac39f5a>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg
-WARC-Date: 2025-05-14T14:07:40.997Z
+WARC-Date: 2025-05-30T09:47:24.623Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:9c48cf5e-498f-4e1f-8abc-2142006b7e3d>
+WARC-Record-ID: <urn:uuid:aa572bdc-0ead-4b5f-969a-3e9b3384a807>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:11e339d154a0d21cc7aca445bd8b673fef48842d49b7347b4f7edd1cafdfae2c
 WARC-Block-Digest: sha256:11e339d154a0d21cc7aca445bd8b673fef48842d49b7347b4f7edd1cafdfae2c
@@ -799,9 +799,9 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg
-WARC-Date: 2025-05-14T14:07:40.997Z
+WARC-Date: 2025-05-30T09:47:24.622Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:ef987426-c29c-44f6-9b15-b3038e77f4ca>
+WARC-Record-ID: <urn:uuid:dd28a8d1-a640-4786-81e6-22db6ac39f5a>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:4437a0cd5e635d131aee32d196a09a680f1e60e59daf0be1ec9b4036cda230b0
 WARC-Block-Digest: sha256:ec8362797b9ca7117715878adb857df4f19632fd529bb1fdd6513c08ab81df42
@@ -851,11 +851,11 @@ Zk;ó°ÉÃ‚≥ÿ‹NZzıÆVôX^ÖXxÊQ˝»Î∑∆˚{∫pˆ√Aˆs+§ÎÍû‚jh(e&fNTÀ•O,åºàhÂê)Pœ¿n)‹⁄∫C
 6ıµ?w˚>˛z⁄"Dè“É∫èë◊¿ã±<Fˇ Án±*;¨Jèœ_xç«Yé±#ŸÎ«ˆèûæÅÔØæGÅπBÔ±*ƒø«Æ∂˝ıØcÓ¨ÏÁvfˆ~=˚ˇ GP6ÎˇŸ
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:3d6eaa94-c60a-4011-bb3b-75c4d1f74312>
+WARC-Concurrent-To: <urn:uuid:dd189985-8148-4d6a-b55a-95d4fa8d6f62>
 WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg
-WARC-Date: 2025-05-14T14:07:40.998Z
+WARC-Date: 2025-05-30T09:47:24.623Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:ae7d0e9a-d455-479f-a261-e4f42f6074f5>
+WARC-Record-ID: <urn:uuid:adb62fda-805a-447a-9264-2ae67678680b>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:5af33ca02efd6d1c7351a82a756013f9a4b6b001935e1394193df0775e89a040
@@ -866,11 +866,11 @@ GET /bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg HTT
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:3d6eaa94-c60a-4011-bb3b-75c4d1f74312>
+WARC-Concurrent-To: <urn:uuid:dd189985-8148-4d6a-b55a-95d4fa8d6f62>
 WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg
-WARC-Date: 2025-05-14T14:07:40.998Z
+WARC-Date: 2025-05-30T09:47:24.624Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:52ecfe92-9fa7-41ae-8c86-43d9ee864575>
+WARC-Record-ID: <urn:uuid:53cc5478-18a8-4df2-a89d-7a70186137cf>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:23a1e90a12b3f2bf7fa851c73a16aca619baff8a8574b30e4ad9a19fc9e97aad
 WARC-Block-Digest: sha256:23a1e90a12b3f2bf7fa851c73a16aca619baff8a8574b30e4ad9a19fc9e97aad
@@ -892,9 +892,9 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg
-WARC-Date: 2025-05-14T14:07:40.998Z
+WARC-Date: 2025-05-30T09:47:24.623Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:3d6eaa94-c60a-4011-bb3b-75c4d1f74312>
+WARC-Record-ID: <urn:uuid:dd189985-8148-4d6a-b55a-95d4fa8d6f62>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:c435cad579dc185a590e008a06c65c1a693beb245256dc66e56d2e6e65c09798
 WARC-Block-Digest: sha256:e0bf1660be5115c572d091f78024d9cd057483f85aa3e9dd964a81b7037b8293
@@ -1220,11 +1220,11 @@ t⁄OSæå‚û•{>`$˜=*‹*Àñv»ÌMÜ-@ÅR; \g5RïﬁÇØU+ÿdí‡7¶+ï’ßo4Ö8'Ç=kvvh£.yπ€ò÷mÚêw’ŸÉ
 ìLG«ï|G+©∏ª¢„t¥-‰EBíÜäﬂñ∆n-ˇŸ
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:ee6f63f7-c355-4a3b-8228-1396b48f82ee>
+WARC-Concurrent-To: <urn:uuid:44e01a0f-cd21-4f87-bff4-a37e08f3cb6c>
 WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg
-WARC-Date: 2025-05-14T14:07:40.999Z
+WARC-Date: 2025-05-30T09:47:24.624Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:5ce9bdef-5f0d-4d4e-bccf-b5a0ba97597f>
+WARC-Record-ID: <urn:uuid:46290286-fc67-4b95-9575-f53409c82186>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:9baec36e5cfd550ec422a2ed11cb277cba1a240d3889cd297b4febfd4ccdcfc2
@@ -1235,11 +1235,11 @@ GET /bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg HTT
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:ee6f63f7-c355-4a3b-8228-1396b48f82ee>
+WARC-Concurrent-To: <urn:uuid:44e01a0f-cd21-4f87-bff4-a37e08f3cb6c>
 WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg
-WARC-Date: 2025-05-14T14:07:40.999Z
+WARC-Date: 2025-05-30T09:47:24.624Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:4b837034-5803-4fd9-ae5b-1ca93cacda7f>
+WARC-Record-ID: <urn:uuid:2bb0957d-bfb8-4710-be8a-db4539066109>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:9be26b33aa1110cb83fc6863a2a6ce089dd9a365a022d641a84e046e09752ed5
 WARC-Block-Digest: sha256:9be26b33aa1110cb83fc6863a2a6ce089dd9a365a022d641a84e046e09752ed5
@@ -1261,9 +1261,9 @@ warcResponseContentEncoding: base64
 
 WARC/1.1
 WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg
-WARC-Date: 2025-05-14T14:07:40.998Z
+WARC-Date: 2025-05-30T09:47:24.624Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:ee6f63f7-c355-4a3b-8228-1396b48f82ee>
+WARC-Record-ID: <urn:uuid:44e01a0f-cd21-4f87-bff4-a37e08f3cb6c>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:c435cad579dc185a590e008a06c65c1a693beb245256dc66e56d2e6e65c09798
 WARC-Block-Digest: sha256:584ef4782332f9ed61616d926fa76d6a392e5574eab50785955b751b5519f480
@@ -1588,11 +1588,11 @@ t⁄OSæå‚û•{>`$˜=*‹*Àñv»ÌMÜ-@ÅR; \g5RïﬁÇØU+ÿdí‡7¶+ï’ßo4Ö8'Ç=kvvh£.yπ€ò÷mÚêw’ŸÉ
 ìLG«ï|G+©∏ª¢„t¥-‰EBíÜäﬂñ∆n-ˇŸ
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:68ee2993-1942-449a-9b38-d5bb51ac00d7>
+WARC-Concurrent-To: <urn:uuid:31fd5ad6-ef74-4322-8f91-e0311b022a6d>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-yKWEoE0xZS11dixW-tVPxNA-large.jpg
-WARC-Date: 2025-05-14T14:07:40.999Z
+WARC-Date: 2025-05-30T09:47:24.625Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:e0e0b7ef-5221-4b4b-94fd-f249c3382cb3>
+WARC-Record-ID: <urn:uuid:d5c1ab73-3b79-497e-a790-63c73db7561d>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:c6f81089539a505fedea72468401c5969dc11a2377336ad30283ca436ca04cb5
@@ -1603,11 +1603,11 @@ HEAD /artworks-yKWEoE0xZS11dixW-tVPxNA-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:68ee2993-1942-449a-9b38-d5bb51ac00d7>
+WARC-Concurrent-To: <urn:uuid:31fd5ad6-ef74-4322-8f91-e0311b022a6d>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-yKWEoE0xZS11dixW-tVPxNA-large.jpg
-WARC-Date: 2025-05-14T14:07:41.000Z
+WARC-Date: 2025-05-30T09:47:24.625Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:34e6efd5-8b18-46f2-b8b7-0aa061b8a4f7>
+WARC-Record-ID: <urn:uuid:4e8df83b-0fcf-4304-9cde-90b9b2194e0f>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:5d77e0b07ca819d40f0d8a92dbebaffcf20962fee899389e3485aaca0ebc6182
 WARC-Block-Digest: sha256:5d77e0b07ca819d40f0d8a92dbebaffcf20962fee899389e3485aaca0ebc6182
@@ -1628,9 +1628,9 @@ responseDecoded: false
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-yKWEoE0xZS11dixW-tVPxNA-large.jpg
-WARC-Date: 2025-05-14T14:07:40.999Z
+WARC-Date: 2025-05-30T09:47:24.625Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:68ee2993-1942-449a-9b38-d5bb51ac00d7>
+WARC-Record-ID: <urn:uuid:31fd5ad6-ef74-4322-8f91-e0311b022a6d>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:5eb4bf82837f9c1a5ca814f15a7b572bb5e29c3287f529958d2d4c615069b012
@@ -1655,11 +1655,11 @@ x-pollyjs-finalurl: https://i1.sndcdn.com/artworks-yKWEoE0xZS11dixW-tVPxNA-large
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:b7af0ceb-21c7-40b0-bedf-1dfbd8e86802>
+WARC-Concurrent-To: <urn:uuid:a30f7af9-be2e-4592-9d1a-609437e71a4c>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-zY2HTkauzmNxTA50-Chh4zw-large.jpg
-WARC-Date: 2025-05-14T14:07:41.000Z
+WARC-Date: 2025-05-30T09:47:24.628Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:97e8223c-d4d3-4ab8-844a-4cbf2d2d0131>
+WARC-Record-ID: <urn:uuid:54240718-a6df-467f-8495-34d7acdb5b51>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:eaf25e540d595c40fc33e8b1edd2aac13000931913c58f2bb194bd16acc991fe
@@ -1670,11 +1670,11 @@ HEAD /artworks-zY2HTkauzmNxTA50-Chh4zw-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:b7af0ceb-21c7-40b0-bedf-1dfbd8e86802>
+WARC-Concurrent-To: <urn:uuid:a30f7af9-be2e-4592-9d1a-609437e71a4c>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-zY2HTkauzmNxTA50-Chh4zw-large.jpg
-WARC-Date: 2025-05-14T14:07:41.000Z
+WARC-Date: 2025-05-30T09:47:24.628Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:09148fb0-5bb8-4442-b423-e2556a5aa556>
+WARC-Record-ID: <urn:uuid:385a5049-61ce-45cf-ab81-c9685c4b36bc>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:3d858e6fe611032be03a63a473eaf6b384a224c03ebf33d34c9f84580e7d508e
 WARC-Block-Digest: sha256:3d858e6fe611032be03a63a473eaf6b384a224c03ebf33d34c9f84580e7d508e
@@ -1695,9 +1695,9 @@ responseDecoded: false
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-zY2HTkauzmNxTA50-Chh4zw-large.jpg
-WARC-Date: 2025-05-14T14:07:41.000Z
+WARC-Date: 2025-05-30T09:47:24.625Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:b7af0ceb-21c7-40b0-bedf-1dfbd8e86802>
+WARC-Record-ID: <urn:uuid:a30f7af9-be2e-4592-9d1a-609437e71a4c>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:857771213bda6231090a998bb711b7472453085cc73254078c8c05105e503837
@@ -1721,11 +1721,11 @@ x-pollyjs-finalurl: https://i1.sndcdn.com/artworks-zY2HTkauzmNxTA50-Chh4zw-large
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:2522e14f-e086-479e-8e4b-d255207c548b>
+WARC-Concurrent-To: <urn:uuid:9957dc49-dd53-4fa2-9540-cc16f878534f>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-qLvJJfstzJcnCP3S-F9GwNQ-large.jpg
-WARC-Date: 2025-05-14T14:07:41.000Z
+WARC-Date: 2025-05-30T09:47:24.629Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:ab535950-eb02-4880-8359-ac3d22b44d50>
+WARC-Record-ID: <urn:uuid:cb7f0d5b-f4ce-4948-960e-05b7a4d8e18d>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:20c7f16bc8165097b20ad272d742ae4133b7788b7915eada1a9050f7e2df90de
@@ -1736,11 +1736,11 @@ HEAD /artworks-qLvJJfstzJcnCP3S-F9GwNQ-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:2522e14f-e086-479e-8e4b-d255207c548b>
+WARC-Concurrent-To: <urn:uuid:9957dc49-dd53-4fa2-9540-cc16f878534f>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-qLvJJfstzJcnCP3S-F9GwNQ-large.jpg
-WARC-Date: 2025-05-14T14:07:41.000Z
+WARC-Date: 2025-05-30T09:47:24.629Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:b363aa93-33fa-4bb0-b3df-c101d9360482>
+WARC-Record-ID: <urn:uuid:e8637376-e035-4c81-804c-4881e533501d>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:48f969835df2bdc9dbcec6eea4a3f13b987ab4792d7535e53fe5dc35b372ff0b
 WARC-Block-Digest: sha256:48f969835df2bdc9dbcec6eea4a3f13b987ab4792d7535e53fe5dc35b372ff0b
@@ -1761,9 +1761,9 @@ responseDecoded: false
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-qLvJJfstzJcnCP3S-F9GwNQ-large.jpg
-WARC-Date: 2025-05-14T14:07:41.000Z
+WARC-Date: 2025-05-30T09:47:24.628Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:2522e14f-e086-479e-8e4b-d255207c548b>
+WARC-Record-ID: <urn:uuid:9957dc49-dd53-4fa2-9540-cc16f878534f>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:e9bbb01b2af24a3a48ab9d0b173286b46711fd19b6c2ecc8de64fecf52ad85d3
@@ -1787,11 +1787,11 @@ x-pollyjs-finalurl: https://i1.sndcdn.com/artworks-qLvJJfstzJcnCP3S-F9GwNQ-large
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:9bfd6c48-3639-42d3-b93e-49b581f6335b>
+WARC-Concurrent-To: <urn:uuid:8341e1be-f497-4ba8-9b99-19b62b02e96e>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-waWa9GoBmtNTbqo1-pwoMvA-large.jpg
-WARC-Date: 2025-05-14T14:07:41.001Z
+WARC-Date: 2025-05-30T09:47:24.630Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:9cfb04a8-2565-44db-bad7-266ae183aadf>
+WARC-Record-ID: <urn:uuid:08a64914-f709-413a-8c3f-828dce1b925b>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:0cb4a1ad6f7a40bb7b7dd915c188f436cfde0db91069176e5b17738c54274be3
@@ -1802,11 +1802,11 @@ HEAD /artworks-waWa9GoBmtNTbqo1-pwoMvA-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:9bfd6c48-3639-42d3-b93e-49b581f6335b>
+WARC-Concurrent-To: <urn:uuid:8341e1be-f497-4ba8-9b99-19b62b02e96e>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-waWa9GoBmtNTbqo1-pwoMvA-large.jpg
-WARC-Date: 2025-05-14T14:07:41.001Z
+WARC-Date: 2025-05-30T09:47:24.630Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:c4298be1-66eb-4a4d-bfc6-3a9b3a1cdb4c>
+WARC-Record-ID: <urn:uuid:39a67e2a-57d6-424b-9b1b-1bcb2835fe75>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:970dbbbc0c58854ee20007a191a4a128bf11d6b3fabef834e7ec405176021838
 WARC-Block-Digest: sha256:970dbbbc0c58854ee20007a191a4a128bf11d6b3fabef834e7ec405176021838
@@ -1827,9 +1827,9 @@ responseDecoded: false
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-waWa9GoBmtNTbqo1-pwoMvA-large.jpg
-WARC-Date: 2025-05-14T14:07:41.001Z
+WARC-Date: 2025-05-30T09:47:24.630Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:9bfd6c48-3639-42d3-b93e-49b581f6335b>
+WARC-Record-ID: <urn:uuid:8341e1be-f497-4ba8-9b99-19b62b02e96e>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:8d38eb075cfd3f8ad9424e36262af90c7f9e482fb81ba17c210d31107868945d
@@ -1853,11 +1853,11 @@ x-pollyjs-finalurl: https://i1.sndcdn.com/artworks-waWa9GoBmtNTbqo1-pwoMvA-large
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:6395de6b-9c06-4f5f-ba7f-04f8458059e4>
+WARC-Concurrent-To: <urn:uuid:b3a4a394-e19a-4171-8b07-3b9e34de4caf>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg
-WARC-Date: 2025-05-14T14:07:41.001Z
+WARC-Date: 2025-05-30T09:47:24.631Z
 WARC-Type: request
-WARC-Record-ID: <urn:uuid:da088d3b-877b-49db-ab55-c2c7d562fd76>
+WARC-Record-ID: <urn:uuid:8aa2e1be-9e8a-4d4f-9407-a9a35e1bb32d>
 Content-Type: application/http; msgtype=request
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:af32281c06b06145c054654084411b763912401070e839d86eaecce2d933f5d3
@@ -1868,11 +1868,11 @@ HEAD /artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg HTTP/1.1
 
 
 WARC/1.1
-WARC-Concurrent-To: <urn:uuid:6395de6b-9c06-4f5f-ba7f-04f8458059e4>
+WARC-Concurrent-To: <urn:uuid:b3a4a394-e19a-4171-8b07-3b9e34de4caf>
 WARC-Target-URI: https://i1.sndcdn.com/artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg
-WARC-Date: 2025-05-14T14:07:41.001Z
+WARC-Date: 2025-05-30T09:47:24.631Z
 WARC-Type: metadata
-WARC-Record-ID: <urn:uuid:a236b154-7697-462d-b876-4c5821890072>
+WARC-Record-ID: <urn:uuid:d3956d7c-03d9-434f-a17b-09848c013c6c>
 Content-Type: application/warc-fields
 WARC-Payload-Digest: sha256:aa43ae923f8d578254c40742af121dfd3755a2349aa8b9cdc5d4f6afc6bc6bb0
 WARC-Block-Digest: sha256:aa43ae923f8d578254c40742af121dfd3755a2349aa8b9cdc5d4f6afc6bc6bb0
@@ -1893,9 +1893,9 @@ responseDecoded: false
 
 WARC/1.1
 WARC-Target-URI: https://i1.sndcdn.com/artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg
-WARC-Date: 2025-05-14T14:07:41.001Z
+WARC-Date: 2025-05-30T09:47:24.631Z
 WARC-Type: response
-WARC-Record-ID: <urn:uuid:6395de6b-9c06-4f5f-ba7f-04f8458059e4>
+WARC-Record-ID: <urn:uuid:b3a4a394-e19a-4171-8b07-3b9e34de4caf>
 Content-Type: application/http; msgtype=response
 WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 WARC-Block-Digest: sha256:7f18581c107acce1d4ac50acd2b03eed291c0d00b8389bca7b426230b568c9f7
@@ -1916,6 +1916,142 @@ x-amz-cf-id: I_eTxHILbIOy6ARZkBEkiDcog3cRoAR_x1VrSO0HvVB5LfVPzLBeQw==
 x-amz-cf-pop: LHR50-P5
 x-cache: Hit from cloudfront
 x-pollyjs-finalurl: https://i1.sndcdn.com/artworks-EjZrLL9ryGLzFDyB-Pm0Vrw-large.jpg
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:df901021-60c1-412e-82e5-3ba695ba3d29>
+WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg
+WARC-Date: 2025-05-30T09:47:24.632Z
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:7a05b471-ca8a-46d1-a617-2b33a6d60ed9>
+Content-Type: application/http; msgtype=request
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:053e7a153cf299acb5c1627542accc9b2391534bfb88327d522cca490b13bfc3
+Content-Length: 90
+
+HEAD /bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg HTTP/1.1
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:df901021-60c1-412e-82e5-3ba695ba3d29>
+WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg
+WARC-Date: 2025-05-30T09:47:24.632Z
+WARC-Type: metadata
+WARC-Record-ID: <urn:uuid:f96da987-998d-424f-9ae3-28a1d29fc096>
+Content-Type: application/warc-fields
+WARC-Payload-Digest: sha256:b642234f046f3326b1d1939acb12a89a557c05a188dea2ee817dd3288e3a80c0
+WARC-Block-Digest: sha256:b642234f046f3326b1d1939acb12a89a557c05a188dea2ee817dd3288e3a80c0
+Content-Length: 349
+
+harEntryId: 96f4451c6e1a446b92515e6983404668
+harEntryOrder: 0
+cache: {}
+startedDateTime: 2025-05-30T09:47:24.418Z
+time: 143
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":143,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 113
+warcRequestCookies: []
+warcResponseHeadersSize: 595
+warcResponseCookies: []
+responseDecoded: false
+
+
+WARC/1.1
+WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg
+WARC-Date: 2025-05-30T09:47:24.631Z
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:df901021-60c1-412e-82e5-3ba695ba3d29>
+Content-Type: application/http; msgtype=response
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:8615f4dcbbebb680cc004341d4c0a86c70ea93f38cb646de043c7ba16e48b25a
+Content-Length: 612
+
+HTTP/1.1 200 OK
+accept-ranges: bytes
+age: 45
+cache-control: public, max-age=600
+connection: keep-alive
+content-length: 87277
+content-type: image/jpeg
+date: Fri, 30 May 2025 09:46:40 GMT
+etag: "42d392cb898fdd897a42cda6941f268f"
+last-modified: Fri, 11 Dec 2020 05:39:07 GMT
+server: AmazonS3
+via: 1.1 ed7b9b4fb9d1b3bd8eb47afc37a6c75c.cloudfront.net (CloudFront)
+x-amz-cf-id: LX5mvhz4CV3MbhOtPe_3-CDKsH3DnHtzgxNjm44mil4Kl7sUjOUtnQ==
+x-amz-cf-pop: LHR5-P6
+x-cache: Hit from cloudfront
+x-pollyjs-finalurl: https://va.sndcdn.com/bg/soundcloud:tracks:944780617/cdcc9c19-bfb1-4962-9aca-6590cfb8efba.jpg
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:5a32d17d-aeb7-4e8e-839c-f20d039b963b>
+WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg
+WARC-Date: 2025-05-30T09:47:24.633Z
+WARC-Type: request
+WARC-Record-ID: <urn:uuid:5f44b9c2-e635-47a5-b630-d87071f57664>
+Content-Type: application/http; msgtype=request
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:d0b0bc57fe2d7e592b16f1153c0ad725df430b3f73e6a4fd0e9698d798874e03
+Content-Length: 90
+
+HEAD /bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg HTTP/1.1
+
+
+
+WARC/1.1
+WARC-Concurrent-To: <urn:uuid:5a32d17d-aeb7-4e8e-839c-f20d039b963b>
+WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg
+WARC-Date: 2025-05-30T09:47:24.633Z
+WARC-Type: metadata
+WARC-Record-ID: <urn:uuid:825bbef1-35a4-429c-b628-307f8e8fc1a8>
+Content-Type: application/warc-fields
+WARC-Payload-Digest: sha256:022801f1887c31824c540234d96b75844bb733389fa1549ffa20165c997750e2
+WARC-Block-Digest: sha256:022801f1887c31824c540234d96b75844bb733389fa1549ffa20165c997750e2
+Content-Length: 349
+
+harEntryId: c6d0c63772fb3191348070df26ea1317
+harEntryOrder: 0
+cache: {}
+startedDateTime: 2025-05-30T09:47:24.418Z
+time: 144
+timings: {"blocked":-1,"dns":-1,"connect":-1,"send":0,"wait":144,"receive":0,"ssl":-1}
+warcRequestHeadersSize: 113
+warcRequestCookies: []
+warcResponseHeadersSize: 595
+warcResponseCookies: []
+responseDecoded: false
+
+
+WARC/1.1
+WARC-Target-URI: https://va.sndcdn.com/bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg
+WARC-Date: 2025-05-30T09:47:24.632Z
+WARC-Type: response
+WARC-Record-ID: <urn:uuid:5a32d17d-aeb7-4e8e-839c-f20d039b963b>
+Content-Type: application/http; msgtype=response
+WARC-Payload-Digest: sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+WARC-Block-Digest: sha256:161845a527f9789c9e2a3e591af8102764d3cbd4cb0e8f70ae36f4e4be291052
+Content-Length: 612
+
+HTTP/1.1 200 OK
+accept-ranges: bytes
+age: 45
+cache-control: public, max-age=600
+connection: keep-alive
+content-length: 87277
+content-type: image/jpeg
+date: Fri, 30 May 2025 09:46:40 GMT
+etag: "42d392cb898fdd897a42cda6941f268f"
+last-modified: Fri, 11 Dec 2020 05:38:06 GMT
+server: AmazonS3
+via: 1.1 64fe15439df273f1f7429f1dfac4f792.cloudfront.net (CloudFront)
+x-amz-cf-id: 7I6mnYVXhRIioB8Gs_rsOG6DvTPFH6rcGRGjgOO_q7Ob2u2NXtogcA==
+x-amz-cf-pop: LHR5-P6
+x-cache: Hit from cloudfront
+x-pollyjs-finalurl: https://va.sndcdn.com/bg/soundcloud:tracks:913782583/9b0d4395-cc72-4aa9-84e1-17b807264e2f.jpg
 
 
 

--- a/tests/unit/mb_enhanced_cover_art_uploads/providers/bandcamp.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/providers/bandcamp.test.ts
@@ -79,6 +79,15 @@ describe('bandcamp provider', () => {
                 types: [ArtworkTypeIDs.Track],
                 comment: 'Track 5',
             }],
+        }, {
+            description: 'subscriber-only releases',
+            url: 'https://arbee.bandcamp.com/album/des-papiers-ii',
+            imageCount: 1,
+            expectedImages: [{
+                index: 0,
+                urlPart: 'a1289075493_',
+                types: [ArtworkTypeIDs.Front],
+            }],
         }];
 
         const extractionFailedCases = [{


### PR DESCRIPTION
The embedded player may be unavailable, e.g., on subscriber-only releases. We can still load some cover art from those, so we'll avoid erroring out when that happens.

The track images could technically be added using the old approach of loading the track pages directly, but since I expect the combination of subscriber-only releases AND track-specific images to be rare, I'm opting to omit this functionality for now.

Note: Not sure why the Soundcloud recordings changed.

Fixes #843 