### PR TITLE
fix(ecau): fix Bandcamp full-size cover downloads

### DIFF
--- a/src/lib/util/request/backend-gmxhr.ts
+++ b/src/lib/util/request/backend-gmxhr.ts
@@ -6,6 +6,19 @@ import { AbortedError, NetworkError, TimeoutError } from './errors';
 import { createTextResponse } from './response';
 import { ResponseHeadersImpl } from './response';
 
+function binaryStringToArrayBuffer(binaryString: string): ArrayBuffer {
+    const buffer = new ArrayBuffer(binaryString.length);
+    const view = new Uint8Array(buffer);
+    for (let index = 0; index < binaryString.length; index++) {
+        view[index] = binaryString.charCodeAt(index) & 0xFF;
+    }
+    return buffer;
+}
+
+function isArrayBuffer(value: unknown): value is ArrayBuffer {
+    return value instanceof ArrayBuffer || Object.prototype.toString.call(value) === '[object ArrayBuffer]';
+}
+
 function createGMXHRResponse(options: RequestOptions | undefined, rawResponse: GM.Response<never>): Response {
     const responseType = options?.responseType ?? 'text';
     const baseResponse = {
@@ -29,7 +42,9 @@ function createGMXHRResponse(options: RequestOptions | undefined, rawResponse: G
         case 'arraybuffer':
             return {
                 ...baseResponse,
-                arrayBuffer: rawResponse.response as ArrayBuffer,
+                arrayBuffer: isArrayBuffer(rawResponse.response)
+                    ? rawResponse.response
+                    : binaryStringToArrayBuffer(String(rawResponse.responseText ?? rawResponse.response ?? '')),
             };
     }
 }
@@ -41,7 +56,8 @@ export function performGMXHRRequest(method: RequestMethod, url: URL | string, op
             url: url instanceof URL ? url.href : url,
             headers: options?.headers,
             data: options?.body,
-            responseType: options?.responseType,
+            responseType: options?.responseType === 'arraybuffer' ? 'text' : options?.responseType,
+            overrideMimeType: options?.responseType === 'arraybuffer' ? 'text/plain; charset=x-user-defined' : undefined,
 
             onload: (rawResponse) => { resolve(createGMXHRResponse(options, rawResponse)); },
             onerror: () => { reject(new NetworkError(url)); },

--- a/src/mb_enhanced_cover_art_uploads/images/download.ts
+++ b/src/mb_enhanced_cover_art_uploads/images/download.ts
@@ -1,11 +1,10 @@
 import pRetry from 'p-retry';
 
-import type { BlobResponse, ProgressEvent } from '@lib/util/request';
+import type { ArrayBufferResponse, ProgressEvent } from '@lib/util/request';
 import { getFromPageContext } from '@lib/compat';
 import { LOGGER } from '@lib/logging/logger';
 import { ArtworkTypeIDs } from '@lib/MB/cover-art';
 import { enumerate } from '@lib/util/array';
-import { blobToBuffer } from '@lib/util/blob';
 import { identity } from '@lib/util/functions';
 import { HTTPResponseError, request } from '@lib/util/request';
 import { urlBasename } from '@lib/util/urls';
@@ -188,7 +187,7 @@ export class CoverArtDownloader {
 
     protected async downloadImageContents(url: URL, fileName: string, id: number, headers: Record<string, string>): Promise<ImageContents> {
         const xhrOptions = {
-            responseType: 'blob',
+            responseType: 'arraybuffer',
             headers: headers,
             onProgress: this.hooks.onDownloadProgress?.bind(this.hooks, id, url),
         } as const;
@@ -220,7 +219,9 @@ export class CoverArtDownloader {
             LOGGER.warn(`Followed redirect of ${url.href} -> ${fetchedUrl.href} while fetching image contents`);
         }
 
-        const { mimeType, isImage } = await this.determineMimeType(response);
+        const contentType = response.headers.get('Content-Type')?.match(/[^;\s]+/)?.[0];
+        const responseBlob = new Blob([response.arrayBuffer], { type: contentType ?? '' });
+        const { mimeType, isImage } = await this.determineMimeType(responseBlob, response.headers);
 
         if (!isImage) {
             if (!mimeType?.startsWith('text/')) {
@@ -239,10 +240,9 @@ export class CoverArtDownloader {
             throw new Error('Expected to receive an image, but received text. Perhaps this provider is not supported yet?');
         }
 
-        // Convert and copy the response blob to a buffer.
-        // We copy the content to make sure the contents do not get unloaded
+        // Copy the response buffer to make sure the contents do not get unloaded
         // before the image is uploaded. See https://github.com/ROpdebee/mb-userscripts/issues/582
-        const contentBuffer = await blobToBuffer(response.blob);
+        const contentBuffer = response.arrayBuffer.slice(0);
 
         return {
             requestedUrl: url,
@@ -255,8 +255,7 @@ export class CoverArtDownloader {
         };
     }
 
-    private async determineMimeType(response: BlobResponse): Promise<{ isImage: false; mimeType: string | undefined } | { isImage: true; mimeType: string }> {
-        const rawFile = new File([response.blob], 'image');
+    private async determineMimeType(blob: Blob, headers: ArrayBufferResponse['headers']): Promise<{ isImage: false; mimeType: string | undefined } | { isImage: true; mimeType: string }> {
         return new Promise((resolve) => {
             // Adapted from https://github.com/metabrainz/musicbrainz-server/blob/2b00b844f3fe4293fc4ccb9de1c30e3c2ddc95c1/root/static/scripts/edit/MB/CoverArt.js#L139
             // We can't use MB.CoverArt.validate_file since it's not available
@@ -285,15 +284,22 @@ export class CoverArtDownloader {
                             resolve({ mimeType: 'application/pdf', isImage: true });
                             break;
 
-                        default:
+                        default: {
+                            const contentType = headers.get('Content-Type')?.match(/[^;\s]+/)?.[0];
+                            if (contentType?.startsWith('image/') === true) {
+                                resolve({ mimeType: contentType, isImage: true });
+                                break;
+                            }
+
                             resolve({
-                                mimeType: response.headers.get('Content-Type')?.match(/[^;\s]+/)?.[0],
+                                mimeType: contentType,
                                 isImage: false,
                             });
+                        }
                     }
                 }
             });
-            reader.readAsArrayBuffer(rawFile.slice(0, 4));
+            reader.readAsArrayBuffer(blob.slice(0, 4));
         });
     }
 

--- a/tests/unit/lib/util/request.test.ts
+++ b/tests/unit/lib/util/request.test.ts
@@ -103,6 +103,29 @@ describe('request', () => {
             expect(onProgress).toHaveBeenNthCalledWith(1, response1);
             expect(onProgress).toHaveBeenNthCalledWith(2, response2);
         });
+
+        it('falls back to responseText for broken arraybuffer responses', async () => {
+            mockGMxmlHttpRequest.mockImplementation((options) => {
+                expect(options.responseType).toBe('text');
+                expect(options.overrideMimeType).toBe('text/plain; charset=x-user-defined');
+                options.onload?.({
+                    ...stubResponse,
+                    finalUrl: 'test',
+                    response: null,
+                    responseHeaders: '',
+                    responseText: '\xFF\xD8\xFF\xE1',
+                    status: 200,
+                    statusText: 'OK',
+                });
+            });
+
+            const response = await request.get('test', {
+                backend: RequestBackend.GMXHR,
+                responseType: 'arraybuffer',
+            });
+
+            expect([...new Uint8Array(response.arrayBuffer)]).toStrictEqual([0xFF, 0xD8, 0xFF, 0xE1]);
+        });
     });
 
     describe('frontend', () => {

--- a/tests/unit/mb_enhanced_cover_art_uploads/images/download.test.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/images/download.test.ts
@@ -12,7 +12,7 @@ import { CoverArtDownloader as OriginalCoverArtDownloader } from '@src/mb_enhanc
 import { getProviderByDomain } from '@src/mb_enhanced_cover_art_uploads/providers';
 import { CoverArtProvider } from '@src/mb_enhanced_cover_art_uploads/providers/base';
 
-import { createBlobResponse, createHttpError, createImageFile } from '../test-utils/dummy-data';
+import { createArrayBufferResponse, createHttpError, createImageFile } from '../test-utils/dummy-data';
 
 jest.mock('p-retry');
 jest.mock('@lib/logging/logger');
@@ -131,7 +131,7 @@ describe('downloading image contents', () => {
     });
 
     it('rejects on HTTP 404 error', async () => {
-        mockRequestGet.mockRejectedValue(createHttpError(createBlobResponse({ status: 404 })));
+        mockRequestGet.mockRejectedValue(createHttpError(createArrayBufferResponse({ status: 404 })));
 
         const result = downloader.downloadImageContents(new URL('https://example.com/broken'), 'test.jpg', 0, {});
 
@@ -140,9 +140,9 @@ describe('downloading image contents', () => {
     });
 
     it('rejects on text response', async () => {
-        mockRequestGet.mockResolvedValueOnce(createBlobResponse({
+        mockRequestGet.mockResolvedValueOnce(createArrayBufferResponse({
             url: 'https://example.com/broken',
-            blob: new Blob(['test']),
+            arrayBuffer: Uint8Array.from([0x74, 0x65, 0x73, 0x74]).buffer,
             headers: new Headers({ 'Content-Type': 'text/html; charset=utf-8' }),
         }));
 
@@ -153,9 +153,9 @@ describe('downloading image contents', () => {
     });
 
     it('rejects on unsupported provider page', async () => {
-        mockRequestGet.mockResolvedValueOnce(createBlobResponse({
+        mockRequestGet.mockResolvedValueOnce(createArrayBufferResponse({
             url: 'https://example.com/not-an-album',
-            blob: new Blob(['test']),
+            arrayBuffer: Uint8Array.from([0x74, 0x65, 0x73, 0x74]).buffer,
             headers: new Headers({ 'Content-Type': 'text/html; charset=utf-8' }),
         }));
         mockGetProviderByDomain.mockReturnValueOnce(fakeProvider);
@@ -167,9 +167,9 @@ describe('downloading image contents', () => {
     });
 
     it('rejects on invalid image', async () => {
-        mockRequestGet.mockResolvedValueOnce(createBlobResponse({
+        mockRequestGet.mockResolvedValueOnce(createArrayBufferResponse({
             url: 'https://example.com/broken',
-            blob: new Blob(['test']),
+            arrayBuffer: Uint8Array.from([0x74, 0x65, 0x73, 0x74]).buffer,
             headers: new Headers({ 'Content-Type': 'application/json' }),
         }));
 
@@ -180,9 +180,9 @@ describe('downloading image contents', () => {
     });
 
     it('rejects on invalid image without content-type header', async () => {
-        mockRequestGet.mockResolvedValueOnce(createBlobResponse({
+        mockRequestGet.mockResolvedValueOnce(createArrayBufferResponse({
             url: 'https://example.com/broken',
-            blob: new Blob(['test']),
+            arrayBuffer: Uint8Array.from([0x74, 0x65, 0x73, 0x74]).buffer,
         }));
 
         const result = downloader.downloadImageContents(new URL('https://example.com/broken'), 'test.jpg', 0, {});
@@ -192,9 +192,9 @@ describe('downloading image contents', () => {
     });
 
     it('resolves with fetched image', async () => {
-        mockRequestGet.mockResolvedValueOnce(createBlobResponse({
+        mockRequestGet.mockResolvedValueOnce(createArrayBufferResponse({
             url: 'https://example.com/working',
-            blob: new Blob([Uint32Array.from([0x474E5089, 0xDEADBEEF])]),
+            arrayBuffer: Uint32Array.from([0x474E5089, 0xDEADBEEF]).buffer,
         }));
 
         const result = downloader.downloadImageContents(new URL('https://example.com/working'), 'test.jpg', 0, {});
@@ -215,13 +215,31 @@ describe('downloading image contents', () => {
             });
     });
 
+    it('accepts image content type when magic bytes cannot be detected', async () => {
+        mockRequestGet.mockResolvedValueOnce(createArrayBufferResponse({
+            url: 'https://example.com/working',
+            arrayBuffer: Uint8Array.from([0x74, 0x65, 0x73, 0x74]).buffer,
+            headers: new Headers({ 'Content-Type': 'image/jpeg' }),
+        }));
+
+        const result = downloader.downloadImageContents(new URL('https://example.com/working'), 'test.jpg', 0, {});
+
+        await expect(result)
+            .resolves.toMatchObject({
+                file: {
+                    type: 'image/jpeg',
+                    name: 'test.0.jpeg',
+                },
+            });
+    });
+
     it('retries on 429 response', async () => {
-        mockRequestGet.mockRejectedValueOnce(createHttpError(createBlobResponse({
+        mockRequestGet.mockRejectedValueOnce(createHttpError(createArrayBufferResponse({
             status: 429,
         })));
-        mockRequestGet.mockResolvedValueOnce(createBlobResponse({
+        mockRequestGet.mockResolvedValueOnce(createArrayBufferResponse({
             url: 'https://example.com/working',
-            blob: new Blob([Uint32Array.from([0x474E5089, 0xDEADBEEF])]),
+            arrayBuffer: Uint32Array.from([0x474E5089, 0xDEADBEEF]).buffer,
         }));
 
         const result = downloader.downloadImageContents(new URL('https://example.com/working'), 'test.jpg', 0, {});
@@ -244,10 +262,10 @@ describe('downloading image contents', () => {
     });
 
     it('rejects on too many 429 responses', async () => {
-        mockRequestGet.mockRejectedValueOnce(createHttpError(createBlobResponse({
+        mockRequestGet.mockRejectedValueOnce(createHttpError(createArrayBufferResponse({
             status: 429,
         })));
-        mockRequestGet.mockRejectedValueOnce(createHttpError(createBlobResponse({
+        mockRequestGet.mockRejectedValueOnce(createHttpError(createArrayBufferResponse({
             status: 429,
         })));
 
@@ -259,9 +277,9 @@ describe('downloading image contents', () => {
     });
 
     it('retains redirection information', async () => {
-        mockRequestGet.mockResolvedValueOnce(createBlobResponse({
+        mockRequestGet.mockResolvedValueOnce(createArrayBufferResponse({
             url: 'https://example.com/redirected',
-            blob: new Blob([Uint32Array.from([0x474E5089, 0xDEADBEEF])]),
+            arrayBuffer: Uint32Array.from([0x474E5089, 0xDEADBEEF]).buffer,
         }));
 
         const result = downloader.downloadImageContents(new URL('https://example.com/working'), 'test.jpg', 0, {});
@@ -279,10 +297,10 @@ describe('downloading image contents', () => {
     });
 
     it('warns when redirect could not be determined', async () => {
-        const response = createBlobResponse({
-            blob: new Blob([Uint32Array.from([0x474E5089, 0xDEADBEEF])]),
+        const response = createArrayBufferResponse({
+            arrayBuffer: Uint32Array.from([0x474E5089, 0xDEADBEEF]).buffer,
         });
-        // Need to set explicitly because `createBlobResponse` creates a random
+        // Need to set explicitly because `createArrayBufferResponse` creates a random
         // URL if we provide it `undefined`.
         Object.defineProperty(response, 'url', { value: undefined });
         mockRequestGet.mockResolvedValueOnce(response);
@@ -296,13 +314,13 @@ describe('downloading image contents', () => {
 
     it('assigns unique ID to each file name', async () => {
         mockRequestGet
-            .mockResolvedValueOnce(createBlobResponse({
+            .mockResolvedValueOnce(createArrayBufferResponse({
                 url: 'https://example.com/working',
-                blob: new Blob([Uint32Array.from([0x474E5089, 0xDEADBEEF])]),
+                arrayBuffer: Uint32Array.from([0x474E5089, 0xDEADBEEF]).buffer,
             }))
-            .mockResolvedValueOnce(createBlobResponse({
+            .mockResolvedValueOnce(createArrayBufferResponse({
                 url: 'https://example.com/working',
-                blob: new Blob([Uint32Array.from([0x474E5089, 0xDEADBEEF])]),
+                arrayBuffer: Uint32Array.from([0x474E5089, 0xDEADBEEF]).buffer,
             }));
 
         let result = downloader.downloadImageContents(new URL('https://example.com/working'), 'test.jpg', 0, {});

--- a/tests/unit/mb_enhanced_cover_art_uploads/test-utils/dummy-data.ts
+++ b/tests/unit/mb_enhanced_cover_art_uploads/test-utils/dummy-data.ts
@@ -1,6 +1,6 @@
 // Abstractions to create dummy data
 
-import type { BlobResponse, Response, TextResponse } from '@lib/util/request';
+import type { ArrayBufferResponse, BlobResponse, Response, TextResponse } from '@lib/util/request';
 import type { CoverArt, FetchedImage } from '@src/mb_enhanced_cover_art_uploads/types';
 import type { QueuedImage } from '@src/mb_enhanced_cover_art_uploads/types';
 import { HTTPResponseError } from '@lib/util/request';
@@ -94,6 +94,14 @@ export function createBlobResponse(response?: Partial<BlobResponse>): BlobRespon
     return {
         ...createResponse(response),
         blob: response.blob ?? createBlob(),
+    };
+}
+
+export function createArrayBufferResponse(response?: Partial<ArrayBufferResponse>): ArrayBufferResponse {
+    response = response ?? {};
+    return {
+        ...createResponse(response),
+        arrayBuffer: response.arrayBuffer ?? new ArrayBuffer(0),
     };
 }
 

--- a/tests/unit/utils/pollyjs/gmxhr-adapter/index.ts
+++ b/tests/unit/utils/pollyjs/gmxhr-adapter/index.ts
@@ -121,6 +121,11 @@ export default class GMXHRAdapter<Context> extends Adapter<object, RequestType<C
                     ...response_,
                     response: arrayBuffer,
                 });
+            } else if (responseType === 'text') {
+                options.onload({
+                    ...response_,
+                    responseText: buffer.toString('binary'),
+                });
             } else {
                 throw new Error(`Unknown response type: ${responseType}`);
             }


### PR DESCRIPTION
- Fixes #904
- fetch image contents as array buffers and make the GM/XHR request wrapper avoid broken binary response path by using byte-preserving text and reconstructing the buffer locally.
- this fixes Bandcamp full-size _0.jpg imports failing because GM.xmlHttpRequest returned null for blob/arraybuffer responses. Also keeps an image/* Content-Type fallback for valid image responses that cannot be identified by magic-byte sniffing.