### PR TITLE
fix(split links): change selector from id to class

### DIFF
--- a/src/mb_multi_external_links/index.ts
+++ b/src/mb_multi_external_links/index.ts
@@ -112,7 +112,7 @@ async function run(windowInstance: Window): Promise<void> {
     // for its existence enables us to skip attempting to find the link input on
     // edit pages that don't have external links, without having to exclude
     // specific pages.
-    const editorContainer = qsMaybe<HTMLElement>('#external-links-editor-container', windowInstance.document);
+    const editorContainer = qsMaybe<HTMLElement>('.external-links-editor-container', windowInstance.document);
     if (!editorContainer) return;
 
     const editor = await ExternalLinksEditor.create(windowInstance);


### PR DESCRIPTION
Link splitter stopped working, as the selector for external-links-editor-container is now a class instead of an id.

Tested on artist, release, recording pages and artist iframe.

Fixes [issue on forums](https://community.metabrainz.org/t/ropdebees-userscripts-support-thread/551947/229)