### PR TITLE
feat(ecau): Upgrade Harmony cover preview links to maximised URLs

### DIFF
--- a/src/mb_caa_dimensions/image-info.ts
+++ b/src/mb_caa_dimensions/image-info.ts
@@ -16,6 +16,8 @@ export interface FileInfo {
 
 /** Image information. */
 export interface ImageInfo extends FileInfo {
+    /** URL of the image. */
+    url?: string;
     /** Dimensions of the image. */
     dimensions?: Dimensions;
 }

--- a/src/mb_enhanced_cover_art_uploads/seeding/dimensions.ts
+++ b/src/mb_enhanced_cover_art_uploads/seeding/dimensions.ts
@@ -162,6 +162,7 @@ export async function getMaximisedImageInfo(imageUrl: string, maximisedCandidate
         }
 
         return {
+            url: maxCandidate.url.href,
             dimensions,
             ...fileInfo,
         };

--- a/src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
+++ b/src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx
@@ -94,6 +94,12 @@ function addSeedLinkToCover(coverElement: HTMLElement, mbid: string, origin: str
         .insertAdjacentElement('beforeend', seedLink);
 }
 
+function updateCoverUrl(fig: HTMLElement, url?: string): void {
+    if (url) {
+        qs<HTMLAnchorElement>('a', fig).href = url;
+    }
+}
+
 async function addDimensions(fig: HTMLElement): Promise<void> {
     const imageUrl = qs<HTMLImageElement>('img', fig).src;
     const dimSpan: HTMLSpanElement = (
@@ -104,6 +110,7 @@ async function addDimensions(fig: HTMLElement): Promise<void> {
     qs('figcaption', fig).insertAdjacentElement('beforeend', dimSpan);
 
     const imageInfo = await getImageInfo(imageUrl);
+    updateCoverUrl(fig, imageInfo.url);
 
     const infoStringParts = [
         imageInfo.dimensions ? `${imageInfo.dimensions.width}×${imageInfo.dimensions.height}` : '',


### PR DESCRIPTION
_Note: Code and description were written with AI-tools_

### Description
Updates the cover art thumbnail links on Harmony release actions pages to point directly to probed, full-resolution maximised image URLs.

### Reasoning
Harmony embeds the default image URLs returned by streaming service APIs (such as Spotify 640×640 or Tidal 1280×1280). While ECAU probes and displays the dimensions and file size of the uncompressed artwork (e.g., Spotify 2000×2000 or Tidal 3000×3000 `origin.jpg`), the thumbnail preview link (`<a href>`) previously remained pointing to the lower-resolution API image.

This created a discrepancy where the caption indicated a high-resolution image, but clicking the thumbnail opened the smaller API variant. Updating the thumbnail link `href` directly aligns the link with the displayed dimensions, allowing users to view, verify, or download the full-resolution artwork directly from the preview link.

### Key Changes
- **Harmony Seeder (`src/mb_enhanced_cover_art_uploads/seeding/harmony/index.tsx`)**:
  - Update the thumbnail anchor's `href` to the resolved `imageInfo.url` when `addDimensions()` completes probing.
- **Seeding Dimensions (`src/mb_enhanced_cover_art_uploads/seeding/dimensions.ts`)**:
  - Propagate the winning candidate's maximised URL on the returned `ImageInfo`.
- **Image Info Contract (`src/mb_caa_dimensions/image-info.ts`)**:
  - Add optional `url?: string` to the `ImageInfo` interface.

### Verification
- **Automated Validation**:
  - `npm run typecheck` — Passed (`tsc -b`).
  - `npm run lint` — Passed with 0 errors / 0 warnings (`eslint`).
  - `npm test` — All 71 Jest suites passed (1,350 unit tests).
  - Production build — Bundled userscripts successfully via `build.ts`.
- **Manual Verification**:
  - Tested on Harmony release actions pages across various providers (Spotify, Tidal, Deezer, iTunes, Qobuz).
  - Verified clicking the cover thumbnail opens the full-resolution image matching the displayed dimensions.