### PR TITLE
fix(spotify): remove User-Agent header

### DIFF
--- a/src/mb_enhanced_cover_art_uploads/providers/spotify.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/spotify.ts
@@ -1,6 +1,7 @@
 import { qsMaybe } from '@lib/util/dom';
 
 import { HeadMetaPropertyProvider } from './base';
+import type { RequestOptions } from '@lib/util/request';
 
 export class SpotifyProvider extends HeadMetaPropertyProvider {
     public readonly supportedDomains = ['open.spotify.com'];
@@ -10,5 +11,15 @@ export class SpotifyProvider extends HeadMetaPropertyProvider {
 
     protected override is404Page(document_: Document): boolean {
         return qsMaybe('head > meta[property="og:title"]', document_) === null;
+    }
+
+    protected override fetchPage(url: URL, options?: RequestOptions): Promise<string> {
+        return super.fetchPage(url, {
+            ...options,
+            headers: {
+                ...options?.headers,
+                'User-Agent': null,
+            },
+        });
     }
 }

--- a/src/mb_enhanced_cover_art_uploads/providers/spotify.ts
+++ b/src/mb_enhanced_cover_art_uploads/providers/spotify.ts
@@ -1,7 +1,7 @@
+import type { RequestOptions } from '@lib/util/request';
 import { qsMaybe } from '@lib/util/dom';
 
 import { HeadMetaPropertyProvider } from './base';
-import type { RequestOptions } from '@lib/util/request';
 
 export class SpotifyProvider extends HeadMetaPropertyProvider {
     public readonly supportedDomains = ['open.spotify.com'];
@@ -13,12 +13,13 @@ export class SpotifyProvider extends HeadMetaPropertyProvider {
         return qsMaybe('head > meta[property="og:title"]', document_) === null;
     }
 
+    // Spotify messes with Open Graph tags based on User-Agent. See also https://community.metabrainz.org/t/551947/210
     protected override fetchPage(url: URL, options?: RequestOptions): Promise<string> {
         return super.fetchPage(url, {
             ...options,
             headers: {
                 ...options?.headers,
-                'User-Agent': null,
+                'User-Agent': '',
             },
         });
     }


### PR DESCRIPTION
As [described in the forum](https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/210?u=chaban), Spotify is messing with the Open Graph tags. Apparently simply omitting the User-Agent header fixes this problem.