### PR TITLE
fix(mb_caa_dimensions): account for dimensions text in default MB cover art size reservation to prevent layout shifts

### DIFF
--- a/src/mb_caa_dimensions/style.scss
+++ b/src/mb_caa_dimensions/style.scss
@@ -28,6 +28,11 @@ div.thumb-position {
     }
 }
 
+// Reserve space for dimension labels below sidebar cover art (MB default is 218px).
+#sidebar .cover-art.present {
+    min-height: 244px;
+}
+
 // Styling of the info spans
 // TODO: beta.MBS of May 24 2024 changed the classname from "cover-art-image" to "artwork-image".
 //       Change this when new class name lands in production MBS.


### PR DESCRIPTION
<img width="354" height="471" alt="image" src="https://github.com/user-attachments/assets/36b82cd2-b457-4723-97df-5067a6dd6775" />

- the blue arrow is the current space reservation;
- the green arrow is the new space reservation, after we have accounted for 26px-high dimensions text;
- the problem here is that when the page loads and you're trying to interact with the sidebar, e.g. to enter genres or click on the label link, the whole sidebar text suddenly shifts away from under the cursor because the dimensions were loaded above and pushed the whole thing down.